### PR TITLE
Code size in account nodes

### DIFF
--- a/core/state/database.go
+++ b/core/state/database.go
@@ -485,7 +485,6 @@ func (tds *TrieDbState) resolveCodeTouches(
 	codeSizeTouches map[common.Hash]common.Hash,
 	resolveFunc trie.ResolveFunc,
 ) error {
-	fmt.Printf("codeTouches: %v\ncodeSizeTouches: %v\n", codeTouches, codeSizeTouches)
 	firstRequest := true
 	for address, codeHash := range codeTouches {
 		delete(codeSizeTouches, codeHash)
@@ -1153,7 +1152,8 @@ func (tds *TrieDbState) ReadAccountCodeSize(address common.Address, codeHash com
 	if cached, ok := tds.readAccountCodeSizeFromTrie(addrHash[:]); ok {
 		codeSize, err = cached, nil
 	} else {
-		code, err := tds.db.Get(dbutils.CodeBucket, codeHash[:])
+		var code []byte
+		code, err = tds.db.Get(dbutils.CodeBucket, codeHash[:])
 		if err != nil {
 			return 0, err
 		}

--- a/core/state/database.go
+++ b/core/state/database.go
@@ -93,6 +93,7 @@ func (nw *NoopWriter) CreateContract(address common.Address) error {
 // A change period can be transaction within a block, or a block within group of blocks
 type Buffer struct {
 	codeReads      map[common.Hash]common.Hash
+	codeSizeReads  map[common.Hash]struct{}
 	codeUpdates    map[common.Hash][]byte
 	storageUpdates map[common.Hash]map[common.Hash][]byte
 	storageReads   map[common.Hash]map[common.Hash]struct{}

--- a/core/state/database_test.go
+++ b/core/state/database_test.go
@@ -1197,3 +1197,65 @@ func TestChangeAccountCodeBetweenBlocks(t *testing.T) {
 	assert.NoError(t, err, "you can receive the new code")
 	assert.Equal(t, newCode, trieCode, "new code should be received")
 }
+
+func TestCacheCodeSize(t *testing.T) {
+	contract := common.HexToAddress("0x71dd1027069078091B3ca48093B00E4735B20624")
+	root := common.HexToHash("0xb939e5bcf5809adfb87ab07f0795b05b95a1d64a90f0eddd0c3123ac5b433854")
+
+	db := ethdb.NewMemDatabase()
+	tds := state.NewTrieDbState(root, db, 0)
+	tds.SetResolveReads(true)
+	tsw := tds.DbStateWriter()
+	intraBlockState := state.New(tds)
+	ctx := context.Background()
+	// Start the 1st transaction
+	tds.StartNewBuffer()
+	intraBlockState.CreateAccount(contract, true)
+
+	code := []byte{0x01, 0x02, 0x03, 0x04}
+
+	intraBlockState.SetCode(contract, code)
+	intraBlockState.AddBalance(contract, big.NewInt(1000000000))
+	if err := intraBlockState.FinalizeTx(ctx, tsw); err != nil {
+		t.Errorf("error finalising 1st tx: %v", err)
+	}
+
+	tds.ResolveStateTrie(false, false)
+
+	tds.StartNewBuffer()
+
+	tds.ReadAccountData(contract)
+
+	tds.ResolveStateTrie(false, true)
+
+	tds.StartNewBuffer()
+
+	tds.Trie().PrintTrie()
+
+	tds.ComputeTrieRoots()
+
+	oldSize := tds.Trie().TrieSize()
+
+	tds.StartNewBuffer()
+
+	codeHash := common.BytesToHash(crypto.Keccak256(code))
+	codeSize, err := tds.ReadAccountCodeSize(contract, codeHash)
+	assert.NoError(t, err, "you can receive the new code")
+	assert.Equal(t, len(code), codeSize, "new code should be received")
+
+	tds.ResolveStateTrie(false, true)
+
+	newSize := tds.Trie().TrieSize()
+	assert.Equal(t, oldSize, newSize, "should not load codeNode, so the size shouldn't change")
+
+	tds.StartNewBuffer()
+
+	code2, err := tds.ReadAccountCode(contract, codeHash)
+	assert.NoError(t, err, "you can receive the new code")
+	assert.Equal(t, code, code2, "new code should be received")
+
+	tds.ResolveStateTrie(false, true)
+
+	newSize2 := tds.Trie().TrieSize()
+	assert.Equal(t, oldSize, newSize2-len(code), "should load codeNode when requesting new data ")
+}

--- a/core/state/database_test.go
+++ b/core/state/database_test.go
@@ -1221,7 +1221,9 @@ func TestCacheCodeSizeSeparately(t *testing.T) {
 		t.Errorf("error finalising 1st tx: %v", err)
 	}
 
-	tds.ResolveStateTrie(false, false)
+	if _, err := tds.ResolveStateTrie(false, false); err != nil {
+		assert.NoError(t, err)
+	}
 
 	oldSize := tds.Trie().TrieSize()
 
@@ -1232,7 +1234,9 @@ func TestCacheCodeSizeSeparately(t *testing.T) {
 	assert.NoError(t, err, "you can receive the new code")
 	assert.Equal(t, len(code), codeSize, "new code should be received")
 
-	tds.ResolveStateTrie(false, false)
+	if _, err = tds.ResolveStateTrie(false, false); err != nil {
+		assert.NoError(t, err)
+	}
 
 	newSize := tds.Trie().TrieSize()
 	assert.Equal(t, oldSize, newSize, "should not load codeNode, so the size shouldn't change")
@@ -1243,7 +1247,9 @@ func TestCacheCodeSizeSeparately(t *testing.T) {
 	assert.NoError(t, err, "you can receive the new code")
 	assert.Equal(t, code, code2, "new code should be received")
 
-	tds.ResolveStateTrie(false, false)
+	if _, err = tds.ResolveStateTrie(false, false); err != nil {
+		assert.NoError(t, err)
+	}
 
 	newSize2 := tds.Trie().TrieSize()
 	assert.Equal(t, oldSize, newSize2-len(code), "should load codeNode when requesting new data ")
@@ -1272,7 +1278,9 @@ func TestCacheCodeSizeInTrie(t *testing.T) {
 		t.Errorf("error finalising 1st tx: %v", err)
 	}
 
-	tds.ResolveStateTrie(false, false)
+	if _, err := tds.ResolveStateTrie(false, false); err != nil {
+		assert.NoError(t, err)
+	}
 
 	tds.StartNewBuffer()
 
@@ -1281,9 +1289,11 @@ func TestCacheCodeSizeInTrie(t *testing.T) {
 	assert.NoError(t, err, "you can receive the code size ")
 	assert.Equal(t, len(code), codeSize, "you can receive the code size")
 
-	tds.ResolveStateTrie(false, false)
+	if _, err = tds.ResolveStateTrie(false, false); err != nil {
+		assert.NoError(t, err)
+	}
 
-	db.Delete(dbutils.CodeBucket, codeHash[:])
+	assert.NoError(t, db.Delete(dbutils.CodeBucket, codeHash[:]))
 
 	codeSize2, err := tds.ReadAccountCodeSize(contract, codeHash)
 	assert.NoError(t, err, "you can still receive code size even with empty DB")

--- a/core/state/database_test.go
+++ b/core/state/database_test.go
@@ -1198,7 +1198,59 @@ func TestChangeAccountCodeBetweenBlocks(t *testing.T) {
 	assert.Equal(t, newCode, trieCode, "new code should be received")
 }
 
-func TestCacheCodeSize(t *testing.T) {
+// TestCacheCodeSizeSeparately makes sure that we don't store CodeNodes for code sizes
+func TestCacheCodeSizeSeparately(t *testing.T) {
+	contract := common.HexToAddress("0x71dd1027069078091B3ca48093B00E4735B20624")
+	root := common.HexToHash("0xb939e5bcf5809adfb87ab07f0795b05b95a1d64a90f0eddd0c3123ac5b433854")
+
+	db := ethdb.NewMemDatabase()
+	tds := state.NewTrieDbState(root, db, 0)
+	tds.SetResolveReads(true)
+	tsw := tds.DbStateWriter()
+	intraBlockState := state.New(tds)
+	ctx := context.Background()
+	// Start the 1st transaction
+	tds.StartNewBuffer()
+	intraBlockState.CreateAccount(contract, true)
+
+	code := []byte{0x01, 0x02, 0x03, 0x04}
+
+	intraBlockState.SetCode(contract, code)
+	intraBlockState.AddBalance(contract, big.NewInt(1000000000))
+	if err := intraBlockState.FinalizeTx(ctx, tsw); err != nil {
+		t.Errorf("error finalising 1st tx: %v", err)
+	}
+
+	tds.ResolveStateTrie(false, false)
+
+	oldSize := tds.Trie().TrieSize()
+
+	tds.StartNewBuffer()
+
+	codeHash := common.BytesToHash(crypto.Keccak256(code))
+	codeSize, err := tds.ReadAccountCodeSize(contract, codeHash)
+	assert.NoError(t, err, "you can receive the new code")
+	assert.Equal(t, len(code), codeSize, "new code should be received")
+
+	tds.ResolveStateTrie(false, false)
+
+	newSize := tds.Trie().TrieSize()
+	assert.Equal(t, oldSize, newSize, "should not load codeNode, so the size shouldn't change")
+
+	tds.StartNewBuffer()
+
+	code2, err := tds.ReadAccountCode(contract, codeHash)
+	assert.NoError(t, err, "you can receive the new code")
+	assert.Equal(t, code, code2, "new code should be received")
+
+	tds.ResolveStateTrie(false, false)
+
+	newSize2 := tds.Trie().TrieSize()
+	assert.Equal(t, oldSize, newSize2-len(code), "should load codeNode when requesting new data ")
+}
+
+// TestCacheCodeSizeInTrie makes sure that we dont just read from the DB all the time
+func TestCacheCodeSizeInTrie(t *testing.T) {
 	contract := common.HexToAddress("0x71dd1027069078091B3ca48093B00E4735B20624")
 	root := common.HexToHash("0xb939e5bcf5809adfb87ab07f0795b05b95a1d64a90f0eddd0c3123ac5b433854")
 
@@ -1224,38 +1276,16 @@ func TestCacheCodeSize(t *testing.T) {
 
 	tds.StartNewBuffer()
 
-	tds.ReadAccountData(contract)
-
-	tds.ResolveStateTrie(false, true)
-
-	tds.StartNewBuffer()
-
-	tds.Trie().PrintTrie()
-
-	tds.ComputeTrieRoots()
-
-	oldSize := tds.Trie().TrieSize()
-
-	tds.StartNewBuffer()
-
 	codeHash := common.BytesToHash(crypto.Keccak256(code))
 	codeSize, err := tds.ReadAccountCodeSize(contract, codeHash)
-	assert.NoError(t, err, "you can receive the new code")
-	assert.Equal(t, len(code), codeSize, "new code should be received")
+	assert.NoError(t, err, "you can receive the code size ")
+	assert.Equal(t, len(code), codeSize, "you can receive the code size")
 
-	tds.ResolveStateTrie(false, true)
+	tds.ResolveStateTrie(false, false)
 
-	newSize := tds.Trie().TrieSize()
-	assert.Equal(t, oldSize, newSize, "should not load codeNode, so the size shouldn't change")
+	db.Delete(dbutils.CodeBucket, codeHash[:])
 
-	tds.StartNewBuffer()
-
-	code2, err := tds.ReadAccountCode(contract, codeHash)
-	assert.NoError(t, err, "you can receive the new code")
-	assert.Equal(t, code, code2, "new code should be received")
-
-	tds.ResolveStateTrie(false, true)
-
-	newSize2 := tds.Trie().TrieSize()
-	assert.Equal(t, oldSize, newSize2-len(code), "should load codeNode when requesting new data ")
+	codeSize2, err := tds.ReadAccountCodeSize(contract, codeHash)
+	assert.NoError(t, err, "you can still receive code size even with empty DB")
+	assert.Equal(t, len(code), codeSize2, "code size should be received even with empty DB")
 }

--- a/trie/hashbuilder.go
+++ b/trie/hashbuilder.go
@@ -231,7 +231,7 @@ func (hb *HashBuilder) accountLeaf(length int, keyHex []byte, storageSize uint64
 	accCopy.Copy(&hb.acc)
 
 	accountCodeSize := codeSizeUncached
-	if !bytes.Equal(accCopy.CodeHash[:], EmptyCodeHash[:]) {
+	if !bytes.Equal(accCopy.CodeHash[:], EmptyCodeHash[:]) && accountCode != nil {
 		accountCodeSize = len(accountCode)
 	}
 

--- a/trie/hashbuilder.go
+++ b/trie/hashbuilder.go
@@ -230,7 +230,12 @@ func (hb *HashBuilder) accountLeaf(length int, keyHex []byte, storageSize uint64
 	var accCopy accounts.Account
 	accCopy.Copy(&hb.acc)
 
-	s := &shortNode{Key: common.CopyBytes(key), Val: &accountNode{accCopy, root, true, accountCode}}
+	accountCodeSize := codeSizeUncached
+	if !bytes.Equal(accCopy.CodeHash[:], EmptyCodeHash[:]) {
+		accountCodeSize = len(accountCode)
+	}
+
+	s := &shortNode{Key: common.CopyBytes(key), Val: &accountNode{accCopy, root, true, accountCode, accountCodeSize}}
 	// this invocation will take care of the popping given number of items from both hash stack and node stack,
 	// pushing resulting hash to the hash stack, and nil to the node stack
 	if err = hb.accountLeafHashWithKey(key, popped); err != nil {

--- a/trie/node.go
+++ b/trie/node.go
@@ -26,6 +26,8 @@ import (
 	"github.com/ledgerwatch/turbo-geth/rlp"
 )
 
+const codeSizeUncached = -1
+
 var indices = []string{"0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "a", "b", "c", "d", "e", "f", "[17]"}
 
 type node interface {
@@ -63,6 +65,7 @@ type (
 		storage     node
 		rootCorrect bool
 		code        codeNode
+		codeSize    int
 	}
 
 	codeNode []byte

--- a/trie/resolver_stateful.go
+++ b/trie/resolver_stateful.go
@@ -193,8 +193,14 @@ func (tr *ResolverStateful) AttachRequestedCode(db ethdb.Getter, requests []*Res
 		if err != nil {
 			return err
 		}
-		if err := req.t.UpdateAccountCode(req.addrHash[:], codeNode(code)); err != nil {
-			return err
+		if req.bytecode {
+			if err := req.t.UpdateAccountCode(req.addrHash[:], codeNode(code)); err != nil {
+				return err
+			}
+		} else {
+			if err := req.t.UpdateAccountCodeSize(req.addrHash[:], len(code)); err != nil {
+				return err
+			}
 		}
 	}
 	return nil

--- a/trie/trie.go
+++ b/trie/trie.go
@@ -135,7 +135,7 @@ func (t *Trie) GetAccount(key []byte) (value *accounts.Account, gotValue bool) {
 
 func (t *Trie) GetAccountCode(key []byte) (value []byte, gotValue bool) {
 	if t.root == nil {
-		return nil, true
+		return nil, false
 	}
 
 	hex := keybytesToHex(key)
@@ -277,9 +277,9 @@ func (t *Trie) UpdateAccount(key []byte, acc *accounts.Account) {
 
 	var newnode *accountNode
 	if value.Root == EmptyRoot || value.Root == (common.Hash{}) {
-		newnode = &accountNode{*value, nil, true, nil}
+		newnode = &accountNode{*value, nil, true, nil, codeSizeUncached}
 	} else {
-		newnode = &accountNode{*value, hashNode(value.Root[:]), true, nil}
+		newnode = &accountNode{*value, hashNode(value.Root[:]), true, nil, codeSizeUncached}
 	}
 
 	if t.root == nil {
@@ -311,6 +311,7 @@ func (t *Trie) UpdateAccountCode(key []byte, code codeNode) error {
 	}
 
 	accNode.code = code
+	accNode.codeSize = len(code)
 
 	// t.insert will call the observer methods itself
 	_, t.root = t.insert(t.root, hex, 0, accNode)
@@ -471,6 +472,7 @@ func (t *Trie) insert(origNode node, key []byte, pos int, value node) (updated b
 					origAccN.code = nil
 				} else if vAccN.code != nil {
 					origAccN.code = vAccN.code
+					origAccN.codeSize = vAccN.codeSize
 				}
 				origAccN.Account.Copy(&vAccN.Account)
 				origAccN.rootCorrect = false

--- a/trie/trie_transform.go
+++ b/trie/trie_transform.go
@@ -23,7 +23,7 @@ func transformSubTrie(nd node, hex []byte, newTrie *Trie, transformFunc keyTrans
 			code = make([]byte, len(n.code))
 			copy(code, n.code)
 		}
-		_, newTrie.root = newTrie.insert(newTrie.root, transformFunc(hex), 0, &accountNode{accountCopy, nil, true, codeNode(code)})
+		_, newTrie.root = newTrie.insert(newTrie.root, transformFunc(hex), 0, &accountNode{accountCopy, nil, true, codeNode(code), n.codeSize})
 		aHex := hex
 		if aHex[len(aHex)-1] == 16 {
 			aHex = aHex[:len(aHex)-1]


### PR DESCRIPTION
Support `ReadAccountCodeSize` operation natively w/o caching the whole code in the trie.