### PR TITLE
Use `geth export` generated files in the stateless prototype

### DIFF
--- a/cmd/state/commands/stateless.go
+++ b/cmd/state/commands/stateless.go
@@ -20,13 +20,14 @@ var (
 	statelessResolver bool
 	witnessDatabase   string
 	writeHistory      bool
+	blockSource       string
 )
 
 func init() {
-	withChaindata(statelessCmd)
 	withStatsfile(statelessCmd)
 	withBlock(statelessCmd)
 
+	statelessCmd.Flags().StringVar(&blockSource, "blockSource", "", "Path to the block source: `db:///path/to/chaindata` or `exportfile:///path/to/my/exportfile`")
 	statelessCmd.Flags().StringVar(&statefile, "statefile", "state", "path to the file where the state will be periodically written during the analysis")
 	statelessCmd.Flags().Uint32Var(&triesize, "triesize", 4*1024*1024, "maximum size of a trie in bytes")
 	statelessCmd.Flags().BoolVar(&preroot, "preroot", false, "Attempt to compute hash of the trie without modifying it")
@@ -61,7 +62,7 @@ var statelessCmd = &cobra.Command{
 		stateless.Stateless(
 			ctx,
 			block,
-			chaindata,
+			blockSource,
 			statefile,
 			triesize,
 			preroot,

--- a/cmd/state/stateless/stateless.go
+++ b/cmd/state/stateless/stateless.go
@@ -2,7 +2,6 @@ package stateless
 
 import (
 	"bytes"
-	"compress/gzip"
 	"context"
 	"encoding/csv"
 	"fmt"
@@ -27,7 +26,6 @@ import (
 	"github.com/ledgerwatch/turbo-geth/core/vm"
 	"github.com/ledgerwatch/turbo-geth/ethdb"
 	"github.com/ledgerwatch/turbo-geth/params"
-	"github.com/ledgerwatch/turbo-geth/rlp"
 	"github.com/ledgerwatch/turbo-geth/trie"
 	"github.com/ledgerwatch/turbo-geth/visual"
 )
@@ -531,81 +529,4 @@ func Stateless(
 	fmt.Printf("Processed %d blocks\n", blockNum)
 	fmt.Printf("Next time specify -block %d\n", blockNum)
 	fmt.Printf("Stateless client analysis took %s\n", time.Since(startTime))
-}
-
-type BlockProvider interface {
-	FastFwd(uint64) error
-	NextBlock() (*types.Block, error)
-}
-
-type BlockChainBlockProvider struct {
-	currentBlock uint64
-	bc           *core.BlockChain
-}
-
-func NewBlockProviderFromBlockChain(bc *core.BlockChain) BlockProvider {
-	return &BlockChainBlockProvider{
-		bc: bc,
-	}
-}
-
-func (p *BlockChainBlockProvider) FastFwd(to uint64) error {
-	p.currentBlock = to
-	return nil
-}
-
-func (p *BlockChainBlockProvider) NextBlock() (*types.Block, error) {
-	block := p.bc.GetBlockByNumber(p.currentBlock)
-	p.currentBlock++
-	return block, nil
-}
-
-type ExportFileBlockProvider struct {
-	stream *rlp.Stream
-	fh     io.Closer
-}
-
-func NewBlockProviderFromExportFile(fn string) (BlockProvider, error) {
-	// Open the file handle and potentially unwrap the gzip stream
-	fh, err := os.Open(fn)
-	if err != nil {
-		return nil, err
-	}
-
-	var reader io.Reader = fh
-	if strings.HasSuffix(fn, ".gz") {
-		if reader, err = gzip.NewReader(reader); err != nil {
-			return nil, err
-		}
-	}
-	stream := rlp.NewStream(reader, 0)
-	return &ExportFileBlockProvider{stream, fh}, nil
-}
-
-func (p *ExportFileBlockProvider) Close() error {
-	return p.fh.Close()
-}
-
-func (p *ExportFileBlockProvider) FastFwd(to uint64) error {
-	var b types.Block
-	for true {
-		if err := p.stream.Decode(&b); err == io.EOF {
-			return nil
-		} else if err != nil {
-			return fmt.Errorf("error fast fwd: %v", err)
-		} else if b.NumberU64() >= to-1 {
-			return nil
-		}
-	}
-	return nil
-}
-
-func (p *ExportFileBlockProvider) NextBlock() (*types.Block, error) {
-	var b types.Block
-	if err := p.stream.Decode(&b); err == io.EOF {
-		return nil, nil
-	} else if err != nil {
-		return nil, fmt.Errorf("error fast fwd: %v", err)
-	}
-	return &b, nil
 }

--- a/cmd/state/stateless/stateless.go
+++ b/cmd/state/stateless/stateless.go
@@ -2,9 +2,11 @@ package stateless
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/csv"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"os"
 	"os/signal"
@@ -25,6 +27,7 @@ import (
 	"github.com/ledgerwatch/turbo-geth/core/vm"
 	"github.com/ledgerwatch/turbo-geth/ethdb"
 	"github.com/ledgerwatch/turbo-geth/params"
+	"github.com/ledgerwatch/turbo-geth/rlp"
 	"github.com/ledgerwatch/turbo-geth/trie"
 	"github.com/ledgerwatch/turbo-geth/visual"
 )
@@ -179,10 +182,15 @@ func Stateless(
 
 	vmConfig := vm.Config{}
 	engine := ethash.NewFullFaker()
-	bcb, err := core.NewBlockChain(ethDb, nil, chainConfig, engine, vm.Config{}, nil)
+	//cb, err := core.NewBlockChain(ethDb, nil, chainConfig, engine, vm.Config{}, nil)
+
+	blockProvider, err := NewBlockProviderFromExportFile("/Users/mandrigin/Desktop/geth-export-1")
+	if closer, ok := blockProvider.(io.Closer); ok {
+		defer closer.Close()
+	}
 	check(err)
 
-	blockProvider := NewBlockProviderFromBlockChain(bcb)
+	// NewBlockProviderFromBlockChain(bcb)
 
 	stateDb, err := createDb(statefile)
 	check(err)
@@ -550,4 +558,54 @@ func (p *BlockChainBlockProvider) NextBlock() (*types.Block, error) {
 	block := p.bc.GetBlockByNumber(p.currentBlock)
 	p.currentBlock++
 	return block, nil
+}
+
+type ExportFileBlockProvider struct {
+	stream *rlp.Stream
+	fh     io.Closer
+}
+
+func NewBlockProviderFromExportFile(fn string) (BlockProvider, error) {
+	// Open the file handle and potentially unwrap the gzip stream
+	fh, err := os.Open(fn)
+	if err != nil {
+		return nil, err
+	}
+
+	var reader io.Reader = fh
+	if strings.HasSuffix(fn, ".gz") {
+		if reader, err = gzip.NewReader(reader); err != nil {
+			return nil, err
+		}
+	}
+	stream := rlp.NewStream(reader, 0)
+	return &ExportFileBlockProvider{stream, fh}, nil
+}
+
+func (p *ExportFileBlockProvider) Close() error {
+	return p.fh.Close()
+}
+
+func (p *ExportFileBlockProvider) FastFwd(to uint64) error {
+	var b types.Block
+	for true {
+		if err := p.stream.Decode(&b); err == io.EOF {
+			return nil
+		} else if err != nil {
+			return fmt.Errorf("error fast fwd: %v", err)
+		} else if b.NumberU64() >= to-1 {
+			return nil
+		}
+	}
+	return nil
+}
+
+func (p *ExportFileBlockProvider) NextBlock() (*types.Block, error) {
+	var b types.Block
+	if err := p.stream.Decode(&b); err == io.EOF {
+		return nil, nil
+	} else if err != nil {
+		return nil, fmt.Errorf("error fast fwd: %v", err)
+	}
+	return &b, nil
 }

--- a/cmd/state/stateless/stateless.go
+++ b/cmd/state/stateless/stateless.go
@@ -133,7 +133,7 @@ type CreateDbFunc func(string) (ethdb.Database, error)
 func Stateless(
 	ctx context.Context,
 	blockNum uint64,
-	blockSourceUri string,
+	blockSourceURI string,
 	statefile string,
 	triesize uint32,
 	tryPreRoot bool,
@@ -172,7 +172,7 @@ func Stateless(
 	check(err)
 	defer stats.Close()
 
-	blockProvider, err := BlockProviderForURI(blockSourceUri, createDb)
+	blockProvider, err := BlockProviderForURI(blockSourceURI, createDb)
 	check(err)
 	defer blockProvider.Close()
 
@@ -263,7 +263,8 @@ func Stateless(
 
 	}
 
-	blockProvider.FastFwd(blockNum)
+	err = blockProvider.FastFwd(blockNum)
+	check(err)
 
 	for !interrupt {
 		select {
@@ -294,7 +295,8 @@ func Stateless(
 		}
 		for i, tx := range block.Transactions() {
 			statedb.Prepare(tx.Hash(), block.Hash(), i)
-			receipt, err := core.ApplyTransaction(chainConfig, bcb2, nil, gp, statedb, tds.TrieStateWriter(), header, tx, usedGas, vmConfig)
+			var receipt *types.Receipt
+			receipt, err = core.ApplyTransaction(chainConfig, bcb2, nil, gp, statedb, tds.TrieStateWriter(), header, tx, usedGas, vmConfig)
 			if err != nil {
 				fmt.Printf("tx %x failed: %v\n", tx.Hash(), err)
 				return

--- a/cmd/state/stateless/stateless_block_providers.go
+++ b/cmd/state/stateless/stateless_block_providers.go
@@ -1,0 +1,90 @@
+package stateless
+
+import (
+	"compress/gzip"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/ledgerwatch/turbo-geth/core"
+	"github.com/ledgerwatch/turbo-geth/core/types"
+	"github.com/ledgerwatch/turbo-geth/rlp"
+)
+
+type BlockProvider interface {
+	FastFwd(uint64) error
+	NextBlock() (*types.Block, error)
+}
+
+type BlockChainBlockProvider struct {
+	currentBlock uint64
+	bc           *core.BlockChain
+}
+
+func NewBlockProviderFromBlockChain(bc *core.BlockChain) BlockProvider {
+	return &BlockChainBlockProvider{
+		bc: bc,
+	}
+}
+
+func (p *BlockChainBlockProvider) FastFwd(to uint64) error {
+	p.currentBlock = to
+	return nil
+}
+
+func (p *BlockChainBlockProvider) NextBlock() (*types.Block, error) {
+	block := p.bc.GetBlockByNumber(p.currentBlock)
+	p.currentBlock++
+	return block, nil
+}
+
+type ExportFileBlockProvider struct {
+	stream *rlp.Stream
+	fh     io.Closer
+}
+
+func NewBlockProviderFromExportFile(fn string) (BlockProvider, error) {
+	// Open the file handle and potentially unwrap the gzip stream
+	fh, err := os.Open(fn)
+	if err != nil {
+		return nil, err
+	}
+
+	var reader io.Reader = fh
+	if strings.HasSuffix(fn, ".gz") {
+		if reader, err = gzip.NewReader(reader); err != nil {
+			return nil, err
+		}
+	}
+	stream := rlp.NewStream(reader, 0)
+	return &ExportFileBlockProvider{stream, fh}, nil
+}
+
+func (p *ExportFileBlockProvider) Close() error {
+	return p.fh.Close()
+}
+
+func (p *ExportFileBlockProvider) FastFwd(to uint64) error {
+	var b types.Block
+	for true {
+		if err := p.stream.Decode(&b); err == io.EOF {
+			return nil
+		} else if err != nil {
+			return fmt.Errorf("error fast fwd: %v", err)
+		} else if b.NumberU64() >= to-1 {
+			return nil
+		}
+	}
+	return nil
+}
+
+func (p *ExportFileBlockProvider) NextBlock() (*types.Block, error) {
+	var b types.Block
+	if err := p.stream.Decode(&b); err == io.EOF {
+		return nil, nil
+	} else if err != nil {
+		return nil, fmt.Errorf("error fast fwd: %v", err)
+	}
+	return &b, nil
+}

--- a/cmd/state/stateless/stateless_block_providers.go
+++ b/cmd/state/stateless/stateless_block_providers.go
@@ -112,7 +112,7 @@ func (p *ExportFileBlockProvider) Close() error {
 
 func (p *ExportFileBlockProvider) FastFwd(to uint64) error {
 	var b types.Block
-	for true {
+	for {
 		if err := p.stream.Decode(&b); err == io.EOF {
 			return nil
 		} else if err != nil {
@@ -121,7 +121,6 @@ func (p *ExportFileBlockProvider) FastFwd(to uint64) error {
 			return nil
 		}
 	}
-	return nil
 }
 
 func (p *ExportFileBlockProvider) NextBlock() (*types.Block, error) {


### PR DESCRIPTION
fixes: #445

replaces `--chaindata=<path-to-boltdb>` parameter with a more flexible `--blockSource` that can take 3 types of arguments:
- `exportfile:///path/to/exportfile` -- use a `geth export` result instead of chaindata
- `db:///path/to/db` -- use a "normal" chaindata
- `/path/to/db/` -- use a "normal" chaindata