### PR TITLE
Naive implementation of MGR P2P SubProtocol

### DIFF
--- a/cmd/hack/hack.go
+++ b/cmd/hack/hack.go
@@ -400,6 +400,22 @@ func bucketStats(chaindata string) {
 	})
 }
 
+func bucketPrefixStats(chaindata string) {
+	db, err := bolt.Open(chaindata, 0600, &bolt.Options{ReadOnly: true})
+	check(err)
+	stats := map[uint8]uint64{}
+	db.View(func(tx *bolt.Tx) error {
+		c := tx.Bucket(dbutils.StorageBucket).Cursor()
+		for k, v := c.First(); k != nil; k, v = c.Next() {
+			stats[k[0]] = stats[k[0]] + uint64(len(v))
+		}
+		return nil
+	})
+	for k, v := range stats {
+		fmt.Printf("%x %dKb\n", k, v)
+	}
+}
+
 func readTrieLog() ([]float64, map[int][]float64, []float64) {
 	data, err := ioutil.ReadFile("dust/hack.log")
 	check(err)
@@ -1662,6 +1678,9 @@ func main() {
 	//defer db.Close()
 	if *action == "bucketStats" {
 		bucketStats(*chaindata)
+	}
+	if *action == "bucketPrefixStats" {
+		bucketPrefixStats(*chaindata)
 	}
 	if *action == "syncChart" {
 		mychart()

--- a/cmd/hack/hack.go
+++ b/cmd/hack/hack.go
@@ -407,7 +407,7 @@ func bucketPrefixStats(chaindata string) {
 	db.View(func(tx *bolt.Tx) error {
 		c := tx.Bucket(dbutils.StorageBucket).Cursor()
 		for k, v := c.First(); k != nil; k, v = c.Next() {
-			stats[k[0]] = stats[k[0]] + uint64(len(v))
+			stats[k[0]] += uint64(len(v))
 		}
 		return nil
 	})

--- a/cmd/state/commands/stateless.go
+++ b/cmd/state/commands/stateless.go
@@ -54,8 +54,10 @@ var statelessCmd = &cobra.Command{
 		createDb := func(path string) (ethdb.Database, error) {
 			return ethdb.NewBoltDatabase(path)
 		}
+		ctx := getContext()
 
 		stateless.Stateless(
+			ctx,
 			block,
 			chaindata,
 			statefile,

--- a/cmd/state/stateless/stateless.go
+++ b/cmd/state/stateless/stateless.go
@@ -309,7 +309,7 @@ func Stateless(
 		execTime1 := time.Since(execStart)
 		execStart = time.Now()
 
-		ctx := chainConfig.WithEIPsFlags(context.Background(), header.Number)
+		ctx := chainConfig.WithEIPsFlags(ctx, header.Number)
 		if err := statedb.FinalizeTx(ctx, tds.TrieStateWriter()); err != nil {
 			fmt.Printf("FinalizeTx of block %d failed: %v\n", blockNum, err)
 			return

--- a/cmd/state/stateless/stateless.go
+++ b/cmd/state/stateless/stateless.go
@@ -132,6 +132,7 @@ func starkData(witness *trie.Witness, starkStatsBase string, blockNum uint64) er
 type CreateDbFunc func(string) (ethdb.Database, error)
 
 func Stateless(
+	ctx context.Context,
 	blockNum uint64,
 	chaindata string,
 	statefile string,
@@ -265,6 +266,12 @@ func Stateless(
 	}
 
 	for !interrupt {
+		select {
+		case <-ctx.Done():
+			panic(ctx.Err())
+		default:
+		}
+
 		trace := blockNum == 50492 // false // blockNum == 545080
 		tds.SetResolveReads(blockNum >= witnessThreshold)
 		block := bcb.GetBlockByNumber(blockNum)
@@ -350,6 +357,7 @@ func Stateless(
 		finalRootFail := false
 		execStart = time.Now()
 		if blockNum >= witnessThreshold && blockWitness != nil { // blockWitness == nil means the extraction fails
+
 			var s *state.Stateless
 			var w *trie.Witness
 			w, err = trie.NewWitnessFromReader(bytes.NewReader(blockWitness), false)
@@ -466,7 +474,7 @@ func Stateless(
 		blockNum++
 		processed++
 
-		if blockNum%10 == 0 {
+		if blockNum%1000 == 0 {
 			// overwrite terminal line, if no snapshot was made and not the first line
 			if blockNum > 0 && !willSnapshot {
 				fmt.Printf("\r")

--- a/cmd/tester/block_generator.go
+++ b/cmd/tester/block_generator.go
@@ -15,13 +15,10 @@ import (
 	"github.com/ledgerwatch/turbo-geth/accounts/abi/bind"
 	"github.com/ledgerwatch/turbo-geth/cmd/tester/contracts"
 	"github.com/ledgerwatch/turbo-geth/common"
-	"github.com/ledgerwatch/turbo-geth/consensus"
 	"github.com/ledgerwatch/turbo-geth/consensus/ethash"
 	"github.com/ledgerwatch/turbo-geth/core"
 	"github.com/ledgerwatch/turbo-geth/core/rawdb"
-	"github.com/ledgerwatch/turbo-geth/core/state"
 	"github.com/ledgerwatch/turbo-geth/core/types"
-	"github.com/ledgerwatch/turbo-geth/core/vm"
 	"github.com/ledgerwatch/turbo-geth/crypto"
 	"github.com/ledgerwatch/turbo-geth/ethdb"
 	"github.com/ledgerwatch/turbo-geth/log"
@@ -103,93 +100,6 @@ func randAddress(r *rand.Rand) common.Address {
 	binary.BigEndian.PutUint64(b[8:], r.Uint64())
 	binary.BigEndian.PutUint32(b[16:], r.Uint32())
 	return b
-}
-
-func generateBlock(
-	parent *types.Block,
-	extra []byte,
-	coinbase common.Address,
-	chainConfig *params.ChainConfig,
-	tds *state.TrieDbState,
-	height int,
-	nonce *uint64,
-	coinbaseKey *ecdsa.PrivateKey,
-	engine consensus.Engine,
-	txGen func(ctx context.Context, i int, nonce uint64, gp *core.GasPool, statedb *state.IntraBlockState) *types.Transaction,
-) (*types.Block, error) {
-	var err error
-	num := parent.Number()
-	tstamp := parent.Time() + 15
-	gasLimit := core.CalcGasLimit(parent, 200000, 8000000)
-	header := &types.Header{
-		ParentHash: parent.Hash(),
-		Number:     num.Add(num, common.Big1),
-		GasLimit:   gasLimit,
-		Extra:      extra,
-		Time:       tstamp,
-		Coinbase:   coinbase,
-		Difficulty: ethash.CalcDifficulty(chainConfig, tstamp, parent.Header()),
-	}
-	tds.SetBlockNr(parent.NumberU64())
-	statedb := state.New(tds)
-	// Add more transactions
-	signedTxs := []*types.Transaction{}
-	receipts := []*types.Receipt{}
-	usedGas := new(uint64)
-	tds.StartNewBuffer()
-
-	if height > 1 && gasLimit >= params.TxGas {
-		signer := types.MakeSigner(chainConfig, big.NewInt(int64(height)))
-		gp := new(core.GasPool).AddGas(header.GasLimit)
-		vmConfig := vm.Config{}
-
-		tx := txGen(context.TODO(), height, *nonce, gp, statedb)
-		signedTx, err1 := types.SignTx(tx, signer, coinbaseKey)
-		if err1 != nil {
-			return nil, fmt.Errorf("SignTx: %w", err1)
-		}
-
-		signedTxs = append(signedTxs, signedTx)
-		receipt, err2 := core.ApplyTransaction(chainConfig, nil, &coinbase, gp, statedb, tds.TrieStateWriter(), header, signedTx, usedGas, vmConfig)
-		if err2 != nil {
-			return nil, fmt.Errorf("ApplyTransaction: tx %x, height: %d, gasPool: %d, usedGas: %d, failed: %v", signedTx.Hash(), height, gp, *usedGas, err2)
-		}
-		if !chainConfig.IsByzantium(header.Number) {
-			tds.StartNewBuffer()
-		}
-		receipts = append(receipts, receipt)
-		*nonce++
-	}
-
-	if _, err = engine.FinalizeAndAssemble(chainConfig, header, statedb, signedTxs, []*types.Header{}, receipts); err != nil {
-		return nil, fmt.Errorf("FinalizeAndAssemble: %w", err)
-	}
-	ctx := chainConfig.WithEIPsFlags(context.Background(), header.Number)
-	if err = statedb.FinalizeTx(ctx, tds.TrieStateWriter()); err != nil {
-		return nil, fmt.Errorf("FinalizeTx: %w", err)
-	}
-
-	var roots []common.Hash
-	roots, err = tds.ComputeTrieRoots()
-	if err != nil {
-		return nil, fmt.Errorf("ComputeTrieRoots: %w", err)
-	}
-	if !chainConfig.IsByzantium(header.Number) {
-		for i, receipt := range receipts {
-			receipt.PostState = roots[i].Bytes()
-		}
-	}
-	header.Root = roots[len(roots)-1]
-	header.GasUsed = *usedGas
-
-	tds.SetBlockNr(uint64(height))
-	err = statedb.CommitBlock(ctx, tds.DbStateWriter())
-	if err != nil {
-		return nil, fmt.Errorf("CommitBlock: %w", err)
-	}
-	// Generate an empty block
-	block := types.NewBlock(header, signedTxs, []*types.Header{}, receipts)
-	return block, nil
 }
 
 type NoopBackend struct {
@@ -407,27 +317,30 @@ func NewBlockGenerator(ctx context.Context, outputFile string, initialHeight int
 	blocks := make(chan *types.Block, 10000)
 	go func() {
 		defer close(blocks)
-		height := initialHeight
 		parent := genesisBlock
-		i := 0
-		n := 10000
+		n := 1000
 		//if ReduceComplexity {
 		//	n = 1 // 1 block per transaction
 		//}
-		for height > 0 {
-			if height < n {
-				n = height
+		now := time.Now()
+		for height, stop := n, false; !stop; height += n {
+			if height > initialHeight {
+				n = initialHeight + n - height
+				stop = true
+				if n == 0 {
+					break
+				}
 			}
 
 			// Generate a batch of blocks, each properly signed
 			blocksSlice, _ := core.GenerateChain(ctx, genesis.Config, parent, engine, db, n, genBlock)
+			parent = blocksSlice[len(blocksSlice)-1]
 			for _, block := range blocksSlice {
 				blocks <- block
-				parent = block
 			}
-			height -= n
-			i++
-			log.Info(fmt.Sprintf("block gen %dK", i*n/1000))
+			if height%10000 == 0 {
+				log.Info(fmt.Sprintf("block gen %dK, %s", height/1000, time.Since(now)))
+			}
 		}
 	}()
 
@@ -472,18 +385,14 @@ func NewForkGenerator(ctx context.Context, base *BlockGenerator, outputFile stri
 	output := bufio.NewWriterSize(outputF, 128*1024)
 	db := ethdb.NewMemDatabase()
 	genesis := genesis()
-
-	genesisBlock, _, tds, err := genesis.ToBlock(db)
-	if err != nil {
-		return nil, err
-	}
-	parent := genesisBlock
+	genesisBlock := genesis.MustCommit(db)
 	extra := []byte("BlockGenerator")
+	coinbaseKey := base.coinbaseKey
+	coinbase := crypto.PubkeyToAddress(coinbaseKey.PublicKey)
 	forkCoinbaseKey, err := crypto.HexToECDSA("048d914460c9b5feb28d79df9c89a44465b1c9c0fa97d4bda32ede37fc178b8d")
 	if err != nil {
 		return nil, err
 	}
-	coinbase := crypto.PubkeyToAddress(base.coinbaseKey.PublicKey)
 	forkCoinbase := crypto.PubkeyToAddress(forkCoinbaseKey.PublicKey)
 	var pos uint64
 	td := new(big.Int)
@@ -502,38 +411,101 @@ func NewForkGenerator(ctx context.Context, base *BlockGenerator, outputFile stri
 	amount := big.NewInt(1) // 1 wei
 	gasPrice := big.NewInt(10000000)
 	engine := ethash.NewFullFaker()
-	txGen := func(ctx context.Context, i int, nonce uint64, gp *core.GasPool, statedb *state.IntraBlockState) *types.Transaction {
-		var tx *types.Transaction
-		switch i {
-		default:
-			to := randAddress(r)
-			tx = types.NewTransaction(nonce, to, amount, params.TxGas, gasPrice, []byte{})
-		}
-		return tx
-	}
 
-	t := time.Now()
-	var nonce uint64 // nonce of the sender (coinbase)
-	for height := 1; height <= int(forkBase+forkHeight); height++ {
+	txOpts := bind.NewKeyedTransactor(coinbaseKey)
+	txOpts.GasPrice = gasPrice
+	txOpts.GasLimit = params.TxGas
+	txOpts.Nonce = big.NewInt(0)
+
+	//backend := &NoopBackend{db: db, genesis: genesis}
+	genBlock := func(i int, gen *core.BlockGen) {
 		select {
 		case <-ctx.Done():
-			return nil, ctx.Err()
+			panic(ctx.Err())
 		default:
 		}
 
-		if height >= int(forkBase) {
-			coinbase = forkCoinbase
+		gen.SetExtra(extra)
+		gen.SetCoinbase(coinbase)
+		if gen.GetHeader().GasLimit <= 15*params.TxGasContractCreation {
+			return
 		}
-		block, err1 := generateBlock(parent, extra, coinbase, genesis.Config, tds, height, &nonce, base.coinbaseKey, engine, txGen)
-		if err1 != nil {
-			return nil, err1
+		gen.SetNonce(types.EncodeNonce(txOpts.Nonce.Uint64()))
+		signer := types.MakeSigner(genesis.Config, txOpts.Nonce)
+		var tx *types.Transaction
+
+		txOpts.GasLimit = 3 * params.TxGasContractCreation
+		switch true {
+		default:
+			to := randAddress(r)
+			tx = types.NewTransaction(txOpts.Nonce.Uint64(), to, amount, params.TxGas, gasPrice, nil)
+			signedTx, err1 := types.SignTx(tx, signer, coinbaseKey)
+			if err1 != nil {
+				panic(err1)
+			}
+			gen.AddTx(signedTx)
 		}
-		buffer, err2 := rlp.EncodeToBytes(block)
-		if err2 != nil {
-			return nil, err2
+		txOpts.Nonce.Add(txOpts.Nonce, common.Big1)
+	}
+
+	blocks := make(chan *types.Block, 10000)
+	go func() {
+		defer close(blocks)
+		parent := genesisBlock
+		n := 1000
+		//if ReduceComplexity {
+		//	n = 1 // 1 block per transaction
+		//}
+		for height, stop := n, false; !stop; height += n {
+			if height > int(forkBase) {
+				n = int(forkBase) + n - height
+				stop = true
+				if n == 0 {
+					break
+				}
+			}
+
+			blocksSlice, _ := core.GenerateChain(ctx, genesis.Config, parent, engine, db, n, genBlock)
+			parent = blocksSlice[len(blocksSlice)-1]
+			for _, block := range blocksSlice {
+				blocks <- block
+			}
+			if height%10000 == 0 {
+				log.Info(fmt.Sprintf("fork gen %dK", (height+1)/1000))
+			}
 		}
-		if _, err3 := output.Write(buffer); err3 != nil {
-			return nil, err3
+
+		n = 1000
+		coinbase = forkCoinbase
+		for height, stop := n, false; !stop; height += n {
+			if height > int(forkHeight) {
+				n = int(forkHeight) + n - height
+				stop = true
+				if n == 0 {
+					break
+				}
+			}
+
+			// Generate a batch of blocks, each properly signed
+			blocksSlice, _ := core.GenerateChain(ctx, genesis.Config, parent, engine, db, n, genBlock)
+			parent = blocksSlice[len(blocksSlice)-1]
+			for _, block := range blocksSlice {
+				blocks <- block
+			}
+			if height%10000 == 0 {
+				log.Info(fmt.Sprintf("fork reorg gen %dK", (height+1)/1000))
+			}
+		}
+	}()
+
+	var parent *types.Block
+	for block := range blocks {
+		buffer, err4 := rlp.EncodeToBytes(block)
+		if err4 != nil {
+			return nil, err4
+		}
+		if _, err5 := output.Write(buffer); err5 != nil {
+			return nil, err5
 		}
 		header := block.Header()
 		hash := header.Hash()
@@ -545,11 +517,6 @@ func NewForkGenerator(ctx context.Context, base *BlockGenerator, outputFile stri
 		td = new(big.Int).Add(td, block.Difficulty())
 		bg.tdByNumber[block.NumberU64()] = td
 		parent = block
-
-		if height%10000 == 0 {
-			log.Info(fmt.Sprintf("fork gen %dK %ss", height/1000, time.Since(t)))
-			t = time.Now()
-		}
 	}
 	bg.lastBlock = parent
 	bg.totalDifficulty = td

--- a/cmd/tester/interfaces.go
+++ b/cmd/tester/interfaces.go
@@ -4,6 +4,7 @@ import (
 	"math/big"
 
 	"github.com/ledgerwatch/turbo-geth/common"
+	"github.com/ledgerwatch/turbo-geth/core/forkid"
 	"github.com/ledgerwatch/turbo-geth/core/types"
 )
 
@@ -16,4 +17,5 @@ type BlockFeeder interface {
 	GetTdByNumber(number uint64) *big.Int
 	TotalDifficulty() *big.Int
 	LastBlock() *types.Block
+	ForkID() forkid.ID
 }

--- a/cmd/tester/main.go
+++ b/cmd/tester/main.go
@@ -38,7 +38,6 @@ var (
 )
 
 func init() {
-	setupLogger()
 
 	// Initialize the CLI app and start Geth
 	app.Action = tester
@@ -121,6 +120,8 @@ func setupLogger() {
 }
 
 func tester(cliCtx *cli.Context) error {
+	setupLogger()
+
 	ctx := rootContext()
 	nodeToConnect, err := getTargetAddr(cliCtx)
 	if err != nil {
@@ -157,6 +158,7 @@ func tester(cliCtx *cli.Context) error {
 }
 
 func genesisCmd(cliCtx *cli.Context) error {
+	setupLogger()
 	res, err := json.Marshal(genesis())
 	if err != nil {
 		return err
@@ -169,6 +171,7 @@ func genesisCmd(cliCtx *cli.Context) error {
 }
 
 func mgrCmd(cliCtx *cli.Context) error {
+	setupLogger()
 	ctx := rootContext()
 	nodeToConnect, err := getTargetAddr(cliCtx)
 	if err != nil {

--- a/cmd/tester/main.go
+++ b/cmd/tester/main.go
@@ -145,6 +145,7 @@ func tester(cliCtx *cli.Context) error {
 	}
 	defer tp.forkFeeder.Close()
 	tp.protocolVersion = uint32(eth.ProtocolVersions[2])
+	tp.networkId = 1 // Mainnet
 	tp.genesisBlockHash = params.MainnetGenesisHash
 	server := makeP2PServer(ctx, tp, []string{eth.ProtocolName, eth.DebugName})
 	// Add protocol

--- a/cmd/tester/main.go
+++ b/cmd/tester/main.go
@@ -144,7 +144,7 @@ func tester(cliCtx *cli.Context) error {
 		panic(fmt.Sprintf("Failed to create fork generator: %v", err))
 	}
 	defer tp.forkFeeder.Close()
-	tp.protocolVersion = uint32(eth.ProtocolVersions[2])
+	tp.protocolVersion = uint32(eth.ProtocolVersions[1])
 	tp.networkId = 1 // Mainnet
 	tp.genesisBlockHash = params.MainnetGenesisHash
 	server := makeP2PServer(ctx, tp, []string{eth.ProtocolName, eth.DebugName})
@@ -207,8 +207,8 @@ func makeP2PServer(ctx context.Context, tp *TesterProtocol, protocols []string) 
 	pMap := map[string]p2p.Protocol{
 		eth.ProtocolName: {
 			Name:    eth.ProtocolName,
-			Version: eth.ProtocolVersions[2],
-			Length:  eth.ProtocolLengths[eth.ProtocolVersions[2]],
+			Version: eth.ProtocolVersions[1],
+			Length:  eth.ProtocolLengths[eth.ProtocolVersions[1]],
 			Run: func(peer *p2p.Peer, rw p2p.MsgReadWriter) error {
 				return tp.protocolRun(ctx, peer, rw)
 			},

--- a/cmd/tester/protocol.go
+++ b/cmd/tester/protocol.go
@@ -116,7 +116,7 @@ func (tp *TesterProtocol) mgrProtocolRun(ctx context.Context, peer *p2p.Peer, rw
 
 			i += len(res.Operators)
 			j++
-			fmt.Printf("Messages: %d, Operators: %dK\n", i/1000, j/1000)
+			fmt.Printf("Messages: %d, Operators: %d\n", i, j)
 		}
 	}
 }

--- a/cmd/tester/protocol.go
+++ b/cmd/tester/protocol.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/ledgerwatch/turbo-geth/common"
+	"github.com/ledgerwatch/turbo-geth/core/forkid"
 	"github.com/ledgerwatch/turbo-geth/core/types"
 	"github.com/ledgerwatch/turbo-geth/eth"
 	"github.com/ledgerwatch/turbo-geth/log"
@@ -23,6 +24,7 @@ type statusData struct {
 	TD              *big.Int
 	CurrentBlock    common.Hash
 	GenesisBlock    common.Hash
+	ForkID          forkid.ID
 }
 
 type TesterProtocol struct {
@@ -164,6 +166,7 @@ func (tp *TesterProtocol) protocolRun(ctx context.Context, peer *p2p.Peer, rw p2
 		TD:              tp.blockFeeder.TotalDifficulty(),
 		CurrentBlock:    tp.blockFeeder.LastBlock().Hash(),
 		GenesisBlock:    tp.genesisBlockHash,
+		ForkID:          tp.blockFeeder.ForkID(),
 	})
 	if err != nil {
 		return fmt.Errorf("failed to send status message to peer: %w", err)

--- a/cmd/tester/protocol.go
+++ b/cmd/tester/protocol.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -103,19 +102,13 @@ func (tp *TesterProtocol) mgrProtocolRun(ctx context.Context, peer *p2p.Peer, rw
 		}
 		switch msg.Code {
 		case eth.MGRWitness:
-			msgStream := rlp.NewStream(msg.Payload, uint64(msg.Size))
-			var marshaledWitness []byte
-			if err := msgStream.Decode(&marshaledWitness); err != nil {
-				return fmt.Errorf("msgStream.Decode: %w", err)
-			}
-
-			res, err := trie.NewWitnessFromReader(bytes.NewReader(marshaledWitness), false)
+			res, err := trie.NewWitnessFromReader(msg.Payload, false)
 			if err != nil {
 				panic(err)
 			}
 
-			i += len(res.Operators)
-			j++
+			i++
+			j += len(res.Operators)
 			fmt.Printf("Messages: %d, Operators: %d\n", i, j)
 		}
 	}

--- a/core/state/database.go
+++ b/core/state/database.go
@@ -1609,6 +1609,25 @@ func (tds *TrieDbState) ExtractWitness(trace bool, isBinary bool) (*trie.Witness
 	return tds.makeBlockWitness(trace, rs, isBinary)
 }
 
+// ExtractWitness produces block witness for the block just been processed, in a serialised form
+func (tds *TrieDbState) ExtractWitnessForPrefix(prefix []byte, trace bool, isBinary bool) (*trie.Witness, error) {
+	rs, codeMap := tds.resolveSetBuilder.Build(isBinary)
+
+	return tds.makeBlockWitnessForPrefix(prefix, trace, rs, codeMap, isBinary)
+}
+
+func (tds *TrieDbState) makeBlockWitnessForPrefix(prefix []byte, trace bool, rs *trie.ResolveSet, codeMap map[common.Hash][]byte, isBinary bool) (*trie.Witness, error) {
+	tds.tMu.Lock()
+	defer tds.tMu.Unlock()
+
+	t := tds.t
+	if isBinary {
+		t = trie.HexToBin(tds.t).Trie()
+	}
+
+	return t.ExtractWitnessForPrefix(prefix, tds.blockNr, trace, rs, codeMap)
+}
+
 func (tds *TrieDbState) makeBlockWitness(trace bool, rs *trie.ResolveSet, isBinary bool) (*trie.Witness, error) {
 	tds.tMu.Lock()
 	defer tds.tMu.Unlock()

--- a/core/state/database.go
+++ b/core/state/database.go
@@ -1611,12 +1611,12 @@ func (tds *TrieDbState) ExtractWitness(trace bool, isBinary bool) (*trie.Witness
 
 // ExtractWitness produces block witness for the block just been processed, in a serialised form
 func (tds *TrieDbState) ExtractWitnessForPrefix(prefix []byte, trace bool, isBinary bool) (*trie.Witness, error) {
-	rs, codeMap := tds.resolveSetBuilder.Build(isBinary)
+	rs := tds.resolveSetBuilder.Build(isBinary)
 
-	return tds.makeBlockWitnessForPrefix(prefix, trace, rs, codeMap, isBinary)
+	return tds.makeBlockWitnessForPrefix(prefix, trace, rs, isBinary)
 }
 
-func (tds *TrieDbState) makeBlockWitnessForPrefix(prefix []byte, trace bool, rs *trie.ResolveSet, codeMap map[common.Hash][]byte, isBinary bool) (*trie.Witness, error) {
+func (tds *TrieDbState) makeBlockWitnessForPrefix(prefix []byte, trace bool, rs *trie.ResolveSet, isBinary bool) (*trie.Witness, error) {
 	tds.tMu.Lock()
 	defer tds.tMu.Unlock()
 
@@ -1625,7 +1625,7 @@ func (tds *TrieDbState) makeBlockWitnessForPrefix(prefix []byte, trace bool, rs 
 		t = trie.HexToBin(tds.t).Trie()
 	}
 
-	return t.ExtractWitnessForPrefix(prefix, tds.blockNr, trace, rs, codeMap)
+	return t.ExtractWitnessForPrefix(prefix, tds.blockNr, trace, rs)
 }
 
 func (tds *TrieDbState) makeBlockWitness(trace bool, rs *trie.ResolveSet, isBinary bool) (*trie.Witness, error) {

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -578,6 +578,9 @@ func (s *Ethereum) Protocols() []p2p.Protocol {
 	// Debug
 	protos = append(protos, s.protocolManager.makeDebugProtocol())
 
+	// MGR
+	protos = append(protos, s.protocolManager.makeMgrProtocol())
+
 	if s.lesServer != nil {
 		protos = append(protos, s.lesServer.Protocols()...)
 	}

--- a/eth/handler.go
+++ b/eth/handler.go
@@ -1347,6 +1347,7 @@ func (pm *ProtocolManager) handleMgrMsg(p *mgrPeer) error {
 		if err != nil {
 			panic(err)
 		}
+		fmt.Printf("Received MGRStatus. len(knownPrefixes)=%d\n", len(knownPrefixes))
 
 		for _, prefix := range knownPrefixes {
 			witness, err := tds.ExtractWitnessForPrefix(prefix, false, false)
@@ -1358,6 +1359,7 @@ func (pm *ProtocolManager) handleMgrMsg(p *mgrPeer) error {
 			if err != nil {
 				panic(err)
 			}
+			fmt.Printf("Sernding MGRWitness\n")
 			err = p2p.Send(p.rw, MGRWitness, buf.Bytes())
 			if err != nil {
 				panic(err)

--- a/eth/handler.go
+++ b/eth/handler.go
@@ -1299,6 +1299,7 @@ func (pm *ProtocolManager) handleDebugMsg(p *debugPeer) error {
 		}
 		pm.blockchain.Stop()
 		pm.blockchain = blockchain
+		pm.forkFilter = forkid.NewFilter(pm.blockchain)
 		initPm(pm, pm.txpool, engine, blockchain, blockchain.ChainDb())
 		pm.quitSync = make(chan struct{})
 		go pm.syncer()

--- a/eth/handler.go
+++ b/eth/handler.go
@@ -17,6 +17,7 @@
 package eth
 
 import (
+	"bytes"
 	"context"
 	"encoding/binary"
 	"encoding/json"
@@ -267,6 +268,36 @@ func (pm *ProtocolManager) makeDebugProtocol() p2p.Protocol {
 	}
 }
 
+func (pm *ProtocolManager) makeMgrProtocol() p2p.Protocol {
+	// Initiate Debug protocol
+	log.Info("Initialising Debug protocol", "versions", FirehoseVersions)
+	return p2p.Protocol{
+		Name:    MGRName,
+		Version: MGRVersions[0],
+		Length:  MGRLengths[MGRVersions[0]],
+		Run: func(p *p2p.Peer, rw p2p.MsgReadWriter) error {
+			peer := &mgrPeer{Peer: p, rw: rw}
+			select {
+			case <-pm.quitSync:
+				return p2p.DiscQuitting
+			default:
+				pm.wg.Add(1)
+				defer pm.wg.Done()
+				return pm.handleMgr(peer)
+			}
+		},
+		NodeInfo: func() interface{} {
+			return pm.NodeInfo()
+		},
+		PeerInfo: func(id enode.ID) interface{} {
+			if p := pm.peers.Peer(fmt.Sprintf("%x", id[:8])); p != nil {
+				return p.Info()
+			}
+			return nil
+		},
+	}
+}
+
 func (pm *ProtocolManager) makeProtocol(version uint) p2p.Protocol {
 	length, ok := ProtocolLengths[version]
 	if !ok {
@@ -450,6 +481,15 @@ func (pm *ProtocolManager) handleDebug(p *debugPeer) error {
 	for {
 		if err := pm.handleDebugMsg(p); err != nil {
 			p.Log().Debug("Debug message handling failed", "err", err)
+			return err
+		}
+	}
+}
+
+func (pm *ProtocolManager) handleMgr(p *mgrPeer) error {
+	for {
+		if err := pm.handleMgrMsg(p); err != nil {
+			p.Log().Debug("MGR message handling failed", "err", err)
 			return err
 		}
 	}
@@ -1278,6 +1318,65 @@ func (pm *ProtocolManager) handleDebugMsg(p *debugPeer) error {
 		if err != nil {
 			return fmt.Errorf("p2p.Send: %w", err)
 		}
+		return nil
+	default:
+		return errResp(ErrInvalidMsgCode, "%v", msg.Code)
+	}
+	return nil
+}
+
+func (pm *ProtocolManager) handleMgrMsg(p *mgrPeer) error {
+	msg, readErr := p.rw.ReadMsg()
+	if readErr != nil {
+		return fmt.Errorf("handleDebugMsg p.rw.ReadMsg: %w", readErr)
+	}
+	if msg.Size > MGRMaxMsgSize {
+		return errResp(ErrMsgTooLarge, "%v > %v", msg.Size, DebugMaxMsgSize)
+	}
+	defer msg.Discard()
+
+	switch msg.Code {
+	case MGRStatus:
+		msgStream := rlp.NewStream(msg.Payload, uint64(msg.Size))
+		var knownPrefixes [][]byte
+		if err := msgStream.Decode(&knownPrefixes); err != nil {
+			return fmt.Errorf("msgStream.Decode: %w", err)
+		}
+
+		tds, err := pm.blockchain.GetTrieDbState()
+		if err != nil {
+			panic(err)
+		}
+
+		for _, prefix := range knownPrefixes {
+			witness, err := tds.ExtractWitnessForPrefix(prefix, false, false)
+			if err != nil {
+				return err
+			}
+			buf := bytes.NewBuffer([]byte{})
+			_, err = witness.WriteTo(buf)
+			if err != nil {
+				panic(err)
+			}
+			err = p2p.Send(p.rw, MGRWitness, buf.Bytes())
+			if err != nil {
+				panic(err)
+			}
+		}
+	case MGRWitness:
+		msgStream := rlp.NewStream(msg.Payload, uint64(msg.Size))
+		var marshaledWitness []byte
+		if err := msgStream.Decode(&marshaledWitness); err != nil {
+			return fmt.Errorf("msgStream.Decode: %w", err)
+		}
+
+		res, err := trie.NewWitnessFromReader(bytes.NewReader(marshaledWitness), false)
+		if err != nil {
+			panic(err)
+		}
+
+		fmt.Printf("Received MGRWitness: %v\n", res)
+
 		return nil
 	default:
 		return errResp(ErrInvalidMsgCode, "%v", msg.Code)

--- a/eth/handler.go
+++ b/eth/handler.go
@@ -1349,8 +1349,8 @@ func (pm *ProtocolManager) handleMgrMsg(p *mgrPeer) error {
 
 		fmt.Printf("Received MGRStatus. len(knownPrefixes)=%d\n", len(knownPrefixes))
 		buf := bytes.NewBuffer([]byte{})
-
-		epoch := tds.GetBlockNr() / 4096
+		blockNr := tds.GetBlockNr()
+		epoch := blockNr / 4096
 		subtree := epoch % 256
 		for i := 0; i < 256; i++ { // spread witness of each subtree
 			prefix := []byte{byte(subtree), byte(i)}
@@ -1362,8 +1362,12 @@ func (pm *ProtocolManager) handleMgrMsg(p *mgrPeer) error {
 			if _, err := witness.WriteTo(buf); err != nil {
 				return err
 			}
-			fmt.Printf("Sernding MGRWitness: %x, of size %d\n", prefix, buf.Len())
-			if err := p2p.Send(p.rw, MGRWitness, buf.Bytes()); err != nil {
+			//fmt.Printf("Sernding MGRWitness: %x, of %d\n", prefix, buf.Len())
+			//for _, o := range witness.Operators {
+			//fmt.Printf("%x\n", o)
+			//}
+
+			if err := p.rw.WriteMsg(p2p.Msg{Code: MGRWitness, Size: 0, Payload: buf}); err != nil {
 				return err
 			}
 		}

--- a/eth/mgr.go
+++ b/eth/mgr.go
@@ -1,0 +1,32 @@
+package eth
+
+import (
+	"github.com/ledgerwatch/turbo-geth/p2p"
+)
+
+const (
+	mgr1 = 1
+)
+
+var MGRName = "mgr" // Parity only supports 3 letter capabilities
+var MGRVersions = []uint{mgr1}
+var MGRLengths = map[uint]uint64{mgr1: 2}
+
+const MGRMaxMsgSize = 10 * 1024 * 1024
+
+// MGR (aka Merry-Go-Round) protocol - providing capabilities of swarm-based-full-sync
+const (
+	MGRStatus  = 0x00
+	MGRWitness = 0x01
+)
+
+type mgrPeer struct {
+	*p2p.Peer
+	rw p2p.MsgReadWriter
+}
+
+// SendByteCode sends a BytecodeCode message.
+func (p *mgrPeer) SendByteCode(id uint64, data [][]byte) error {
+	msg := bytecodeMsg{ID: id, Code: data}
+	return p2p.Send(p.rw, BytecodeCode, msg)
+}

--- a/eth/mgr.go
+++ b/eth/mgr.go
@@ -4,6 +4,11 @@ import (
 	"github.com/ledgerwatch/turbo-geth/p2p"
 )
 
+// MGR (aka Merry-Go-Round) protocol - providing capabilities of swarm-based-full-sync
+// At a high level, MGR operates by enumerating the full state in a predetermined order
+// and gossiping this data among the clients which are actively syncing.
+// For a client to fully sync it needs to “ride” one full rotation of the merry-go-round.
+
 const (
 	mgr1 = 1
 )
@@ -14,7 +19,6 @@ var MGRLengths = map[uint]uint64{mgr1: 2}
 
 const MGRMaxMsgSize = 10 * 1024 * 1024
 
-// MGR (aka Merry-Go-Round) protocol - providing capabilities of swarm-based-full-sync
 const (
 	MGRStatus  = 0x00
 	MGRWitness = 0x01

--- a/trie/trie_witness.go
+++ b/trie/trie_witness.go
@@ -6,12 +6,12 @@ func (t *Trie) ExtractWitness(blockNr uint64, trace bool, rs *ResolveSet) (*Witn
 	return extractWitnessFromRootNode(t.root, blockNr, trace, rs)
 }
 
-func (t *Trie) ExtractWitnessForPrefix(prefix []byte, blockNr uint64, trace bool, rs *ResolveSet, codeMap CodeMap) (*Witness, error) {
+func (t *Trie) ExtractWitnessForPrefix(prefix []byte, blockNr uint64, trace bool, rs *ResolveSet) (*Witness, error) {
 	node, _, found := t.getNode(prefix, false)
 	if !found {
 		return nil, errors.New("no data found for given prefix")
 	}
-	return extractWitnessFromRootNode(node, blockNr, trace, rs, codeMap)
+	return extractWitnessFromRootNode(node, blockNr, trace, rs)
 }
 
 // extractWitnessFromRootNode extracts a witness for a subtrie starting from the specified root

--- a/trie/trie_witness.go
+++ b/trie/trie_witness.go
@@ -1,7 +1,17 @@
 package trie
 
+import "errors"
+
 func (t *Trie) ExtractWitness(blockNr uint64, trace bool, rs *ResolveSet) (*Witness, error) {
 	return extractWitnessFromRootNode(t.root, blockNr, trace, rs)
+}
+
+func (t *Trie) ExtractWitnessForPrefix(prefix []byte, blockNr uint64, trace bool, rs *ResolveSet, codeMap CodeMap) (*Witness, error) {
+	node, _, found := t.getNode(prefix, false)
+	if !found {
+		return nil, errors.New("no data found for given prefix")
+	}
+	return extractWitnessFromRootNode(node, blockNr, trace, rs, codeMap)
 }
 
 // extractWitnessFromRootNode extracts a witness for a subtrie starting from the specified root


### PR DESCRIPTION
Naive implementation of MGR ( https://ethresear.ch/t/merry-go-round-sync/ ) P2P SubProtocol:
```
epoch := tds.GetBlockNr() / 4096
subtree := epoch % 256          // define first byte
for i := 0; i < 256; i++ {     // define second byte and spread witness of each 2-bytes subtree
	prefix := []byte{byte(subtree), byte(i)}
	witness, err := tds.ExtractWitnessForPrefix(prefix)
        p2p.Send(p.rw, MGRWitness, witness,)
}
```

Also in PR: 
- [Stateless] Make `./cmd/state stateless` cancelable 
- [Tester] Move ForkGenerator to core.GenerateChain
- [Tester] Add basic support of MGR 

