### PR TITLE
Metrics server without pprof

### DIFF
--- a/cmd/prometheus/docker-compose.yml
+++ b/cmd/prometheus/docker-compose.yml
@@ -3,7 +3,6 @@ version: '2.2'
 services:
 
   turbo-geth:
-    image: turbo-geth:latest
     build: ./../..
     command: --nousb --metrics --metrics.expensive --pprof --pprofaddr=0.0.0.0 --pprofport=6060 --remote-db-listen-addr=0.0.0.0:9999
     stop_grace_period: 2m
@@ -12,6 +11,7 @@ services:
     ports:
       - 30303:30303
       - 8545:8545
+      - 6060:6060
       - 9999:9999
 
   prometheus:
@@ -26,16 +26,12 @@ services:
     image: grafana/grafana
     ports:
       - 3000:3000
-    depends_on:
-      prometheus:
-        condition: service_started
     volumes:
       - ./grafana:/var/lib/grafana
       - ./datasources:/etc/grafana/provisioning/datasources
       - ./dashboards:/etc/grafana/provisioning/dashboards
 
   restapi:
-    image: turbo-geth-restapi:latest
     build:
       context: ./../../
       dockerfile: ./cmd/restapi/Dockerfile
@@ -44,7 +40,6 @@ services:
       - 8080:8080
 
   debugui:
-    image: turbo-geth-debugui:latest
     build: ./../../debug-web-ui
     stdin_open: true
     ports:

--- a/cmd/prometheus/prometheus.yml
+++ b/cmd/prometheus/prometheus.yml
@@ -18,3 +18,5 @@ scrape_configs:
       - targets:
         - turbo-geth:6060
         - host.docker.internal:6060
+        - host.docker.internal:6061
+        - host.docker.internal:6062

--- a/ethdb/kv_abstract_test.go
+++ b/ethdb/kv_abstract_test.go
@@ -21,7 +21,7 @@ func TestManagedTx(t *testing.T) {
 	writeDBs := []ethdb.KV{
 		ethdb.NewBolt().InMem().MustOpen(ctx),
 		ethdb.NewBolt().InMem().MustOpen(ctx), // for remote db
-		//ethdb.NewBadger().InMem().MustOpen(ctx),
+		ethdb.NewBadger().InMem().MustOpen(ctx),
 	}
 
 	serverIn, clientOut := io.Pipe()
@@ -30,7 +30,7 @@ func TestManagedTx(t *testing.T) {
 	readDBs := []ethdb.KV{
 		writeDBs[0],
 		ethdb.NewRemote().InMem(clientIn, clientOut).MustOpen(ctx),
-		//writeDBs[2],
+		writeDBs[2],
 	}
 
 	serverCtx, serverCancel := context.WithCancel(ctx)

--- a/ethdb/kv_abstract_test.go
+++ b/ethdb/kv_abstract_test.go
@@ -56,6 +56,7 @@ func TestManagedTx(t *testing.T) {
 
 	for _, db := range writeDBs {
 		db := db
+
 		if err := db.Update(ctx, func(tx ethdb.Tx) error {
 			b := tx.Bucket(dbutils.AccountsBucket)
 			for i := uint8(0); i < 10; i++ {

--- a/ethdb/kv_abstract_test.go
+++ b/ethdb/kv_abstract_test.go
@@ -56,7 +56,6 @@ func TestManagedTx(t *testing.T) {
 
 	for _, db := range writeDBs {
 		db := db
-
 		if err := db.Update(ctx, func(tx ethdb.Tx) error {
 			b := tx.Bucket(dbutils.AccountsBucket)
 			for i := uint8(0); i < 10; i++ {

--- a/metrics/exp/exp.go
+++ b/metrics/exp/exp.go
@@ -36,14 +36,14 @@ func (exp *exp) expHandler(w http.ResponseWriter, r *http.Request) {
 }
 
 // Exp will register an expvar powered metrics handler with http.DefaultServeMux on "/debug/vars"
-func Exp(r metrics.Registry) {
+func Exp(r metrics.Registry, mux *http.ServeMux) {
 	h := ExpHandler(r)
 	// this would cause a panic:
 	// panic: http: multiple registrations for /debug/vars
 	// http.HandleFunc("/debug/vars", e.expHandler)
 	// haven't found an elegant way, so just use a different endpoint
-	http.Handle("/debug/metrics", h)
-	http.Handle("/debug/metrics/prometheus", prometheus.Handler(r))
+	mux.Handle("/debug/metrics", h)
+	mux.Handle("/debug/metrics/prometheus", prometheus.Handler(r))
 }
 
 // ExpHandler will return an expvar powered metrics handler.


### PR DESCRIPTION
Now: `--metrics` doesn't depend on `--pprof` 