### PR TITLE
don't pass common ctx to blochain.Commit

### DIFF
--- a/cmd/state/stateless/stateless.go
+++ b/cmd/state/stateless/stateless.go
@@ -448,7 +448,8 @@ func Stateless(
 		}
 		tds.SetBlockNr(blockNum)
 
-		err = statedb.CommitBlock(ctx, tds.DbStateWriter())
+		commitBlockCtx := context.Background() // because .CommitBlock must not be interrupted
+		err = statedb.CommitBlock(commitBlockCtx, tds.DbStateWriter())
 		if err != nil {
 			fmt.Printf("Commiting block %d failed: %v", blockNum, err)
 			return


### PR DESCRIPTION
don't pass common ctx to commit block, to avoid cancelation in the middle of commit