### PR TITLE
Optimize resolver cached

### DIFF
--- a/common/dbutils/composite_keys.go
+++ b/common/dbutils/composite_keys.go
@@ -119,14 +119,15 @@ func DecodeIncarnation(buf []byte) uint64 {
 	return incarnation ^ ^uint64(0)
 }
 
-func RemoveIncarnationFromKey(storageKey []byte) []byte {
-	if len(storageKey) <= common.HashLength {
-		return storageKey
+func RemoveIncarnationFromKey(key []byte, buf *[]byte) {
+	tmp := *buf
+	if len(key) <= common.HashLength {
+		tmp = append(tmp, key...)
+	} else {
+		tmp = append(tmp, key[:common.HashLength]...)
+		tmp = append(tmp, key[common.HashLength+8:]...)
 	}
-	buf := make([]byte, 0, common.HashLength*2)
-	buf = append(buf, storageKey[:common.HashLength]...)
-	buf = append(buf, storageKey[common.HashLength+8:]...)
-	return buf
+	*buf = tmp
 }
 
 // Key + blockNum

--- a/trie/resolver_stateful_cached.go
+++ b/trie/resolver_stateful_cached.go
@@ -351,12 +351,7 @@ func (tr *ResolverStatefulCached) MultiWalk2(db *bolt.DB, blockNr uint64, bucket
 	startkey := startkeys[rangeIdx]
 
 	startKeyNoInc.Reset()
-	if len(startkey) <= common.HashLength {
-		startKeyNoInc.B = append(startKeyNoInc.B, startkey...)
-	} else {
-		startKeyNoInc.B = append(startKeyNoInc.B, startkey[:common.HashLength]...)
-		startKeyNoInc.B = append(startKeyNoInc.B, startkey[common.HashLength+8:]...)
-	}
+	dbutils.RemoveIncarnationFromKey(startkey, &startKeyNoInc.B)
 
 	err := db.View(func(tx *bolt.Tx) error {
 		cacheBucket := tx.Bucket(dbutils.IntermediateTrieHashBucket)
@@ -443,13 +438,7 @@ func (tr *ResolverStatefulCached) MultiWalk2(db *bolt.DB, blockNr uint64, bucket
 						fixedbytes, mask = ethdb.Bytesmask(fixedbits[rangeIdx])
 						startkey = startkeys[rangeIdx]
 						startKeyNoInc.Reset()
-						if len(startkey) <= common.HashLength {
-							startKeyNoInc.B = append(startKeyNoInc.B, startkey...)
-						} else {
-							startKeyNoInc.B = append(startKeyNoInc.B, startkey[:common.HashLength]...)
-							startKeyNoInc.B = append(startKeyNoInc.B, startkey[common.HashLength+8:]...)
-						}
-
+						dbutils.RemoveIncarnationFromKey(startkey, &startKeyNoInc.B)
 					}
 				}
 			}

--- a/trie/resolver_stateful_cached.go
+++ b/trie/resolver_stateful_cached.go
@@ -350,14 +350,12 @@ func (tr *ResolverStatefulCached) MultiWalk2(db *bolt.DB, blockNr uint64, bucket
 	fixedbytes, mask := ethdb.Bytesmask(fixedbits[rangeIdx])
 	startkey := startkeys[rangeIdx]
 
-	if !isAccountBucket {
-		startKeyNoInc.Reset()
-		if len(startkey) <= common.HashLength {
-			startKeyNoInc.B = append(startKeyNoInc.B, startkey...)
-		} else {
-			startKeyNoInc.B = append(startKeyNoInc.B, startkey[:common.HashLength]...)
-			startKeyNoInc.B = append(startKeyNoInc.B, startkey[common.HashLength+8:]...)
-		}
+	startKeyNoInc.Reset()
+	if len(startkey) <= common.HashLength {
+		startKeyNoInc.B = append(startKeyNoInc.B, startkey...)
+	} else {
+		startKeyNoInc.B = append(startKeyNoInc.B, startkey[:common.HashLength]...)
+		startKeyNoInc.B = append(startKeyNoInc.B, startkey[common.HashLength+8:]...)
 	}
 
 	err := db.View(func(tx *bolt.Tx) error {
@@ -444,6 +442,14 @@ func (tr *ResolverStatefulCached) MultiWalk2(db *bolt.DB, blockNr uint64, bucket
 						}
 						fixedbytes, mask = ethdb.Bytesmask(fixedbits[rangeIdx])
 						startkey = startkeys[rangeIdx]
+						startKeyNoInc.Reset()
+						if len(startkey) <= common.HashLength {
+							startKeyNoInc.B = append(startKeyNoInc.B, startkey...)
+						} else {
+							startKeyNoInc.B = append(startKeyNoInc.B, startkey[:common.HashLength]...)
+							startKeyNoInc.B = append(startKeyNoInc.B, startkey[common.HashLength+8:]...)
+						}
+
 					}
 				}
 			}


### PR DESCRIPTION
* skip storage subtree by .Seek() when len(cacheK) <= common.HashLength
* dbutils.RemoveIncarnationFromKey - doesn't do allocation