### PR TITLE
return error from .First() and .Next() methods of RemoteDb

### DIFF
--- a/cmd/state/stateless/state.go
+++ b/cmd/state/stateless/state.go
@@ -131,6 +131,7 @@ func (r *Reporter) StateGrowth1(ctx context.Context) {
 	// For each timestamp, how many accounts were created in the state
 	creationsByBlock := make(map[uint64]int)
 	var addrHash common.Hash
+
 	// Go through the history of account first
 	if err := r.db.View(ctx, func(tx *remote.Tx) error {
 		b, err := tx.Bucket(dbutils.AccountsHistoryBucket)


### PR DESCRIPTION
Next implementation does break some static analysis of Goland:
<img width="790" alt="Screen Shot 2019-12-26 at 5 38 15 PM" src="https://user-images.githubusercontent.com/46885206/71474935-1d9e8980-2808-11ea-8233-a9fe98c27a8e.png">

If remove `err != nil` from loop definition - warning disapear. 
Must we think about it as about static analyzer bug? 
I reported issue here: https://youtrack.jetbrains.com/issue/GO-7976


# Another KV interfaces 

### TiKv 
```go
func scan(keyPrefix []byte, limit int) ([]KV, error) {
	tx, err := client.Begin(context.TODO())
	if err != nil {
		return nil, err
	}
	it, err := tx.Iter(context.TODO(), key.Key(keyPrefix), nil)
	if err != nil {
		return nil, err
	}
	defer it.Close()
	var ret []KV
	for it.Valid() && limit > 0 {
		ret = append(ret, KV{K: it.Key()[:], V: it.Value()[:]})
		limit--
		it.Next(context.TODO())
	}
	return ret, nil
}
```

### Cockroach KV
```go
        ri := kv.NewRangeIterator(sc.execCfg.DistSender)
	for ri.Seek(ctx, tableSpan.Key, kv.Ascending); ; ri.Next(ctx) {
		if !ri.Valid() {
			return ri.Error().GoError()
		}
        }
```


### Mongo 
```go
// Passing bson.D{{}} as the filter matches all documents in the collection
cur, err := collection.Find(context.TODO(), bson.D{{}}, findOptions)
if err != nil {
    log.Fatal(err)
}

// Finding multiple documents returns a cursor
// Iterating through the cursor allows us to decode documents one at a time
for cur.Next(context.TODO()) {
    
    // create a value into which the single document can be decoded
    var elem Trainer
    err := cur.Decode(&elem)
    if err != nil {
        log.Fatal(err)
    }

    results = append(results, &elem)
}

if err := cur.Err(); err != nil {
    log.Fatal(err)
}

// Close the cursor once finished
cur.Close(context.TODO())
```
### Mongo cursor options
```go
// CursorOptions are extra options that are required to construct a BatchCursor.
type CursorOptions struct {
	BatchSize      int32
	MaxTimeMS      int64
	Limit          int32
	CommandMonitor *event.CommandMonitor
	Crypt          *Crypt
}

```