### PR TITLE
stateless: flush the partial witnesses DB for every saved witness

### DIFF
--- a/cmd/state/stateless/stateless.go
+++ b/cmd/state/stateless/stateless.go
@@ -268,9 +268,8 @@ func Stateless(
 			check(err)
 			fmt.Printf("witnesses will be stored to a db at path: %s\n\tstats: %s\n", witnessDatabasePath, statsFilePath)
 			defer func() {
-				err := witnessDBWriter.Flush()
-				if err != nil {
-					fmt.Printf("error while flushing the witness db: %v", err)
+				if flushErr := witnessDBWriter.Flush(); flushErr != nil {
+					fmt.Printf("error while flushing the witness db: %v", flushErr)
 				}
 			}()
 		}

--- a/cmd/state/stateless/stateless.go
+++ b/cmd/state/stateless/stateless.go
@@ -267,11 +267,6 @@ func Stateless(
 			witnessDBWriter, err = NewWitnessDBWriter(db, statsFileCsv)
 			check(err)
 			fmt.Printf("witnesses will be stored to a db at path: %s\n\tstats: %s\n", witnessDatabasePath, statsFilePath)
-			defer func() {
-				if flushErr := witnessDBWriter.Flush(); flushErr != nil {
-					fmt.Printf("error while flushing the witness db: %v", flushErr)
-				}
-			}()
 		}
 
 	}

--- a/cmd/state/stateless/stateless.go
+++ b/cmd/state/stateless/stateless.go
@@ -267,6 +267,12 @@ func Stateless(
 			witnessDBWriter, err = NewWitnessDBWriter(db, statsFileCsv)
 			check(err)
 			fmt.Printf("witnesses will be stored to a db at path: %s\n\tstats: %s\n", witnessDatabasePath, statsFilePath)
+			defer func() {
+				err := witnessDBWriter.Flush()
+				if err != nil {
+					fmt.Printf("error while flushing the witness db: %v", err)
+				}
+			}()
 		}
 
 	}


### PR DESCRIPTION
fixes a out of memory issue when running `state stateless` and storing resolution witnesses to the DB