### PR TITLE
State analytic less memory and checkpoints

### DIFF
--- a/cmd/state/commands/gas_limits.go
+++ b/cmd/state/commands/gas_limits.go
@@ -18,13 +18,13 @@ var gasLimitsCmd = &cobra.Command{
 	Short: "gasLimits",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		ctx := getContext()
-		reporter, err := stateless.NewReporter(ctx, remoteDbAddress)
+		db, err := connectRemoteDb(ctx, remoteDbAddress)
 		if err != nil {
 			return err
 		}
 
 		fmt.Println("Processing started...")
-		reporter.GasLimits(ctx)
+		stateless.NewGasLimitReporter(ctx, db).GasLimits(ctx)
 		return nil
 	},
 }

--- a/cmd/state/commands/root.go
+++ b/cmd/state/commands/root.go
@@ -12,9 +12,8 @@ import (
 	"syscall"
 
 	"github.com/ledgerwatch/turbo-geth/ethdb/remote"
-	"github.com/spf13/cobra"
-
 	"github.com/ledgerwatch/turbo-geth/log"
+	"github.com/spf13/cobra"
 )
 
 var (

--- a/cmd/state/commands/root.go
+++ b/cmd/state/commands/root.go
@@ -4,12 +4,14 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"net"
 	"os"
 	"os/signal"
 	"runtime"
 	"runtime/pprof"
 	"syscall"
 
+	"github.com/ledgerwatch/turbo-geth/ethdb/remote"
 	"github.com/spf13/cobra"
 
 	"github.com/ledgerwatch/turbo-geth/log"
@@ -43,6 +45,19 @@ func getContext() context.Context {
 		cancel()
 	}()
 	return ctx
+}
+
+func connectRemoteDb(ctx context.Context, remoteDbAddress string) (*remote.DB, error) {
+	dial := func(ctx context.Context) (in io.Reader, out io.Writer, closer io.Closer, err error) {
+		dialer := net.Dialer{}
+		conn, err := dialer.DialContext(ctx, "tcp", remoteDbAddress)
+		if err != nil {
+			return nil, nil, nil, fmt.Errorf("could not connect to remoteDb. addr: %s. err: %w", remoteDbAddress, err)
+		}
+		return conn, conn, conn, err
+	}
+
+	return remote.NewDB(ctx, dial)
 }
 
 var rootCmd = &cobra.Command{

--- a/cmd/state/commands/state_growth.go
+++ b/cmd/state/commands/state_growth.go
@@ -13,14 +13,14 @@ func init() {
 		Short: "stateGrowth",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := getContext()
-			reporter, err := stateless.NewReporter(ctx, remoteDbAddress)
+			db, err := connectRemoteDb(ctx, remoteDbAddress)
 			if err != nil {
 				return err
 			}
 
 			fmt.Println("Processing started...")
-			reporter.StateGrowth1(ctx)
-			reporter.StateGrowth2(ctx)
+			stateless.NewStateGrowth1Reporter(ctx, db).StateGrowth1(ctx)
+			stateless.NewStateGrowth2Reporter(ctx, db).StateGrowth2(ctx)
 			return nil
 		},
 	}

--- a/cmd/state/stateless/state.go
+++ b/cmd/state/stateless/state.go
@@ -48,7 +48,7 @@ const (
 	PrintMemStatsEvery = 1 * 1000 * 1000
 	PrintProgressEvery = 100 * 1000
 	SaveSnapshotEvery  = 1 * 1000 * 1000
-	MaxIterationsPerTx = 1 * 1000 * 1000
+	MaxIterationsPerTx = 10 * 1000 * 1000
 	CursorBatchSize    = 10 * 1000
 )
 

--- a/cmd/state/stateless/state.go
+++ b/cmd/state/stateless/state.go
@@ -1781,7 +1781,7 @@ func dustEOA() {
 		idx++
 	}
 	sort.Sort(tsi)
-	fmt.Printf("Writing dataset...")
+	fmt.Printf("Writing dataset...\n")
 	f, err := os.Create("dust_eoa.csv")
 	check(err)
 	defer f.Close()

