### PR TITLE
Fix erroneous incarnation for accounts created and called in the same…

### DIFF
--- a/core/state/intra_block_state.go
+++ b/core/state/intra_block_state.go
@@ -862,6 +862,7 @@ func updateAccount(ctx context.Context, stateWriter StateWriter, addr common.Add
 			if err := stateWriter.CreateContract(addr); err != nil {
 				return err
 			}
+			stateObject.created = false
 		}
 	}
 	return nil


### PR DESCRIPTION
… block (e.g. 0x2c785fa15498fe27f1fc5f809bcd9c10c9481752)