### PR TITLE
Handle empty backtrace parameter gracefully

### DIFF
--- a/internal/debug/flags.go
+++ b/internal/debug/flags.go
@@ -141,9 +141,11 @@ func SetupCobra(cmd *cobra.Command) error {
 	if err != nil {
 		return err
 	}
-	err = glogger.BacktraceAt(backtrace)
-	if err != nil {
-		return err
+	if backtrace != "" {
+		err = glogger.BacktraceAt(backtrace)
+		if err != nil {
+			return err
+		}
 	}
 	log.Root().SetHandler(glogger)
 


### PR DESCRIPTION
Fixes the issue that causes a panic when starting `state` command.
```
> go run ./cmd/state verifySnapshot

panic: expect file.go:234
```