--- a/cmd/state/stateless/state.go
+++ b/cmd/state/stateless/state.go
@@ -133,9 +133,8 @@ func NewReporter(ctx context.Context, remoteDbAddress string) (*Reporter, error)
 // Each day has it's own partition
 // It means that you can only continue execution of report from last snapshot.Save() checkpoint - read buckets forward from last key
 // But not re-read bucket
-func file(prefix string, version string) string {
-	y, m, d := time.Now().Date()
-	return path.Join(dir(), fmt.Sprintf("%s_%d%d%d_v%d.cbor", prefix, y, m, d, version))
+func file(prefix string, version int) string {
+	return path.Join(dir(), fmt.Sprintf("%s_%s_v%d.cbor", prefix, time.Now().Format("2006-01-28"), version))
 }
 
 func dir() string {
@@ -192,7 +191,7 @@ type StateGrowth1Snapshot struct {
 	CreationsByBlock map[uint64]int         // For each timestamp, how many accounts were created in the state
 }
 
-var StateGrowth1SnapshotFile = file("StateGrowth1", "1")
+var StateGrowth1SnapshotFile = file("StateGrowth1", 1)
 
 func (s *StateGrowth1Snapshot) Restore() {
 	restore(StateGrowth1SnapshotFile, s)
@@ -229,7 +228,8 @@ func (r *Reporter) StateGrowth1(ctx context.Context) {
 		CreationsByBlock: make(map[uint64]int),       // For each timestamp, how many accounts were created in the state
 	}
 
-	//s.Restore()
+	s.Restore()
+	fmt.Println("Len:", s.LastTimestamps.Len())
 
 	var vIsEmpty bool
 	var err error

--- a/cmd/state/stateless/state.go
+++ b/cmd/state/stateless/state.go
@@ -47,7 +47,7 @@ var emptyCodeHash = crypto.Keccak256(nil)
 
 const PrintProgressEvery = 1 * 1000 * 1000
 const PrintMemStatsEvery = 10 * 1000 * 1000
-const SaveSnapshotEvery = 1 * 1000 * 1000
+const SaveSnapshotEvery = 10 * 1000 * 1000
 
 func check(e error) {
 	if e != nil {
@@ -134,7 +134,7 @@ func NewReporter(ctx context.Context, remoteDbAddress string) (*Reporter, error)
 // It means that you can only continue execution of report from last snapshot.Save() checkpoint - read buckets forward from last key
 // But not re-read bucket
 func file(prefix string, version int) string {
-	return path.Join(dir(), fmt.Sprintf("%s_%s_v%d.cbor", prefix, time.Now().Format("2006-01-28"), version))
+	return path.Join(dir(), fmt.Sprintf("%s_%s_v%d.cbor", prefix, time.Now().Format("2006-01-02"), version))
 }
 
 func dir() string {

--- a/cmd/state/stateless/state.go
+++ b/cmd/state/stateless/state.go
@@ -369,7 +369,7 @@ beginTx2:
 		idx++
 	}
 	sort.Sort(tsi)
-	fmt.Printf("Writing dataset...")
+	fmt.Printf("Writing dataset...\n")
 	f, err := os.Create("accounts_growth.csv")
 	check(err)
 	defer f.Close()

--- a/cmd/state/stateless/state.go
+++ b/cmd/state/stateless/state.go
@@ -210,7 +210,6 @@ func (r *StateGrowth1Reporter) StateGrowth1(ctx context.Context) {
 	var count int
 	var addrHash common.Hash
 	var processingDone bool
-	var a = make(map[string]struct{}, 10)
 
 beginTx:
 	// Go through the history of account first
@@ -238,11 +237,6 @@ beginTx:
 			}
 
 			copy(addrHash[:], k[:32]) // First 32 bytes is the hash of the address, then timestamp encoding
-			if _, ok := a[string(k)]; ok {
-				panic("repeated!")
-			} else {
-				a[string(k)] = struct{}{}
-			}
 			addr := string(addrHash.Bytes())
 			timestamp, _ := dbutils.DecodeTimestamp(k[32:])
 			if timestamp+1 > r.MaxTimestamp {

--- a/cmd/state/stateless/state.go
+++ b/cmd/state/stateless/state.go
@@ -548,7 +548,7 @@ beginTx2:
 				r.save(ctx)
 			}
 		}
-		processingDone = false
+		processingDone = true
 		return nil
 	}); err != nil {
 		panic(err)

--- a/cmd/state/stateless/state.go
+++ b/cmd/state/stateless/state.go
@@ -434,8 +434,8 @@ beginTx:
 			}
 
 			copy(addrHash[:], k[:32]) // First 20 bytes is the address
-			addr := string(addrHash.Bytes())
 			copy(hash[:], k[40:72])
+			addr := string(addrHash.Bytes())
 			timestamp, _ := dbutils.DecodeTimestamp(k[72:])
 			if timestamp+1 > r.MaxTimestamp {
 				r.MaxTimestamp = timestamp + 1

--- a/cmd/state/stateless/state.go
+++ b/cmd/state/stateless/state.go
@@ -434,8 +434,8 @@ beginTx:
 			}
 
 			copy(addrHash[:], k[:32]) // First 20 bytes is the address
-			copy(hash[:], k[40:72])
 			addr := string(addrHash.Bytes())
+			copy(hash[:], k[40:72])
 			timestamp, _ := dbutils.DecodeTimestamp(k[72:])
 			if timestamp+1 > r.MaxTimestamp {
 				r.MaxTimestamp = timestamp + 1

--- a/cmd/state/stateless/transaction_stats.go
+++ b/cmd/state/stateless/transaction_stats.go
@@ -24,15 +24,15 @@ type TxTracer struct {
 	gasForCREATE         uint64
 	gasForEthSendingCALL uint64
 	currentBlock         uint64
+	measureCurrentGas    uint64
+	measureCreate        bool
+	trace                bool
+	measureDepth         int
 	sinceAccounts        map[common.Address]uint64
 	sinceStorage         map[common.Address]map[common.Hash]uint64
 	created              map[common.Address]struct{}
 	lastAccessedAccounts map[common.Address]uint64
 	lastAccessedStorage  map[common.Address]map[common.Hash]uint64
-	measureCreate        bool
-	measureDepth         int
-	measureCurrentGas    uint64
-	trace                bool
 }
 
 func NewTxTracer() *TxTracer {

--- a/cmd/state/stateless/transaction_stats.go
+++ b/cmd/state/stateless/transaction_stats.go
@@ -24,15 +24,15 @@ type TxTracer struct {
 	gasForCREATE         uint64
 	gasForEthSendingCALL uint64
 	currentBlock         uint64
-	measureCurrentGas    uint64
-	measureCreate        bool
-	trace                bool
-	measureDepth         int
 	sinceAccounts        map[common.Address]uint64
 	sinceStorage         map[common.Address]map[common.Hash]uint64
 	created              map[common.Address]struct{}
 	lastAccessedAccounts map[common.Address]uint64
 	lastAccessedStorage  map[common.Address]map[common.Hash]uint64
+	measureCreate        bool
+	measureDepth         int
+	measureCurrentGas    uint64
+	trace                bool
 }
 
 func NewTxTracer() *TxTracer {

--- a/common/typedtree/radix.go
+++ b/common/typedtree/radix.go
@@ -19,6 +19,10 @@ func NewRadixMapHash2Uint64() *RadixMapHash2Uint64 {
 	}
 }
 
+func (t *RadixMapHash2Uint64) Len() int {
+	return t.tree.Len()
+}
+
 func (t *RadixMapHash2Uint64) Get(k string) (map[common.Hash]uint64, bool) {
 	v, ok := t.tree.Get(k)
 	if !ok {
@@ -77,6 +81,10 @@ func NewRadixMapUint642Int() *RadixMapUint642Int {
 	}
 }
 
+func (t *RadixMapUint642Int) Len() int {
+	return t.tree.Len()
+}
+
 func (t *RadixMapUint642Int) Get(k string) (map[uint64]int, bool) {
 	v, ok := t.tree.Get(k)
 	if !ok {
@@ -127,11 +135,15 @@ type RadixUint64 struct {
 	tree    *radix.Tree
 }
 
-func NewUint64() *RadixUint64 {
+func NewRadixUint64() *RadixUint64 {
 	return &RadixUint64{
 		version: "1",
 		tree:    radix.New(),
 	}
+}
+
+func (t *RadixUint64) Len() int {
+	return t.tree.Len()
 }
 
 func (t *RadixUint64) Get(k string) (uint64, bool) {

--- a/common/typedtree/radix.go
+++ b/common/typedtree/radix.go
@@ -1,0 +1,181 @@
+package typedtree
+
+import (
+	"github.com/armon/go-radix"
+	"github.com/ledgerwatch/turbo-geth/common"
+	"github.com/ugorji/go/codec"
+)
+
+// string -> map[common.Hash]uint64
+type RadixMapHash2Uint64 struct {
+	version string
+	tree    *radix.Tree
+}
+
+func NewRadixMapHash2Uint64() *RadixMapHash2Uint64 {
+	return &RadixMapHash2Uint64{
+		version: "1",
+		tree:    radix.New(),
+	}
+}
+
+func (t *RadixMapHash2Uint64) Get(k string) (map[common.Hash]uint64, bool) {
+	v, ok := t.tree.Get(k)
+	if !ok {
+		return nil, false
+	}
+	return v.(map[common.Hash]uint64), true
+}
+
+func (t *RadixMapHash2Uint64) Set(k string, v map[common.Hash]uint64) {
+	t.tree.Insert(k, v)
+}
+
+func (t *RadixMapHash2Uint64) Walk(f func(string, map[common.Hash]uint64) bool) {
+	t.tree.Walk(func(k string, v interface{}) bool {
+		return f(k, v.(map[common.Hash]uint64))
+	})
+}
+
+func (t *RadixMapHash2Uint64) CodecEncodeSelf(e *codec.Encoder) {
+	e.MustEncode(t.version)
+	e.MustEncode(t.tree.Len())
+	t.tree.Walk(func(k string, v interface{}) bool {
+		e.MustEncode(&k)
+		e.MustEncode(&v)
+		return false
+	})
+}
+
+func (t *RadixMapHash2Uint64) CodecDecodeSelf(d *codec.Decoder) {
+	var version string
+	d.MustDecode(&version)
+	if version != t.version {
+		panic("unexpected version")
+	}
+	var amount int
+	d.MustDecode(&amount)
+	var k string
+	var v map[common.Hash]uint64
+	for i := 0; i < amount; i++ {
+		d.MustDecode(&k)
+		d.MustDecode(&v)
+		t.tree.Insert(k, v)
+	}
+}
+
+// string ->  map[uint64]int
+type RadixMapUint642Int struct {
+	version string
+	tree    *radix.Tree
+}
+
+func NewRadixMapUint642Int() *RadixMapUint642Int {
+	return &RadixMapUint642Int{
+		version: "1",
+		tree:    radix.New(),
+	}
+}
+
+func (t *RadixMapUint642Int) Get(k string) (map[uint64]int, bool) {
+	v, ok := t.tree.Get(k)
+	if !ok {
+		return nil, false
+	}
+	return v.(map[uint64]int), true
+}
+
+func (t *RadixMapUint642Int) Set(k string, v map[uint64]int) {
+	t.tree.Insert(k, v)
+}
+func (t *RadixMapUint642Int) Walk(f func(string, map[uint64]int) bool) {
+	t.tree.Walk(func(k string, v interface{}) bool {
+		return f(k, v.(map[uint64]int))
+	})
+}
+
+func (t *RadixMapUint642Int) CodecEncodeSelf(e *codec.Encoder) {
+	e.MustEncode(t.version)
+	e.MustEncode(t.tree.Len())
+	t.tree.Walk(func(k string, v interface{}) bool {
+		e.MustEncode(&k)
+		e.MustEncode(&v)
+		return false
+	})
+}
+
+func (t *RadixMapUint642Int) CodecDecodeSelf(d *codec.Decoder) {
+	var version string
+	d.MustDecode(&version)
+	if version != t.version {
+		panic("unexpected version")
+	}
+	var amount int
+	d.MustDecode(&amount)
+	var k string
+	var v map[uint64]int
+	for i := 0; i < amount; i++ {
+		d.MustDecode(&k)
+		d.MustDecode(&v)
+		t.tree.Insert(k, v)
+	}
+}
+
+// string -> uint64
+type RadixUint64 struct {
+	version string
+	tree    *radix.Tree
+}
+
+func NewUint64() *RadixUint64 {
+	return &RadixUint64{
+		version: "1",
+		tree:    radix.New(),
+	}
+}
+
+func (t *RadixUint64) Get(k string) (uint64, bool) {
+	v, ok := t.tree.Get(k)
+	if !ok {
+		return 0, false
+	}
+	return v.(uint64), true
+}
+
+func (t *RadixUint64) Set(k string, v uint64) {
+	t.tree.Insert(k, v)
+}
+
+func (t *RadixUint64) Walk(f func(string, uint64) bool) {
+	t.tree.Walk(func(k string, v interface{}) bool {
+		return f(k, v.(uint64))
+	})
+}
+
+func (t *RadixUint64) CodecEncodeSelf(e *codec.Encoder) {
+	e.MustEncode(t.version)
+	e.MustEncode(t.tree.Len())
+	t.tree.Walk(func(k string, v interface{}) bool {
+		e.MustEncode(&k)
+		e.MustEncode(&v)
+		return false
+	})
+}
+
+func (t *RadixUint64) CodecDecodeSelf(d *codec.Decoder) {
+	var version string
+	d.MustDecode(&version)
+	if version != t.version {
+		panic("unexpected version")
+	}
+
+	var amount int
+	d.MustDecode(&amount)
+	var k string
+	var v uint64
+	for i := 0; i < amount; i++ {
+		d.MustDecode(&k)
+		d.MustDecode(&v)
+		t.tree.Insert(k, v)
+	}
+}

--- a/common/typedtree/radix.go
+++ b/common/typedtree/radix.go
@@ -25,10 +25,10 @@ func (t *RadixMapHash2Uint64) Len() int {
 
 func (t *RadixMapHash2Uint64) Get(k string) (map[common.Hash]uint64, bool) {
 	v, ok := t.tree.Get(k)
-	if !ok {
-		return nil, false
+	if ok {
+		return v.(map[common.Hash]uint64), ok
 	}
-	return v.(map[common.Hash]uint64), true
+	return nil, ok
 }
 
 func (t *RadixMapHash2Uint64) Set(k string, v map[common.Hash]uint64) {
@@ -59,9 +59,9 @@ func (t *RadixMapHash2Uint64) CodecDecodeSelf(d *codec.Decoder) {
 	}
 	var amount int
 	d.MustDecode(&amount)
-	var k string
-	var v map[common.Hash]uint64
 	for i := 0; i < amount; i++ {
+		var k string
+		var v map[common.Hash]uint64
 		d.MustDecode(&k)
 		d.MustDecode(&v)
 		t.tree.Insert(k, v)
@@ -87,10 +87,10 @@ func (t *RadixMapUint642Int) Len() int {
 
 func (t *RadixMapUint642Int) Get(k string) (map[uint64]int, bool) {
 	v, ok := t.tree.Get(k)
-	if !ok {
-		return nil, false
+	if ok {
+		return v.(map[uint64]int), ok
 	}
-	return v.(map[uint64]int), true
+	return nil, ok
 }
 
 func (t *RadixMapUint642Int) Set(k string, v map[uint64]int) {
@@ -120,9 +120,9 @@ func (t *RadixMapUint642Int) CodecDecodeSelf(d *codec.Decoder) {
 	}
 	var amount int
 	d.MustDecode(&amount)
-	var k string
-	var v map[uint64]int
 	for i := 0; i < amount; i++ {
+		var k string
+		var v map[uint64]int
 		d.MustDecode(&k)
 		d.MustDecode(&v)
 		t.tree.Insert(k, v)
@@ -148,10 +148,10 @@ func (t *RadixUint64) Len() int {
 
 func (t *RadixUint64) Get(k string) (uint64, bool) {
 	v, ok := t.tree.Get(k)
-	if !ok {
-		return 0, false
+	if ok {
+		return v.(uint64), ok
 	}
-	return v.(uint64), true
+	return 0, ok
 }
 
 func (t *RadixUint64) Set(k string, v uint64) {
@@ -183,9 +183,9 @@ func (t *RadixUint64) CodecDecodeSelf(d *codec.Decoder) {
 
 	var amount int
 	d.MustDecode(&amount)
-	var k string
-	var v uint64
 	for i := 0; i < amount; i++ {
+		var k string
+		var v uint64
 		d.MustDecode(&k)
 		d.MustDecode(&v)
 		t.tree.Insert(k, v)

--- a/ethdb/remote/bolt_remote.go
+++ b/ethdb/remote/bolt_remote.go
@@ -99,7 +99,7 @@ const (
 const DefaultCursorBatchSize uint64 = 1
 const CursorMaxBatchSize uint64 = 1 * 1000 * 1000
 const ServerMaxConnections uint64 = 2048
-const ClientMaxConnections uint64 = 32
+const ClientMaxConnections uint64 = 128
 
 // tracing enable by evn GODEBUG=remotedb.debug=1
 var tracing bool
@@ -1199,7 +1199,6 @@ func (c *Cursor) First() (key []byte, value []byte, err error) {
 
 	k, v := c.cacheKeys[c.cacheIdx], c.cacheValues[c.cacheIdx]
 	c.cacheIdx++
-
 	return k, v, nil
 
 }

--- a/ethdb/remote/bolt_remote.go
+++ b/ethdb/remote/bolt_remote.go
@@ -99,7 +99,7 @@ const (
 const DefaultCursorBatchSize uint64 = 1
 const CursorMaxBatchSize uint64 = 1 * 1000 * 1000
 const ServerMaxConnections uint64 = 2048
-const ClientMaxConnections uint64 = 128
+const ClientMaxConnections uint64 = 32
 
 // tracing enable by evn GODEBUG=remotedb.debug=1
 var tracing bool
@@ -123,6 +123,7 @@ func newDecoder(r io.Reader) *codec.Decoder {
 	default:
 		{
 			var handle codec.CborHandle
+			handle.ReaderBufferSize = 64 * 1024
 			d = codec.NewDecoder(r, &handle)
 		}
 	}
@@ -148,6 +149,7 @@ func newEncoder(w io.Writer) *codec.Encoder {
 	default:
 		{
 			var handle codec.CborHandle
+			handle.WriterBufferSize = 64 * 1024
 			e = codec.NewEncoder(w, &handle)
 		}
 	}

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/StackExchange/wmi v0.0.0-20190523213315-cbe66965904d // indirect
 	github.com/VictoriaMetrics/fastcache v1.5.4
 	github.com/aristanetworks/goarista v0.0.0-20170210015632-ea17b1a17847
+	github.com/armon/go-radix v1.0.0
 	github.com/blend/go-sdk v2.0.0+incompatible // indirect
 	github.com/btcsuite/btcd v0.0.0-20171128150713-2e60448ffcc6
 	github.com/cespare/cp v0.1.0

--- a/go.sum
+++ b/go.sum
@@ -37,6 +37,8 @@ github.com/allegro/bigcache v1.2.1-0.20190218064605-e24eb225f156/go.mod h1:Cb/ax
 github.com/aristanetworks/goarista v0.0.0-20170210015632-ea17b1a17847 h1:rtI0fD4oG/8eVokGVPYJEW1F88p1ZNgXiEIs9thEE4A=
 github.com/aristanetworks/goarista v0.0.0-20170210015632-ea17b1a17847/go.mod h1:D/tb0zPVXnP7fmsLZjtdUhSsumbK/ij54UXjjVgMGxQ=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
+github.com/armon/go-radix v1.0.0 h1:F4z6KzEeeQIMeLFa97iZU6vupzoecKdU5TX24SNppXI=
+github.com/armon/go-radix v1.0.0/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
 github.com/blend/go-sdk v2.0.0+incompatible h1:FL9X/of4ZYO5D2JJNI4vHrbXPfuSDbUa7h8JP9+E92w=


### PR DESCRIPTION
### Problems: 
- Analytics client eating too much memory (store buckets data in maps)
- Analytics server eating too much memory (long read transaction holding Bolt pages from GC)
- Analytic steps taking a long time, but can't interrupt it and then continue from last position

### What's done:
- use radix tree to reduce memory usage of analytics client
- add .FirstKey() and .NextKey() methods which don't transfer values by network
- `save/restore` of analytics progress - can start from last saved position (by cbor serialization of whole analytic state to file)
- snapshot file name has YY-MM-DD - it means everyday analytics will run from scratch (but I don't clean up old files). 

### Not implemented yet: 
- Need somehow rollback server read transaction (to avoid server memory growth) 
