### PR TITLE
Debug tool for recursively comparing state (in DB or in a file) with geth archive node

### DIFF
--- a/cmd/hack/hack.go
+++ b/cmd/hack/hack.go
@@ -24,6 +24,7 @@ import (
 	"github.com/ledgerwatch/turbo-geth/core/rawdb"
 	"github.com/ledgerwatch/turbo-geth/core/state"
 	"github.com/ledgerwatch/turbo-geth/core/types"
+	"github.com/ledgerwatch/turbo-geth/core/types/accounts"
 	"github.com/ledgerwatch/turbo-geth/core/vm"
 	"github.com/ledgerwatch/turbo-geth/crypto"
 	"github.com/ledgerwatch/turbo-geth/ethdb"
@@ -674,11 +675,8 @@ func extractTrie(block int) {
 	}
 }
 
-func testRewind(block, rewind int) {
-	//ethDb, err := ethdb.NewBoltDatabase("/Users/alexeyakhunov/Library/Ethereum/testnet/geth/chaindata")
-	//ethDb, err := ethdb.NewBoltDatabase("/home/akhounov/.ethereum/geth/chaindata")
-	//ethDb, err := ethdb.NewBoltDatabase("statedb")
-	ethDb, err := ethdb.NewBoltDatabase("/Volumes/tb4/turbo-geth/geth//chaindata")
+func testRewind(chaindata string, block, rewind int) {
+	ethDb, err := ethdb.NewBoltDatabase(chaindata)
 	check(err)
 	defer ethDb.Close()
 	bc, err := core.NewBlockChain(ethDb, nil, params.MainnetChainConfig, ethash.NewFaker(), vm.Config{}, nil)
@@ -1098,7 +1096,11 @@ func readAccount(chaindata string, account common.Address) {
 	check(err)
 	secKey := crypto.Keccak256(account[:])
 	v, _ := ethDb.Get(dbutils.AccountsBucket, secKey)
-	fmt.Printf("%x:%x\n", secKey, v)
+	var a accounts.Account
+	if err = a.DecodeForStorage(v); err != nil {
+		panic(err)
+	}
+	fmt.Printf("%x:%x\n%x\n", secKey, v, a.Root)
 }
 
 func repairCurrent() {
@@ -1193,7 +1195,7 @@ func main() {
 	//mychart()
 	//testRebuild()
 	if *action == "testRewind" {
-		testRewind(*block, *rewind)
+		testRewind(*chaindata, *block, *rewind)
 	}
 	//hashFile()
 	//buildHashFromFile()

--- a/cmd/hack/hack.go
+++ b/cmd/hack/hack.go
@@ -1093,11 +1093,10 @@ func printBranches(block uint64) {
 	}
 }
 
-func readAccount() {
-	ethDb, err := ethdb.NewBoltDatabase("statedb")
+func readAccount(chaindata string, account common.Address) {
+	ethDb, err := ethdb.NewBoltDatabase(chaindata)
 	check(err)
-	accountBytes := common.FromHex(*account)
-	secKey := crypto.Keccak256(accountBytes)
+	secKey := crypto.Keccak256(account[:])
 	v, _ := ethDb.Get(dbutils.AccountsBucket, secKey)
 	fmt.Printf("%x:%x\n", secKey, v)
 }
@@ -1230,7 +1229,9 @@ func main() {
 	//execToBlock(*block)
 	//extractTrie(*block)
 	//repair()
-	//readAccount()
+	if *action == "readAccount" {
+		readAccount(*chaindata, common.HexToAddress(*account))
+	}
 	//repairCurrent()
 	//testMemBolt()
 	//fmt.Printf("\u00b3\n")

--- a/cmd/rpctest/main.go
+++ b/cmd/rpctest/main.go
@@ -23,7 +23,6 @@ import (
 var action = flag.String("action", "", "action to execute")
 var url = flag.String("url", "", "URL to use for RPC requests")
 var block = flag.Int("block", 1, "specifies a block number for operation")
-var account = flag.String("account", "0x", "specifies account to investigate")
 var chaindata = flag.String("chaindata", "chaindata", "path to the chaindata database file")
 
 type EthError struct {
@@ -1061,6 +1060,6 @@ func main() {
 
 	flag.Parse()
 	if *action == "proofs" {
-		proofs(*chaindata, *url, *block, common.HexToAddress(*account))
+		proofs(*chaindata, *url, *block)
 	}
 }

--- a/cmd/rpctest/main.go
+++ b/cmd/rpctest/main.go
@@ -1062,4 +1062,7 @@ func main() {
 	if *action == "proofs" {
 		proofs(*chaindata, *url, *block)
 	}
+	if *action == "fixState" {
+		fixState(*chaindata, *url)
+	}
 }

--- a/cmd/rpctest/main.go
+++ b/cmd/rpctest/main.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"bytes"
 	"encoding/json"
+	"flag"
 	"fmt"
 	"io"
 	"net/http"
@@ -14,7 +15,15 @@ import (
 	"github.com/ledgerwatch/turbo-geth/common"
 	"github.com/ledgerwatch/turbo-geth/common/hexutil"
 	"github.com/ledgerwatch/turbo-geth/crypto"
+	"github.com/ledgerwatch/turbo-geth/log"
+	"github.com/mattn/go-colorable"
+	"github.com/mattn/go-isatty"
 )
+
+var action = flag.String("action", "", "action to execute")
+var url = flag.String("url", "", "URL to use for RPC requests")
+var block = flag.Int("block", 1, "specifies a block number for operation")
+var account = flag.String("account", "0x", "specifies account to investigate")
 
 type EthError struct {
 	Code    int    `json:"code"`
@@ -1034,5 +1043,23 @@ func bench6() {
 }
 
 func main() {
-	bench1()
+	var (
+		ostream log.Handler
+		glogger *log.GlogHandler
+	)
+
+	usecolor := (isatty.IsTerminal(os.Stderr.Fd()) || isatty.IsCygwinTerminal(os.Stderr.Fd())) && os.Getenv("TERM") != "dumb"
+	output := io.Writer(os.Stderr)
+	if usecolor {
+		output = colorable.NewColorableStderr()
+	}
+	ostream = log.StreamHandler(output, log.TerminalFormat(usecolor))
+	glogger = log.NewGlogHandler(ostream)
+	log.Root().SetHandler(glogger)
+	glogger.Verbosity(log.Lvl(3)) // 3 == verbosity INFO
+
+	flag.Parse()
+	if *action == "proofs" {
+		proofs(*url, *block, common.HexToAddress(*account))
+	}
 }

--- a/cmd/rpctest/main.go
+++ b/cmd/rpctest/main.go
@@ -24,6 +24,7 @@ var action = flag.String("action", "", "action to execute")
 var url = flag.String("url", "", "URL to use for RPC requests")
 var block = flag.Int("block", 1, "specifies a block number for operation")
 var account = flag.String("account", "0x", "specifies account to investigate")
+var chaindata = flag.String("chaindata", "chaindata", "path to the chaindata database file")
 
 type EthError struct {
 	Code    int    `json:"code"`
@@ -1060,6 +1061,6 @@ func main() {
 
 	flag.Parse()
 	if *action == "proofs" {
-		proofs(*url, *block, common.HexToAddress(*account))
+		proofs(*chaindata, *url, *block, common.HexToAddress(*account))
 	}
 }

--- a/cmd/rpctest/proofs.go
+++ b/cmd/rpctest/proofs.go
@@ -44,7 +44,7 @@ func proofs(chaindata string, url string, block int) {
 	}
 	defer ethDb.Close()
 	var t *trie.Trie
-	if _, err := os.Stat(fileName); err != nil {
+	if _, err = os.Stat(fileName); err != nil {
 		if os.IsNotExist(err) {
 			// Resolve 6 top levels of the accounts trie
 			r := trie.NewResolver(6, true, uint64(block))
@@ -115,6 +115,10 @@ func proofs(chaindata string, url string, block int) {
 				}
 				return true, nil
 			})
+			if err != nil {
+				fmt.Printf("Error when looking for suitable account for diffKey %x\n", diffKey)
+				return
+			}
 			if !found {
 				fmt.Printf("Could not find suitable account for diffKey %x\n", diffKey)
 				return

--- a/cmd/rpctest/proofs.go
+++ b/cmd/rpctest/proofs.go
@@ -7,9 +7,11 @@ import (
 	"time"
 
 	"github.com/ledgerwatch/turbo-geth/common"
+	"github.com/ledgerwatch/turbo-geth/common/dbutils"
 	"github.com/ledgerwatch/turbo-geth/common/hexutil"
 	"github.com/ledgerwatch/turbo-geth/crypto"
 	"github.com/ledgerwatch/turbo-geth/ethdb"
+	"github.com/ledgerwatch/turbo-geth/rlp"
 	"github.com/ledgerwatch/turbo-geth/trie"
 )
 
@@ -34,7 +36,7 @@ type StorageResult struct {
 	Proof []string     `json:"proof"`
 }
 
-func proofs(chaindata string, url string, block int, account common.Address) {
+func proofs(chaindata string, url string, block int) {
 	fileName := "trie.txt"
 	ethDb, err := ethdb.NewBoltDatabase(chaindata)
 	if err != nil {
@@ -44,8 +46,8 @@ func proofs(chaindata string, url string, block int, account common.Address) {
 	var t *trie.Trie
 	if _, err := os.Stat(fileName); err != nil {
 		if os.IsNotExist(err) {
-			// Resolve 5 top levels of the accounts trie
-			r := trie.NewResolver(5, true, uint64(block))
+			// Resolve 6 top levels of the accounts trie
+			r := trie.NewResolver(6, true, uint64(block))
 			t = trie.New(common.Hash{})
 			req := t.NewResolveRequest(nil, []byte{}, 0, nil)
 			r.AddRequest(req)
@@ -53,7 +55,7 @@ func proofs(chaindata string, url string, block int, account common.Address) {
 			if err != nil {
 				panic(err)
 			}
-			fmt.Printf("Resoled with hash: %x\n", t.Hash())
+			fmt.Printf("Resolved with hash: %x\n", t.Hash())
 			f, err1 := os.Create(fileName)
 			if err1 == nil {
 				defer f.Close()
@@ -83,20 +85,102 @@ func proofs(chaindata string, url string, block int, account common.Address) {
 		Timeout: time.Second * 600,
 	}
 	reqID := 0
-	reqID++
-	template := `{"jsonrpc":"2.0","method":"eth_getProof","params":["0x%x",[],"0x%x"],"id":%d}`
-	var proof EthGetProof
-	if err := post(client, url, fmt.Sprintf(template, account, block, reqID), &proof); err != nil {
-		fmt.Printf("Could not get block number: %v\n", err)
-		return
+
+	level := 0
+	diffKeys := [][]byte{[]byte{}}
+	var newDiffKeys [][]byte
+
+	for len(diffKeys) > 0 && level < 6 {
+
+		fmt.Printf("================================================\n")
+		fmt.Printf("LEVEL %d, diffKeys: %d\n", level, len(diffKeys))
+		fmt.Printf("================================================\n")
+		for _, diffKey := range diffKeys {
+			// Find account with the suitable hash
+			var startKey common.Hash
+			for i, d := range diffKey {
+				if i%2 == 0 {
+					startKey[i/2] |= (d << 4)
+				} else {
+					startKey[i/2] |= d
+				}
+			}
+			var account common.Address
+			var found bool
+			err = ethDb.Walk(dbutils.PreimagePrefix, startKey[:], uint(4*len(diffKey)), func(k, v []byte) (bool, error) {
+				if len(v) == common.AddressLength {
+					copy(account[:], v)
+					found = true
+					return false, nil
+				}
+				return true, nil
+			})
+			if !found {
+				fmt.Printf("Could not find suitable account for diffKey %x\n", diffKey)
+				return
+			}
+			reqID++
+			template := `{"jsonrpc":"2.0","method":"eth_getProof","params":["0x%x",[],"0x%x"],"id":%d}`
+			var proof EthGetProof
+			if err := post(client, url, fmt.Sprintf(template, account, block, reqID), &proof); err != nil {
+				fmt.Printf("Could not get block number: %v\n", err)
+				return
+			}
+			if proof.Error != nil {
+				fmt.Printf("Error retrieving proof: %d %s\n", proof.Error.Code, proof.Error.Message)
+				return
+			}
+			if len(proof.Result.AccountProof) <= len(diffKey) {
+				fmt.Printf("RPC result needs to be at least %d levels deep\n", len(diffKey)+1)
+				return
+			}
+			p := proof.Result.AccountProof[len(diffKey)]
+			b := common.FromHex(p)
+			h := common.BytesToHash(crypto.Keccak256(b))
+			hE := t.HashOfHexKey(diffKey)
+			if h != hE {
+				fmt.Printf(":( key %x: %x %x adding nibbles: ", diffKey, h, hE)
+				var branch [17][]byte
+				err = rlp.DecodeBytes(b, &branch)
+				if err != nil {
+					fmt.Printf("Error decoding: %v\n", err)
+				}
+				// Expand keys further
+				for nibble := byte(0); nibble < 16; nibble++ {
+					newDiff := make([]byte, len(diffKey)+1)
+					copy(newDiff, diffKey)
+					newDiff[len(diffKey)] = nibble
+					var proofHash common.Hash
+					copy(proofHash[:], branch[nibble])
+					newHash := t.HashOfHexKey(newDiff)
+					if proofHash != newHash {
+						newDiffKeys = append(newDiffKeys, newDiff)
+						fmt.Printf("%x", nibble)
+					}
+				}
+				fmt.Printf("\n")
+			} else {
+				fmt.Printf("MATCH key %x: %x %x\n", diffKey, h, hE)
+			}
+			/*
+				for _, p := range proof.Result.AccountProof {
+					var branch [17][]byte
+
+					err = rlp.DecodeBytes(b, &branch)
+					if err != nil {
+						fmt.Printf("Error decoding: %v\n", err)
+					}
+					h := crypto.Keccak256(b)
+					fmt.Printf("%x: %s\n", h, p)
+				}
+			*/
+		}
+		diffKeys = newDiffKeys
+		newDiffKeys = nil
+		level++
 	}
-	if proof.Error != nil {
-		fmt.Printf("Error retrieving proof: %d %s\n", proof.Error.Code, proof.Error.Message)
-		return
-	}
-	for _, p := range proof.Result.AccountProof {
-		b := common.FromHex(p)
-		h := crypto.Keccak256(b)
-		fmt.Printf("%x: %s\n", h, p)
+	fmt.Printf("\n\nRESULT:\n")
+	for _, diffKey := range diffKeys {
+		fmt.Printf("%x\n", diffKey)
 	}
 }

--- a/cmd/rpctest/proofs.go
+++ b/cmd/rpctest/proofs.go
@@ -90,7 +90,7 @@ func proofs(chaindata string, url string, block int) {
 	diffKeys := [][]byte{{}}
 	var newDiffKeys [][]byte
 
-	for len(diffKeys) > 0 && level < 6 {
+	for len(diffKeys) > 0 && level < 7 {
 
 		fmt.Printf("================================================\n")
 		fmt.Printf("LEVEL %d, diffKeys: %d\n", level, len(diffKeys))
@@ -152,6 +152,7 @@ func proofs(chaindata string, url string, block int) {
 				err = rlp.DecodeBytes(b, &branch)
 				if err != nil {
 					fmt.Printf("Error decoding: %v\n", err)
+					fmt.Printf("%s\n", p)
 				}
 				// Expand keys further
 				for nibble := byte(0); nibble < 16; nibble++ {
@@ -160,13 +161,15 @@ func proofs(chaindata string, url string, block int) {
 					newDiff[len(diffKey)] = nibble
 					var proofHash common.Hash
 					copy(proofHash[:], branch[nibble])
-					newHash, err := t.HashOfHexKey(newDiff)
-					if err != nil {
-						fmt.Printf("Error computing partial hash for %x: %v\n", newDiff, err)
-					}
-					if proofHash != newHash {
-						newDiffKeys = append(newDiffKeys, newDiff)
-						fmt.Printf("%x", nibble)
+					if proofHash != (common.Hash{}) || err != nil {
+						newHash, err := t.HashOfHexKey(newDiff)
+						if err != nil {
+							fmt.Printf("Error computing partial hash for %x: %v\n", newDiff, err)
+						}
+						if proofHash != newHash {
+							newDiffKeys = append(newDiffKeys, newDiff)
+							fmt.Printf("%x", nibble)
+						}
 					}
 				}
 				fmt.Printf("\n")

--- a/cmd/rpctest/proofs.go
+++ b/cmd/rpctest/proofs.go
@@ -137,9 +137,13 @@ func proofs(chaindata string, url string, block int) {
 			p := proof.Result.AccountProof[len(diffKey)]
 			b := common.FromHex(p)
 			h := common.BytesToHash(crypto.Keccak256(b))
-			hE := t.HashOfHexKey(diffKey)
+			hE, err := t.HashOfHexKey(diffKey)
+			if err != nil {
+				fmt.Printf("Error computing partial hash for %x: %v\n", diffKey, err)
+				return
+			}
 			if h != hE {
-				fmt.Printf(":( key %x: %x %x adding nibbles: ", diffKey, h, hE)
+				fmt.Printf("key %x: %x %x adding nibbles: ", diffKey, h, hE)
 				var branch [17][]byte
 				err = rlp.DecodeBytes(b, &branch)
 				if err != nil {
@@ -152,7 +156,10 @@ func proofs(chaindata string, url string, block int) {
 					newDiff[len(diffKey)] = nibble
 					var proofHash common.Hash
 					copy(proofHash[:], branch[nibble])
-					newHash := t.HashOfHexKey(newDiff)
+					newHash, err := t.HashOfHexKey(newDiff)
+					if err != nil {
+						fmt.Printf("Error computing partial hash for %x: %v\n", newDiff, err)
+					}
 					if proofHash != newHash {
 						newDiffKeys = append(newDiffKeys, newDiff)
 						fmt.Printf("%x", nibble)
@@ -162,18 +169,6 @@ func proofs(chaindata string, url string, block int) {
 			} else {
 				fmt.Printf("MATCH key %x: %x %x\n", diffKey, h, hE)
 			}
-			/*
-				for _, p := range proof.Result.AccountProof {
-					var branch [17][]byte
-
-					err = rlp.DecodeBytes(b, &branch)
-					if err != nil {
-						fmt.Printf("Error decoding: %v\n", err)
-					}
-					h := crypto.Keccak256(b)
-					fmt.Printf("%x: %s\n", h, p)
-				}
-			*/
 		}
 		diffKeys = newDiffKeys
 		newDiffKeys = nil

--- a/cmd/rpctest/proofs.go
+++ b/cmd/rpctest/proofs.go
@@ -3,11 +3,14 @@ package main
 import (
 	"fmt"
 	"net/http"
+	"os"
 	"time"
 
 	"github.com/ledgerwatch/turbo-geth/common"
 	"github.com/ledgerwatch/turbo-geth/common/hexutil"
 	"github.com/ledgerwatch/turbo-geth/crypto"
+	"github.com/ledgerwatch/turbo-geth/ethdb"
+	"github.com/ledgerwatch/turbo-geth/trie"
 )
 
 type EthGetProof struct {
@@ -31,7 +34,51 @@ type StorageResult struct {
 	Proof []string     `json:"proof"`
 }
 
-func proofs(url string, block int, account common.Address) {
+func proofs(chaindata string, url string, block int, account common.Address) {
+	fileName := "trie.txt"
+	ethDb, err := ethdb.NewBoltDatabase(chaindata)
+	if err != nil {
+		panic(err)
+	}
+	defer ethDb.Close()
+	var t *trie.Trie
+	if _, err := os.Stat(fileName); err != nil {
+		if os.IsNotExist(err) {
+			// Resolve 5 top levels of the accounts trie
+			r := trie.NewResolver(5, true, uint64(block))
+			t = trie.New(common.Hash{})
+			req := t.NewResolveRequest(nil, []byte{}, 0, nil)
+			r.AddRequest(req)
+			err = r.ResolveWithDb(ethDb, uint64(block))
+			if err != nil {
+				panic(err)
+			}
+			fmt.Printf("Resoled with hash: %x\n", t.Hash())
+			f, err1 := os.Create(fileName)
+			if err1 == nil {
+				defer f.Close()
+				t.Print(f)
+			} else {
+				panic(err1)
+			}
+			fmt.Printf("Saved trie to file\n")
+		} else {
+			panic(err)
+		}
+	} else {
+		f, err1 := os.Open(fileName)
+		if err1 == nil {
+			defer f.Close()
+			var err2 error
+			t, err2 = trie.Load(f)
+			if err2 != nil {
+				panic(err2)
+			}
+			fmt.Printf("Restored from file with hash: %x\n", t.Hash())
+		} else {
+			panic(err1)
+		}
+	}
 	var client = &http.Client{
 		Timeout: time.Second * 600,
 	}
@@ -39,7 +86,7 @@ func proofs(url string, block int, account common.Address) {
 	reqID++
 	template := `{"jsonrpc":"2.0","method":"eth_getProof","params":["0x%x",[],"0x%x"],"id":%d}`
 	var proof EthGetProof
-	if err := post(client, url, fmt.Sprintf(template, common.FromHex("0xaCf95bD28Cd5f0A669eA3B9F9cF97Cce7574257c"), 8956072, reqID), &proof); err != nil {
+	if err := post(client, url, fmt.Sprintf(template, account, block, reqID), &proof); err != nil {
 		fmt.Printf("Could not get block number: %v\n", err)
 		return
 	}

--- a/cmd/rpctest/proofs.go
+++ b/cmd/rpctest/proofs.go
@@ -1,0 +1,55 @@
+package main
+
+import (
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/ledgerwatch/turbo-geth/common"
+	"github.com/ledgerwatch/turbo-geth/common/hexutil"
+	"github.com/ledgerwatch/turbo-geth/crypto"
+)
+
+type EthGetProof struct {
+	CommonResponse
+	Result AccountResult `json:"result"`
+}
+
+// Result structs for GetProof
+type AccountResult struct {
+	Address      common.Address  `json:"address"`
+	AccountProof []string        `json:"accountProof"`
+	Balance      *hexutil.Big    `json:"balance"`
+	CodeHash     common.Hash     `json:"codeHash"`
+	Nonce        hexutil.Uint64  `json:"nonce"`
+	StorageHash  common.Hash     `json:"storageHash"`
+	StorageProof []StorageResult `json:"storageProof"`
+}
+type StorageResult struct {
+	Key   string       `json:"key"`
+	Value *hexutil.Big `json:"value"`
+	Proof []string     `json:"proof"`
+}
+
+func proofs(url string, block int, account common.Address) {
+	var client = &http.Client{
+		Timeout: time.Second * 600,
+	}
+	reqID := 0
+	reqID++
+	template := `{"jsonrpc":"2.0","method":"eth_getProof","params":["0x%x",[],"0x%x"],"id":%d}`
+	var proof EthGetProof
+	if err := post(client, url, fmt.Sprintf(template, common.FromHex("0xaCf95bD28Cd5f0A669eA3B9F9cF97Cce7574257c"), 8956072, reqID), &proof); err != nil {
+		fmt.Printf("Could not get block number: %v\n", err)
+		return
+	}
+	if proof.Error != nil {
+		fmt.Printf("Error retrieving proof: %d %s\n", proof.Error.Code, proof.Error.Message)
+		return
+	}
+	for _, p := range proof.Result.AccountProof {
+		b := common.FromHex(p)
+		h := crypto.Keccak256(b)
+		fmt.Printf("%x: %s\n", h, p)
+	}
+}

--- a/cmd/rpctest/proofs.go
+++ b/cmd/rpctest/proofs.go
@@ -230,7 +230,7 @@ func fixState(chaindata string, url string) {
 				for nextKey != nil {
 					reqID++
 					var sr DebugStorageRange
-					if err := post(client, url, fmt.Sprintf(template, blockHash, 0, address, *nextKey, 1024, reqID), &sr); err != nil {
+					if err = post(client, url, fmt.Sprintf(template, blockHash, 0, address, *nextKey, 1024, reqID), &sr); err != nil {
 						fmt.Printf("Could not get storageRange: %v\n", err)
 						return false, err
 					}
@@ -250,7 +250,7 @@ func fixState(chaindata string, url string) {
 					l := account.EncodingLengthForStorage()
 					b := make([]byte, l)
 					account.EncodeForStorage(b)
-					if err := stateDb.Put(dbutils.AccountsBucket, addrHash[:], b); err != nil {
+					if err = stateDb.Put(dbutils.AccountsBucket, addrHash[:], b); err != nil {
 						fmt.Printf("Could not repair: %v\n", err)
 					}
 				}

--- a/cmd/rpctest/proofs.go
+++ b/cmd/rpctest/proofs.go
@@ -87,7 +87,7 @@ func proofs(chaindata string, url string, block int) {
 	reqID := 0
 
 	level := 0
-	diffKeys := [][]byte{[]byte{}}
+	diffKeys := [][]byte{{}}
 	var newDiffKeys [][]byte
 
 	for len(diffKeys) > 0 && level < 6 {

--- a/cmd/state/state_snapshot.go
+++ b/cmd/state/state_snapshot.go
@@ -346,7 +346,7 @@ func checkRoots(stateDb ethdb.Database, rootHash common.Hash, blockNum uint64) {
 		panic(err)
 	}
 	for addrHash, root := range roots {
-		if root != (common.Hash{}) && root != trie.EmptyRoot {
+		if root != (common.Hash{}) {
 			st := trie.New(root)
 			sr := trie.NewResolver(32, false, blockNum)
 			key := []byte{}

--- a/trie/debug.go
+++ b/trie/debug.go
@@ -435,7 +435,7 @@ func (t *Trie) HashOfHexKey(hexKey []byte) (common.Hash, error) {
 					account = true
 				}
 			} else {
-				return common.Hash{}, fmt.Errorf("too long shortNode key: pos %d, hexKey %x", pos, hexKey)
+				return common.Hash{}, fmt.Errorf("too long shortNode key: pos %d, hexKey %x: %s", pos, hexKey, n.fstring(""))
 			}
 		case *duoNode:
 			i1, i2 := n.childrenIdx()

--- a/trie/trie.go
+++ b/trie/trie.go
@@ -588,7 +588,7 @@ func (t *Trie) hook(hex []byte, n node) {
 			panic(fmt.Sprintf("Unknown node: %T", n))
 		}
 	}
-	if _, ok := nd.(hashNode); !ok {
+	if _, ok := nd.(hashNode); !ok && nd != nil {
 		return
 	}
 	t.touchAll(n, hex, false)


### PR DESCRIPTION
Partially solves https://github.com/ledgerwatch/turbo-geth/issues/190

It uses `eth_getProof` to narrow down from the root to the branches of the trie that have different hashes from what is expected (what is expected is taken from the results of the `eth_getProof` RPC call).