### PR TITLE
Don't use `chaindata` where we don't need it.

### DIFF
--- a/cmd/state/commands/gas_limits.go
+++ b/cmd/state/commands/gas_limits.go
@@ -10,7 +10,6 @@ import (
 )
 
 func init() {
-	withChaindata(gasLimitsCmd)
 	withRemoteDb(gasLimitsCmd)
 	rootCmd.AddCommand(gasLimitsCmd)
 }

--- a/cmd/state/commands/state_growth.go
+++ b/cmd/state/commands/state_growth.go
@@ -36,7 +36,6 @@ func init() {
 		},
 	}
 
-	withChaindata(stateGrowthCmd)
 	withRemoteDb(stateGrowthCmd)
 	rootCmd.AddCommand(stateGrowthCmd)
 }

--- a/cmd/state/commands/stateless.go
+++ b/cmd/state/commands/stateless.go
@@ -23,11 +23,18 @@ var (
 	blockSource       string
 )
 
+func withBlocksource(cmd *cobra.Command) {
+	cmd.Flags().StringVar(&blockSource, "blockSource", "", "Path to the block source: `db:///path/to/chaindata` or `exportfile:///path/to/my/exportfile`")
+	if err := cmd.MarkFlagRequired("blockSource"); err != nil {
+		panic(err)
+	}
+}
+
 func init() {
 	withStatsfile(statelessCmd)
 	withBlock(statelessCmd)
+	withBlocksource(statelessCmd)
 
-	statelessCmd.Flags().StringVar(&blockSource, "blockSource", "", "Path to the block source: `db:///path/to/chaindata` or `exportfile:///path/to/my/exportfile`")
 	statelessCmd.Flags().StringVar(&statefile, "statefile", "state", "path to the file where the state will be periodically written during the analysis")
 	statelessCmd.Flags().Uint32Var(&triesize, "triesize", 4*1024*1024, "maximum size of a trie in bytes")
 	statelessCmd.Flags().BoolVar(&preroot, "preroot", false, "Attempt to compute hash of the trie without modifying it")

--- a/cmd/state/commands/verify_snapshot.go
+++ b/cmd/state/commands/verify_snapshot.go
@@ -5,9 +5,18 @@ import (
 	"github.com/spf13/cobra"
 )
 
+var (
+	snapshotPath string
+)
+
 func init() {
-	withBlock(verifySnapshotCmd)
-	withChaindata(verifySnapshotCmd)
+	verifySnapshotCmd.Flags().StringVar(&snapshotPath, "snapshot", "snapshot", "Path to the snapshot to verify")
+	if err := verifySnapshotCmd.MarkFlagFilename("snapshot", ""); err != nil {
+		panic(err)
+	}
+	if err := verifySnapshotCmd.MarkFlagRequired("snapshot"); err != nil {
+		panic(err)
+	}
 	rootCmd.AddCommand(verifySnapshotCmd)
 }
 
@@ -15,7 +24,7 @@ var verifySnapshotCmd = &cobra.Command{
 	Use:   "verifySnapshot",
 	Short: "Verifies snapshots made by the 'stateless' action",
 	RunE: func(cmd *cobra.Command, args []string) error {
-		stateless.VerifySnapshot(block, chaindata)
+		stateless.VerifySnapshot(snapshotPath)
 		return nil
 	},
 }

--- a/cmd/state/stateless/state_snapshot.go
+++ b/cmd/state/stateless/state_snapshot.go
@@ -402,8 +402,8 @@ func StateSnapshot(blockNum uint64) error {
 	return nil
 }
 
-func VerifySnapshot(blockNum uint64, chaindata string) {
-	ethDb, err := ethdb.NewBoltDatabase(chaindata)
+func VerifySnapshot(path string) {
+	ethDb, err := ethdb.NewBoltDatabase(path)
 	check(err)
 	defer ethDb.Close()
 	hash := rawdb.ReadHeadBlockHash(ethDb)


### PR DESCRIPTION
Also remove unnecessary arguments from the stateless prototype sub-commands.