### PR TITLE
Control the size of the trie in stateless prototype, save state snapshot after errors

### DIFF
--- a/cmd/state/state.go
+++ b/cmd/state/state.go
@@ -53,6 +53,7 @@ var chaindata = flag.String("chaindata", "chaindata", "path to the chaindata fil
 var statefile = flag.String("statefile", "state", "path to the file where the state will be periodically written during the analysis")
 var start = flag.Int("start", 0, "number of data points to skip when making a chart")
 var window = flag.Int("window", 1024, "size of the window for moving average")
+var triesize = flag.Int("triesize", 1024*1024, "maximum number of nodes in the state trie")
 
 func check(e error) {
 	if e != nil {
@@ -1681,7 +1682,7 @@ func main() {
 	//nakedAccountChart()
 	//specExecChart1()
 	if *action == "stateless" {
-		stateless(*chaindata, *statefile)
+		stateless(*chaindata, *statefile, *triesize)
 	}
 	if *action == "stateless_chart" {
 		stateless_chart_key_values("/Users/alexeyakhunov/mygit/go-ethereum/st_1/stateless.csv", []int{21, 20, 19, 18}, "breakdown.png", 2800000, 1)

--- a/cmd/state/stateless.go
+++ b/cmd/state/stateless.go
@@ -152,7 +152,11 @@ func stateless(chaindata string, statefile string, triesize int) {
 		checkRoots(stateDb, db, preRoot, blockNum-1)
 	}
 	batch := stateDb.NewBatch()
-	defer batch.Commit()
+	defer func() {
+		if _, err := batch.Commit(); err != nil {
+			fmt.Printf("Failed to commit batch: %v\n", err)
+		}
+	}()
 	tds, err := state.NewTrieDbState(preRoot, batch, blockNum-1)
 	check(err)
 	if blockNum > 1 {

--- a/cmd/state/stateless.go
+++ b/cmd/state/stateless.go
@@ -153,7 +153,7 @@ func stateless(chaindata string, statefile string, triesize int) {
 	}
 	batch := stateDb.NewBatch()
 	defer func() {
-		if _, err := batch.Commit(); err != nil {
+		if _, err = batch.Commit(); err != nil {
 			fmt.Printf("Failed to commit batch: %v\n", err)
 		}
 	}()

--- a/cmd/state/stateless.go
+++ b/cmd/state/stateless.go
@@ -152,6 +152,7 @@ func stateless(chaindata string, statefile string, triesize int) {
 		checkRoots(stateDb, db, preRoot, blockNum-1)
 	}
 	batch := stateDb.NewBatch()
+	defer batch.Commit()
 	tds, err := state.NewTrieDbState(preRoot, batch, blockNum-1)
 	check(err)
 	if blockNum > 1 {
@@ -287,10 +288,6 @@ func stateless(chaindata string, statefile string, triesize int) {
 			fmt.Println("interrupted, please wait for cleanup...")
 		default:
 		}
-	}
-	if _, err := batch.Commit(); err != nil {
-		fmt.Printf("Failed to commit batch: %v\n", err)
-		return
 	}
 	stateDb.Close()
 	fmt.Printf("Processed %d blocks\n", blockNum)

--- a/cmd/state/stateless.go
+++ b/cmd/state/stateless.go
@@ -106,8 +106,8 @@ func writeStats(w io.Writer, blockNum uint64, blockProof trie.BlockProof) {
 }
 */
 
-func stateless(chaindata string, statefile string) {
-	//state.MaxTrieCacheGen = 64*1024
+func stateless(chaindata string, statefile string, triesize int) {
+	state.MaxTrieCacheGen = uint32(triesize)
 	startTime := time.Now()
 	sigs := make(chan os.Signal, 1)
 	interruptCh := make(chan bool, 1)


### PR DESCRIPTION
This will be needed to reproduce an apparent bug in `trie.Resolver`