### PR TITLE
/cmd/state stateGrowth

### DIFF
--- a/cmd/rpcdaemon/commands/daemon.go
+++ b/cmd/rpcdaemon/commands/daemon.go
@@ -40,13 +40,13 @@ type EthAPI interface {
 
 // APIImpl is implementation of the EthAPI interface based on remote Db access
 type APIImpl struct {
-	remoteDbAdddress string
-	db               *remote.DB
+	remoteDbAddress string
+	db              *remote.DB
 }
 
 func (api *APIImpl) ensureConnected(ctx context.Context) error {
 	if api.db == nil {
-		conn, err := net.Dial("tcp", api.remoteDbAdddress)
+		conn, err := net.Dial("tcp", api.remoteDbAddress)
 		if err != nil {
 			return err
 		}
@@ -61,8 +61,8 @@ func (api *APIImpl) ensureConnected(ctx context.Context) error {
 }
 
 // ConnectAPIImpl connects to the remote DB and returns APIImpl instance
-func ConnectAPIImpl(remoteDbAdddress string) (*APIImpl, error) {
-	return &APIImpl{remoteDbAdddress: remoteDbAdddress}, nil
+func ConnectAPIImpl(remoteDbAddress string) (*APIImpl, error) {
+	return &APIImpl{remoteDbAddress: remoteDbAddress}, nil
 }
 
 // BlockNumber returns the currently highest block number available in the remote db
@@ -259,7 +259,7 @@ func daemon(cfg Config) {
 	cors := splitAndTrim(cfg.rpcCORSDomain)
 	enabledApis := splitAndTrim(cfg.rpcAPI)
 	var rpcAPI = []rpc.API{}
-	apiImpl, err := ConnectAPIImpl(cfg.remoteDbAdddress)
+	apiImpl, err := ConnectAPIImpl(cfg.remoteDbAddress)
 	if err != nil {
 		log.Error("Could not connect to remoteDb", "error", err)
 		return

--- a/cmd/rpcdaemon/commands/daemon.go
+++ b/cmd/rpcdaemon/commands/daemon.go
@@ -44,16 +44,18 @@ type APIImpl struct {
 	db               *remote.DB
 }
 
-func (api *APIImpl) ensureConnected() error {
+func (api *APIImpl) ensureConnected(ctx context.Context) error {
 	if api.db == nil {
 		conn, err := net.Dial("tcp", api.remoteDbAdddress)
 		if err != nil {
 			return err
 		}
-		api.db, err = remote.NewDB(conn, conn, conn)
+
+		api.db, err = remote.NewDB(ctx, conn, conn, conn)
 		if err != nil {
 			return err
 		}
+
 	}
 	return nil
 }
@@ -65,7 +67,7 @@ func ConnectAPIImpl(remoteDbAdddress string) (*APIImpl, error) {
 
 // BlockNumber returns the currently highest block number available in the remote db
 func (api *APIImpl) BlockNumber(ctx context.Context) (uint64, error) {
-	if err := api.ensureConnected(); err != nil {
+	if err := api.ensureConnected(context.Background()); err != nil {
 		return 0, err
 	}
 	var blockNumber uint64
@@ -99,7 +101,7 @@ func (api *APIImpl) BlockNumber(ctx context.Context) (uint64, error) {
 // GetBlockByNumber see https://github.com/ethereum/wiki/wiki/JSON-RPC#eth_getblockbynumber
 // see internal/ethapi.PublicBlockChainAPI.GetBlockByNumber
 func (api *APIImpl) GetBlockByNumber(ctx context.Context, number rpc.BlockNumber, fullTx bool) (map[string]interface{}, error) {
-	if err := api.ensureConnected(); err != nil {
+	if err := api.ensureConnected(context.Background()); err != nil {
 		return nil, err
 	}
 

--- a/cmd/rpcdaemon/commands/daemon.go
+++ b/cmd/rpcdaemon/commands/daemon.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/binary"
 	"fmt"
+	"io"
 	"math/big"
 	"net"
 	"os"
@@ -44,34 +45,25 @@ type APIImpl struct {
 	db              *remote.DB
 }
 
-func (api *APIImpl) ensureConnected() error {
-	if api.db == nil {
-		conn, err := net.Dial("tcp", api.remoteDbAddress)
-		if err != nil {
-			return err
-		}
-
-		api.db, err = remote.NewDB(conn, conn, conn)
-		if err != nil {
-			return err
-		}
-
-	}
-	return nil
-}
-
 // ConnectAPIImpl connects to the remote DB and returns APIImpl instance
 func ConnectAPIImpl(remoteDbAddress string) (*APIImpl, error) {
-	return &APIImpl{remoteDbAddress: remoteDbAddress}, nil
+	dial := func(ctx context.Context) (in io.Reader, out io.Writer, closer io.Closer, err error) {
+		dialer := net.Dialer{}
+		conn, err := dialer.DialContext(ctx, "tcp", remoteDbAddress)
+		return conn, conn, conn, err
+	}
+	db, err := remote.NewDB(dial)
+	if err != nil {
+		return nil, err
+	}
+
+	return &APIImpl{remoteDbAddress: remoteDbAddress, db: db}, nil
 }
 
 // BlockNumber returns the currently highest block number available in the remote db
 func (api *APIImpl) BlockNumber(ctx context.Context) (uint64, error) {
-	if err := api.ensureConnected(); err != nil {
-		return 0, err
-	}
 	var blockNumber uint64
-	if err := api.db.View(ctx, func(tx *remote.Tx) error {
+	err := api.db.View(ctx, func(tx *remote.Tx) error {
 		b := tx.Bucket(dbutils.HeadHeaderKey)
 		if b == nil {
 			return fmt.Errorf("bucket %s not found", dbutils.HeadHeaderKey)
@@ -90,31 +82,26 @@ func (api *APIImpl) BlockNumber(ctx context.Context) (uint64, error) {
 		}
 		blockNumber = binary.BigEndian.Uint64(blockNumberData)
 		return nil
-	}); err != nil {
-		api.db.Close()
-		api.db = nil
+	})
+	if err != nil {
 		return 0, err
 	}
+
 	return blockNumber, nil
 }
 
 // GetBlockByNumber see https://github.com/ethereum/wiki/wiki/JSON-RPC#eth_getblockbynumber
 // see internal/ethapi.PublicBlockChainAPI.GetBlockByNumber
 func (api *APIImpl) GetBlockByNumber(ctx context.Context, number rpc.BlockNumber, fullTx bool) (map[string]interface{}, error) {
-	if err := api.ensureConnected(); err != nil {
-		return nil, err
-	}
-
 	var block *types.Block
 	additionalFields := make(map[string]interface{})
 
-	if err := api.db.View(ctx, func(tx *remote.Tx) error {
+	err := api.db.View(ctx, func(tx *remote.Tx) error {
 		block = GetBlockByNumber(tx, uint64(number.Int64()))
 		additionalFields["totalDifficulty"] = ReadTd(tx, block.Hash(), uint64(number.Int64()))
 		return nil
-	}); err != nil {
-		api.db.Close()
-		api.db = nil
+	})
+	if err != nil {
 		return nil, err
 	}
 

--- a/cmd/rpcdaemon/commands/root.go
+++ b/cmd/rpcdaemon/commands/root.go
@@ -15,7 +15,7 @@ import (
 )
 
 type Config struct {
-	remoteDbAdddress string
+	remoteDbAddress  string
 	rpcListenAddress string
 	rpcPort          int
 	rpcCORSDomain    string
@@ -34,7 +34,7 @@ var (
 func init() {
 	rootCmd.PersistentFlags().StringVar(&cpuprofile, "cpuprofile", "", "write cpu profile `file`")
 	rootCmd.PersistentFlags().StringVar(&memprofile, "memprofile", "", "write memory profile `file`")
-	rootCmd.Flags().StringVar(&cfg.remoteDbAdddress, "remote-db-addr", "localhost:9999", "address of remote DB listener of a turbo-geth node")
+	rootCmd.Flags().StringVar(&cfg.remoteDbAddress, "remote-db-addr", "localhost:9999", "address of remote DB listener of a turbo-geth node")
 	rootCmd.Flags().StringVar(&cfg.rpcListenAddress, "rpcaddr", node.DefaultHTTPHost, "HTTP-RPC server listening interface")
 	rootCmd.Flags().IntVar(&cfg.rpcPort, "rpcport", node.DefaultHTTPPort, "HTTP-RPC server listening port")
 	rootCmd.Flags().StringVar(&cfg.rpcCORSDomain, "rpccorsdomain", "", "Comma separated list of domains from which to accept cross origin requests (browser enforced)")

--- a/cmd/state/commands/global_flags_vars.go
+++ b/cmd/state/commands/global_flags_vars.go
@@ -3,9 +3,10 @@ package commands
 import "github.com/spf13/cobra"
 
 var (
-	chaindata string
-	statsfile string
-	block     uint64
+	chaindata        string
+	statsfile        string
+	block            uint64
+	remoteDbAdddress string
 )
 
 func withBlock(cmd *cobra.Command) {
@@ -24,4 +25,8 @@ func withStatsfile(cmd *cobra.Command) {
 	if err := cmd.MarkFlagFilename("statsfile", "csv"); err != nil {
 		panic(err)
 	}
+}
+
+func withRemoteDb(cmd *cobra.Command) {
+	cmd.Flags().StringVar(&remoteDbAdddress, "remote-db-addr", "", "remote db rpc address")
 }

--- a/cmd/state/commands/global_flags_vars.go
+++ b/cmd/state/commands/global_flags_vars.go
@@ -3,10 +3,10 @@ package commands
 import "github.com/spf13/cobra"
 
 var (
-	chaindata        string
-	statsfile        string
-	block            uint64
-	remoteDbAdddress string
+	chaindata       string
+	statsfile       string
+	block           uint64
+	remoteDbAddress string
 )
 
 func withBlock(cmd *cobra.Command) {
@@ -28,5 +28,5 @@ func withStatsfile(cmd *cobra.Command) {
 }
 
 func withRemoteDb(cmd *cobra.Command) {
-	cmd.Flags().StringVar(&remoteDbAdddress, "remote-db-addr", "", "remote db rpc address")
+	cmd.Flags().StringVar(&remoteDbAddress, "remote-db-addr", "", "remote db rpc address")
 }

--- a/cmd/state/commands/state_growth.go
+++ b/cmd/state/commands/state_growth.go
@@ -6,16 +6,24 @@ import (
 )
 
 func init() {
-	withChaindata(stateGrowthCmd)
-	rootCmd.AddCommand(stateGrowthCmd)
-}
+	stateGrowthCmd := &cobra.Command{
+		Use:   "stateGrowth",
+		Short: "stateGrowth",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			reporter, err := stateless.NewReporter(remoteDbAdddress)
+			if err != nil {
+				return err
+			}
 
-var stateGrowthCmd = &cobra.Command{
-	Use:   "stateGrowth",
-	Short: "stateGrowth",
-	RunE: func(cmd *cobra.Command, args []string) error {
-		stateless.StateGrowth1(chaindata)
-		stateless.StateGrowth2(chaindata)
-		return nil
-	},
+			reporter.StateGrowth1(chaindata)
+			reporter.StateGrowth2(chaindata)
+			return nil
+		},
+	}
+
+	withChaindata(stateGrowthCmd)
+
+	withRemoteDb(stateGrowthCmd)
+
+	rootCmd.AddCommand(stateGrowthCmd)
 }

--- a/cmd/state/commands/state_growth.go
+++ b/cmd/state/commands/state_growth.go
@@ -17,7 +17,7 @@ func init() {
 		Use:   "stateGrowth",
 		Short: "stateGrowth",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			reporter, err := stateless.NewReporter(remoteDbAdddress)
+			reporter, err := stateless.NewReporter(remoteDbAddress)
 			if err != nil {
 				return err
 			}

--- a/cmd/state/commands/state_growth.go
+++ b/cmd/state/commands/state_growth.go
@@ -15,7 +15,7 @@ func init() {
 				return err
 			}
 
-			//reporter.StateGrowth1(chaindata)
+			reporter.StateGrowth1(chaindata)
 			reporter.StateGrowth2(chaindata)
 			return nil
 		},

--- a/cmd/state/commands/state_growth.go
+++ b/cmd/state/commands/state_growth.go
@@ -15,7 +15,7 @@ func init() {
 				return err
 			}
 
-			reporter.StateGrowth1(chaindata)
+			//reporter.StateGrowth1(chaindata)
 			reporter.StateGrowth2(chaindata)
 			return nil
 		},

--- a/cmd/state/commands/state_growth.go
+++ b/cmd/state/commands/state_growth.go
@@ -25,8 +25,8 @@ func init() {
 			ctx, _ := getContext()
 
 			fmt.Println("Processing started...")
-			reporter.StateGrowth1(ctx, chaindata)
-			reporter.StateGrowth2(ctx, chaindata)
+			reporter.StateGrowth1(ctx)
+			reporter.StateGrowth2(ctx)
 			return nil
 		},
 	}

--- a/cmd/state/stateless/state.go
+++ b/cmd/state/stateless/state.go
@@ -180,7 +180,7 @@ func (r *Reporter) StateGrowth1(chaindata string) {
 			return nil
 		}
 		c := b.Cursor()
-		for k, _ := c.Seek([]byte("0xx")); k != nil; k, _ = c.Next() {
+		for k, _ := c.First(); k != nil; k, _ = c.Next() {
 			// First 32 bytes is the hash of the address
 			copy(addrHash[:], k[:32])
 			lastTimestamps[addrHash] = maxTimestamp

--- a/cmd/state/stateless/state.go
+++ b/cmd/state/stateless/state.go
@@ -136,7 +136,7 @@ func (r *Reporter) StateGrowth1(chaindata string) {
 	creationsByBlock := make(map[uint64]int)
 	var addrHash common.Hash
 	// Go through the history of account first
-	if err := r.db.View(func(tx *remote.Tx) error {
+	err = r.db.View(func(tx *remote.Tx) error {
 		b := tx.Bucket(dbutils.AccountsHistoryBucket)
 		if b == nil {
 			return nil
@@ -163,14 +163,15 @@ func (r *Reporter) StateGrowth1(chaindata string) {
 			}
 		}
 		return nil
-	}); err != nil {
+	})
+	if err != nil {
 		r.db.Close()
 		r.db = nil
 		check(err)
 	}
 
 	// Go through the current state
-	if err := r.db.View(func(tx *remote.Tx) error {
+	err = r.db.View(func(tx *remote.Tx) error {
 		pre := tx.Bucket(dbutils.PreimagePrefix)
 		if pre == nil {
 			return nil
@@ -190,7 +191,8 @@ func (r *Reporter) StateGrowth1(chaindata string) {
 			}
 		}
 		return nil
-	}); err != nil {
+	})
+	if err != nil {
 		r.db.Close()
 		r.db = nil
 		check(err)
@@ -241,7 +243,7 @@ func (r *Reporter) StateGrowth2(chaindata string) {
 	var addrHash common.Hash
 	var hash common.Hash
 	// Go through the history of account first
-	if err = r.db.View(func(tx *remote.Tx) error {
+	err = r.db.View(func(tx *remote.Tx) error {
 		b := tx.Bucket(dbutils.StorageHistoryBucket)
 		if b == nil {
 			return nil
@@ -284,14 +286,15 @@ func (r *Reporter) StateGrowth2(chaindata string) {
 			}
 		}
 		return nil
-	}); err != nil {
+	})
+	if err != nil {
 		r.db.Close()
 		r.db = nil
 		check(err)
 	}
 
 	// Go through the current state
-	if err = r.db.View(func(tx *remote.Tx) error {
+	err = r.db.View(func(tx *remote.Tx) error {
 		b := tx.Bucket(dbutils.StorageBucket)
 		if b == nil {
 			return nil
@@ -312,7 +315,8 @@ func (r *Reporter) StateGrowth2(chaindata string) {
 			}
 		}
 		return nil
-	}); err != nil {
+	})
+	if err != nil {
 		r.db.Close()
 		r.db = nil
 		check(err)

--- a/cmd/state/stateless/state.go
+++ b/cmd/state/stateless/state.go
@@ -242,7 +242,7 @@ func (r *Reporter) StateGrowth2(chaindata string) {
 	var hash common.Hash
 	// Go through the history of account first
 	if err = r.db.View(func(tx *remote.Tx) error {
-		b := tx.Bucket(dbutils.AccountsHistoryBucket)
+		b := tx.Bucket(dbutils.StorageHistoryBucket)
 		if b == nil {
 			return nil
 		}

--- a/ethdb/remote/bolt_remote.go
+++ b/ethdb/remote/bolt_remote.go
@@ -394,14 +394,13 @@ func Server(ctx context.Context, db *bolt.DB, in io.Reader, out io.Writer, close
 			if err := decoder.Decode(&numberOfKeys); err != nil {
 				log.Error("could not decode numberOfKeys for CmdCursorFirst", "error", err)
 			}
-			var key, value []byte
 			cursor, ok := cursors[cursorHandle]
 			if !ok {
 				lastError = fmt.Errorf("cursor not found")
 				continue
 			}
 
-			for key, value = cursor.First(); key != nil || numberOfKeys > 0; key, value = cursor.Next() {
+			for key, value := cursor.First(); key != nil || numberOfKeys > 0; key, value = cursor.Next() {
 				select {
 				default:
 				case <-ctx.Done():

--- a/ethdb/remote/bolt_remote.go
+++ b/ethdb/remote/bolt_remote.go
@@ -720,8 +720,8 @@ func (b *Bucket) Cursor() *Cursor {
 		out:          b.out,
 		cursorHandle: cursorHandle,
 
-		cacheKeys:   make([][]byte, DefaultCursorCacheSize, DefaultCursorCacheSize),
-		cacheValues: make([][]byte, DefaultCursorCacheSize, DefaultCursorCacheSize),
+		cacheKeys:   make([][]byte, DefaultCursorCacheSize),
+		cacheValues: make([][]byte, DefaultCursorCacheSize),
 	}
 
 	return cursor
@@ -853,5 +853,4 @@ func (c *Cursor) fetchPage(cmd Command, numberOfKeys uint64) {
 		}
 	}
 
-	return
 }

--- a/ethdb/remote/bolt_remote_test.go
+++ b/ethdb/remote/bolt_remote_test.go
@@ -366,17 +366,17 @@ func TestCmdSeek(t *testing.T) {
 	if err = encoder.Encode(&bucketHandle); err != nil {
 		t.Errorf("Could not encode bucketHandler for CmdCursor: %v", err)
 	}
-	c = CmdSeek
+	c = CmdCursorSeek
 	if err = encoder.Encode(&c); err != nil {
-		t.Errorf("Could not encode CmdSeek: %v", err)
+		t.Errorf("Could not encode CmdCursorSeek: %v", err)
 	}
 	var cursorHandle uint64 = 3
 	if err = encoder.Encode(&cursorHandle); err != nil {
-		t.Errorf("Could not encode cursorHandle for CmdSeek: %v", err)
+		t.Errorf("Could not encode cursorHandle for CmdCursorSeek: %v", err)
 	}
 	var seekKey = []byte("key15") // Should find key2
 	if err = encoder.Encode(&seekKey); err != nil {
-		t.Errorf("Could not encode seekKey for CmdSeek: %v", err)
+		t.Errorf("Could not encode seekKey for CmdCursorSeek: %v", err)
 	}
 	// By now we constructed all input requests, now we call the
 	// Server to process them all
@@ -405,16 +405,16 @@ func TestCmdSeek(t *testing.T) {
 	if cursorHandle != 3 {
 		t.Errorf("Unexpected cursorHandle: %d", cursorHandle)
 	}
-	// Results of CmdSeek
+	// Results of CmdCursorSeek
 	var key, value []byte
 	if err = decoder.Decode(&key); err != nil {
-		t.Errorf("Could not decode response from CmdSeek: %v", err)
+		t.Errorf("Could not decode response from CmdCursorSeek: %v", err)
 	}
 	if string(key) != key2 {
 		t.Errorf("Unexpected key: %s", key)
 	}
 	if err = decoder.Decode(&value); err != nil {
-		t.Errorf("Could not decode response from CmdSeek: %v", err)
+		t.Errorf("Could not decode response from CmdCursorSeek: %v", err)
 	}
 	if string(value) != value2 {
 		t.Errorf("Unexpected value: %s", key)
@@ -476,24 +476,24 @@ func TestCmdNext(t *testing.T) {
 	if err = encoder.Encode(&bucketHandle); err != nil {
 		t.Errorf("Could not encode bucketHandler for CmdCursor: %v", err)
 	}
-	c = CmdSeek
+	c = CmdCursorSeek
 	if err = encoder.Encode(&c); err != nil {
-		t.Errorf("Could not encode CmdSeek: %v", err)
+		t.Errorf("Could not encode CmdCursorSeek: %v", err)
 	}
 	var cursorHandle uint64 = 3
 	if err = encoder.Encode(&cursorHandle); err != nil {
-		t.Errorf("Could not encode cursorHandle for CmdSeek: %v", err)
+		t.Errorf("Could not encode cursorHandle for CmdCursorSeek: %v", err)
 	}
 	var seekKey = []byte("key1") // Should find key1
 	if err = encoder.Encode(&seekKey); err != nil {
-		t.Errorf("Could not encode seekKey for CmdSeek: %v", err)
+		t.Errorf("Could not encode seekKey for CmdCursorSeek: %v", err)
 	}
-	c = CmdNext
+	c = CmdCursorNext
 	if err = encoder.Encode(&c); err != nil {
-		t.Errorf("Could not encode CmdNext: %v", err)
+		t.Errorf("Could not encode CmdCursorNext: %v", err)
 	}
 	if err = encoder.Encode(&cursorHandle); err != nil {
-		t.Errorf("Could not encode cursorHandler for CmdNext: %v", err)
+		t.Errorf("Could not encode cursorHandler for CmdCursorNext: %v", err)
 	}
 	var numberOfKeys uint64 = 3 // Trying to get 3 keys, but will get 1 + nil
 	if err = encoder.Encode(&numberOfKeys); err != nil {
@@ -526,41 +526,41 @@ func TestCmdNext(t *testing.T) {
 	if cursorHandle != 3 {
 		t.Errorf("Unexpected cursorHandle: %d", cursorHandle)
 	}
-	// Results of CmdSeek
+	// Results of CmdCursorSeek
 	var key, value []byte
 	if err = decoder.Decode(&key); err != nil {
-		t.Errorf("Could not decode response from CmdSeek: %v", err)
+		t.Errorf("Could not decode response from CmdCursorSeek: %v", err)
 	}
 	if string(key) != key1 {
 		t.Errorf("Unexpected key: %s", key)
 	}
 	if err = decoder.Decode(&value); err != nil {
-		t.Errorf("Could not decode response from CmdSeek: %v", err)
+		t.Errorf("Could not decode response from CmdCursorSeek: %v", err)
 	}
 	if string(value) != value1 {
 		t.Errorf("Unexpected value: %s", value)
 	}
-	// Results of CmdNext
+	// Results of CmdCursorNext
 	if err = decoder.Decode(&key); err != nil {
-		t.Errorf("Could not decode response from CmdNext: %v", err)
+		t.Errorf("Could not decode response from CmdCursorNext: %v", err)
 	}
 	if string(key) != key2 {
 		t.Errorf("Unexpected key: %s", key)
 	}
 	if err = decoder.Decode(&value); err != nil {
-		t.Errorf("Could not decode response from CmdNext: %v", err)
+		t.Errorf("Could not decode response from CmdCursorNext: %v", err)
 	}
 	if string(value) != value2 {
 		t.Errorf("Unexpected value: %s", value)
 	}
 	if err = decoder.Decode(&key); err != nil {
-		t.Errorf("Could not decode response from CmdNext: %v", err)
+		t.Errorf("Could not decode response from CmdCursorNext: %v", err)
 	}
 	if key != nil {
 		t.Errorf("Unexpected key: %s", key)
 	}
 	if err = decoder.Decode(&value); err != nil {
-		t.Errorf("Could not decode response from CmdNext: %v", err)
+		t.Errorf("Could not decode response from CmdCursorNext: %v", err)
 	}
 	if value != nil {
 		t.Errorf("Unexpected value: %s", value)

--- a/ethdb/remote/bolt_remote_test.go
+++ b/ethdb/remote/bolt_remote_test.go
@@ -18,6 +18,7 @@ package remote
 
 import (
 	"bytes"
+	"context"
 	"testing"
 
 	"github.com/ledgerwatch/bolt"
@@ -40,6 +41,8 @@ const (
 )
 
 func TestCmdVersion(t *testing.T) {
+	ctx := context.Background()
+
 	// ---------- Start of boilerplate code
 	db, err := bolt.Open("in-memory", 0600, &bolt.Options{MemOnly: true})
 	if err != nil {
@@ -58,7 +61,7 @@ func TestCmdVersion(t *testing.T) {
 	if err = encoder.Encode(&c); err != nil {
 		t.Errorf("Could not encode CmdVersion: %v", err)
 	}
-	if err = Server(db, &inBuf, &outBuf, closer); err != nil {
+	if err = Server(ctx, db, &inBuf, &outBuf, closer); err != nil {
 		t.Errorf("Error while calling Server: %v", err)
 	}
 	var v uint64
@@ -71,6 +74,7 @@ func TestCmdVersion(t *testing.T) {
 }
 
 func TestCmdBeginEndLastError(t *testing.T) {
+	ctx := context.Background()
 	// ---------- Start of boilerplate code
 	db, err := bolt.Open("in-memory", 0600, &bolt.Options{MemOnly: true})
 	if err != nil {
@@ -121,7 +125,7 @@ func TestCmdBeginEndLastError(t *testing.T) {
 	}
 	// By now we constructed all input requests, now we call the
 	// Server to process them all
-	if err = Server(db, &inBuf, &outBuf, closer); err != nil {
+	if err = Server(ctx, db, &inBuf, &outBuf, closer); err != nil {
 		t.Errorf("Error while calling Server: %v", err)
 	}
 	// And then we interpret the results
@@ -144,6 +148,8 @@ func TestCmdBeginEndLastError(t *testing.T) {
 }
 
 func TestCmdBucket(t *testing.T) {
+	ctx := context.Background()
+
 	// ---------- Start of boilerplate code
 	db, err := bolt.Open("in-memory", 0600, &bolt.Options{MemOnly: true})
 	if err != nil {
@@ -183,7 +189,7 @@ func TestCmdBucket(t *testing.T) {
 	}
 	// By now we constructed all input requests, now we call the
 	// Server to process them all
-	if err = Server(db, &inBuf, &outBuf, closer); err != nil {
+	if err = Server(ctx, db, &inBuf, &outBuf, closer); err != nil {
 		t.Errorf("Error while calling Server: %v", err)
 	}
 	// And then we interpret the results
@@ -203,6 +209,8 @@ func TestCmdBucket(t *testing.T) {
 }
 
 func TestCmdGet(t *testing.T) {
+	ctx := context.Background()
+
 	// ---------- Start of boilerplate code
 	db, err := bolt.Open("in-memory", 0600, &bolt.Options{MemOnly: true})
 	if err != nil {
@@ -276,7 +284,7 @@ func TestCmdGet(t *testing.T) {
 	}
 	// By now we constructed all input requests, now we call the
 	// Server to process them all
-	if err = Server(db, &inBuf, &outBuf, closer); err != nil {
+	if err = Server(ctx, db, &inBuf, &outBuf, closer); err != nil {
 		t.Errorf("Error while calling Server: %v", err)
 	}
 	// And then we interpret the results
@@ -312,6 +320,8 @@ func TestCmdGet(t *testing.T) {
 }
 
 func TestCmdSeek(t *testing.T) {
+	ctx := context.Background()
+
 	// ---------- Start of boilerplate code
 	db, err := bolt.Open("in-memory", 0600, &bolt.Options{MemOnly: true})
 	if err != nil {
@@ -380,7 +390,7 @@ func TestCmdSeek(t *testing.T) {
 	}
 	// By now we constructed all input requests, now we call the
 	// Server to process them all
-	if err = Server(db, &inBuf, &outBuf, closer); err != nil {
+	if err = Server(ctx, db, &inBuf, &outBuf, closer); err != nil {
 		t.Errorf("Error while calling Server: %v", err)
 	}
 	// And then we interpret the results
@@ -423,6 +433,7 @@ func TestCmdSeek(t *testing.T) {
 
 func TestCmdNext(t *testing.T) {
 	// ---------- Start of boilerplate code
+	ctx := context.Background()
 	db, err := bolt.Open("in-memory", 0600, &bolt.Options{MemOnly: true})
 	if err != nil {
 		t.Errorf("Could not create database: %v", err)
@@ -501,7 +512,7 @@ func TestCmdNext(t *testing.T) {
 	}
 	// By now we constructed all input requests, now we call the
 	// Server to process them all
-	if err = Server(db, &inBuf, &outBuf, closer); err != nil {
+	if err = Server(ctx, db, &inBuf, &outBuf, closer); err != nil {
 		t.Errorf("Error while calling Server: %v", err)
 	}
 	// And then we interpret the results
@@ -569,6 +580,7 @@ func TestCmdNext(t *testing.T) {
 
 func TestCmdFirst(t *testing.T) {
 	// ---------- Start of boilerplate code
+	ctx := context.Background()
 	db, err := bolt.Open("in-memory", 0600, &bolt.Options{MemOnly: true})
 	if err != nil {
 		t.Errorf("Could not create database: %v", err)
@@ -648,7 +660,7 @@ func TestCmdFirst(t *testing.T) {
 	}
 	// By now we constructed all input requests, now we call the
 	// Server to process them all
-	if err = Server(db, &inBuf, &outBuf, closer); err != nil {
+	if err = Server(ctx, db, &inBuf, &outBuf, closer); err != nil {
 		t.Errorf("Error while calling Server: %v", err)
 	}
 	// And then we interpret the results

--- a/ethdb/remote/bolt_remote_test.go
+++ b/ethdb/remote/bolt_remote_test.go
@@ -100,7 +100,7 @@ func TestCmdBeginEndLastError(t *testing.T) {
 	if err = encoder.Encode(&txHandle); err != nil {
 		t.Errorf("Could not encode txHandle: %v", err)
 	}
-	// CmdLastError to retrive the error related to the CmdEndTx with the wrong handle
+	// CmdLastError to retrieve the error related to the CmdEndTx with the wrong handle
 	c = CmdLastError
 	if err = encoder.Encode(&c); err != nil {
 		t.Errorf("Could not encode CmdLastError: %v", err)
@@ -126,17 +126,17 @@ func TestCmdBeginEndLastError(t *testing.T) {
 	}
 	// And then we interpret the results
 	if err = decoder.Decode(&txHandle); err != nil {
-		t.Errorf("Could not decode response from CmdBeginTx")
+		t.Errorf("Could not decode response from CmdBeginTx, %v", err)
 	}
 	var lastErrorStr string
 	if err = decoder.Decode(&lastErrorStr); err != nil {
-		t.Errorf("Could not decode response from CmdLastError")
+		t.Errorf("Could not decode response from CmdLastError, %v", err)
 	}
 	if lastErrorStr != "transaction not found" {
 		t.Errorf("Wrong error message from CmdLastError: %s", lastErrorStr)
 	}
 	if err = decoder.Decode(&lastErrorStr); err != nil {
-		t.Errorf("Could not decode response from CmdLastError")
+		t.Errorf("Could not decode response from CmdLastError, %v", err)
 	}
 	if lastErrorStr != "<nil>" {
 		t.Errorf("Wrong error message from CmdLastError: %s", lastErrorStr)
@@ -188,14 +188,14 @@ func TestCmdBucket(t *testing.T) {
 	}
 	// And then we interpret the results
 	if err = decoder.Decode(&txHandle); err != nil {
-		t.Errorf("Could not decode response from CmdBegin")
+		t.Errorf("Could not decode response from CmdBegin, %v", err)
 	}
 	if txHandle != 1 {
 		t.Errorf("Unexpected txHandle: %d", txHandle)
 	}
 	var bucketHandle uint64
 	if err = decoder.Decode(&bucketHandle); err != nil {
-		t.Errorf("Could not decode response from CmdBucket")
+		t.Errorf("Could not decode response from CmdBucket, %v", err)
 	}
 	if bucketHandle != 2 {
 		t.Errorf("Unexpected bucketHandle: %d", bucketHandle)
@@ -282,14 +282,14 @@ func TestCmdGet(t *testing.T) {
 	// And then we interpret the results
 	// Results of CmdBeginTx
 	if err = decoder.Decode(&txHandle); err != nil {
-		t.Errorf("Could not decode response from CmdBegin")
+		t.Errorf("Could not decode response from CmdBegin, %v", err)
 	}
 	if txHandle != 1 {
 		t.Errorf("Unexpected txHandle: %d", txHandle)
 	}
 	// Results of CmdBucket
 	if err = decoder.Decode(&bucketHandle); err != nil {
-		t.Errorf("Could not decode response from CmdBucket")
+		t.Errorf("Could not decode response from CmdBucket, %v", err)
 	}
 	if bucketHandle != 2 {
 		t.Errorf("Unexpected bucketHandle: %d", bucketHandle)
@@ -386,14 +386,14 @@ func TestCmdSeek(t *testing.T) {
 	// And then we interpret the results
 	// Results of CmdBeginTx
 	if err = decoder.Decode(&txHandle); err != nil {
-		t.Errorf("Could not decode response from CmdBegin")
+		t.Errorf("Could not decode response from CmdBegin, %v", err)
 	}
 	if txHandle != 1 {
 		t.Errorf("Unexpected txHandle: %d", txHandle)
 	}
 	// Results of CmdBucket
 	if err = decoder.Decode(&bucketHandle); err != nil {
-		t.Errorf("Could not decode response from CmdBucket")
+		t.Errorf("Could not decode response from CmdBucket, %v", err)
 	}
 	if bucketHandle != 2 {
 		t.Errorf("Unexpected bucketHandle: %d", bucketHandle)
@@ -497,7 +497,7 @@ func TestCmdNext(t *testing.T) {
 	}
 	var numberOfKeys uint64 = 3 // Trying to get 3 keys, but will get 1 + nil
 	if err = encoder.Encode(&numberOfKeys); err != nil {
-		t.Errorf("Could not encode numberOfKeys for CmdNex: %v", err)
+		t.Errorf("Could not encode numberOfKeys for CmdCursorNext: %v", err)
 	}
 	// By now we constructed all input requests, now we call the
 	// Server to process them all
@@ -507,14 +507,14 @@ func TestCmdNext(t *testing.T) {
 	// And then we interpret the results
 	// Results of CmdBeginTx
 	if err = decoder.Decode(&txHandle); err != nil {
-		t.Errorf("Could not decode response from CmdBegin")
+		t.Errorf("Could not decode response from CmdBegin, %v", err)
 	}
 	if txHandle != 1 {
 		t.Errorf("Unexpected txHandle: %d", txHandle)
 	}
 	// Results of CmdBucket
 	if err = decoder.Decode(&bucketHandle); err != nil {
-		t.Errorf("Could not decode response from CmdBucket")
+		t.Errorf("Could not decode response from CmdBucket, %v", err)
 	}
 	if bucketHandle != 2 {
 		t.Errorf("Unexpected bucketHandle: %d", bucketHandle)

--- a/node/node.go
+++ b/node/node.go
@@ -17,6 +17,7 @@
 package node
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"net"
@@ -632,7 +633,12 @@ func (n *Node) OpenDatabase(name string) (ethdb.Database, error) {
 		return nil, err
 	}
 	if n.config.RemoteDbListenAddress != "" {
-		go remote.Listener(boltDb.DB(), n.config.RemoteDbListenAddress, nil)
+		ctx, cancel := context.WithCancel(context.Background())
+		go remote.Listener(ctx, boltDb.DB(), n.config.RemoteDbListenAddress)
+
+		// TODO: cancel context by OS signal. See: https://gist.github.com/prantoran/69d14842f0a350007ff35fbb540252d8#file-main-go
+		_ = cancel
+
 	}
 	return boltDb, nil
 }

--- a/node/service.go
+++ b/node/service.go
@@ -17,6 +17,7 @@
 package node
 
 import (
+	"context"
 	"reflect"
 
 	"github.com/ledgerwatch/turbo-geth/accounts"
@@ -63,7 +64,11 @@ func (ctx *ServiceContext) OpenDatabase(name string) (ethdb.Database, error) {
 		return nil, err
 	}
 	if ctx.config.RemoteDbListenAddress != "" {
-		go remote.Listener(boltDb.DB(), ctx.config.RemoteDbListenAddress, nil)
+		tcpCtx, cancel := context.WithCancel(context.Background())
+		go remote.Listener(tcpCtx, boltDb.DB(), ctx.config.RemoteDbListenAddress)
+
+		// TODO: call cancel when OS sent signal.
+		_ = cancel
 	}
 	return boltDb, nil
 	/*


### PR DESCRIPTION
### In PR: 
- #211 
- added context into `remote.NewDB`. Need to discuss - maybe move it out and check `<-ctx.Done()` in user's code (in for loop of `cursor.Next`). Because if we calling `remote.NewDB` from HTTP Handler - then we can't pass request ctx (it will close after current request finish) to `remote.NewDB` (we wan't reuse DB connection). 
- cancel context on interruption signal

### Performance: 
- `./cmd/state stateGrowth` with batch size 100K take 20min. Current implementation spend most of time in network read/write.
<img width="1437" alt="Screen Shot 2019-12-04 at 5 03 59 PM" src="https://user-images.githubusercontent.com/46885206/70133111-162c0a80-16b8-11ea-9824-5d14addc419f.png">
 



