### PR TITLE
Fix hash mismatch at block 76328

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,4 @@ profile.cov
 /dashboard/assets/package-lock.json
 
 **/yarn-error.log
+/timings.txt

--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,5 @@ profile.cov
 
 **/yarn-error.log
 /timings.txt
+right_*.txt
+root_*.txt

--- a/cmd/state/stateless/stateless.go
+++ b/cmd/state/stateless/stateless.go
@@ -198,8 +198,8 @@ func Stateless(
 	engine := ethash.NewFullFaker()
 
 	if blockNum > 1 {
-		bc, err := core.NewBlockChain(stateDb, nil, chainConfig, engine, vm.Config{}, nil)
-		check(err)
+		bc, errBc := core.NewBlockChain(stateDb, nil, chainConfig, engine, vm.Config{}, nil)
+		check(errBc)
 		block := bc.GetBlockByNumber(blockNum - 1)
 		fmt.Printf("Block number: %d\n", blockNum-1)
 		fmt.Printf("Block root hash: %x\n", block.Root())

--- a/cmd/state/stateless/stateless_block_providers.go
+++ b/cmd/state/stateless/stateless_block_providers.go
@@ -74,12 +74,12 @@ func NewBlockProviderFromDb(path string, createDbFunc CreateDbFunc) (BlockProvid
 	}, nil
 }
 
-func (m *BlockChainBlockProvider) Engine() consensus.Engine {
-	return m.bc.Engine()
+func (p *BlockChainBlockProvider) Engine() consensus.Engine {
+	return p.bc.Engine()
 }
 
-func (m *BlockChainBlockProvider) GetHeader(h common.Hash, i uint64) *types.Header {
-	return m.bc.GetHeader(h, i)
+func (p *BlockChainBlockProvider) GetHeader(h common.Hash, i uint64) *types.Header {
+	return p.bc.GetHeader(h, i)
 }
 
 func (p *BlockChainBlockProvider) Close() error {
@@ -156,7 +156,9 @@ func (p *ExportFileBlockProvider) WriteHeader(h *types.Header) {
 	rawdb.WriteHeader(context.TODO(), p.batch, h)
 
 	if p.batch.BatchSize() > 1000 {
-		p.batch.Commit()
+		if _, err := p.batch.Commit(); err != nil {
+			panic(fmt.Errorf("error writing headers: %w", err))
+		}
 		p.batch = nil
 	}
 }
@@ -189,13 +191,13 @@ func (p *ExportFileBlockProvider) NextBlock() (*types.Block, error) {
 	return &b, nil
 }
 
-func (m *ExportFileBlockProvider) Engine() consensus.Engine {
-	return m.engine
+func (p *ExportFileBlockProvider) Engine() consensus.Engine {
+	return p.engine
 }
 
-func (m *ExportFileBlockProvider) GetHeader(h common.Hash, i uint64) *types.Header {
-	if m.batch != nil {
-		return rawdb.ReadHeader(m.batch, h, i)
+func (p *ExportFileBlockProvider) GetHeader(h common.Hash, i uint64) *types.Header {
+	if p.batch != nil {
+		return rawdb.ReadHeader(p.batch, h, i)
 	}
-	return rawdb.ReadHeader(m.headersDb, h, i)
+	return rawdb.ReadHeader(p.headersDb, h, i)
 }

--- a/cmd/state/stateless/stateless_block_providers.go
+++ b/cmd/state/stateless/stateless_block_providers.go
@@ -71,6 +71,7 @@ func NewBlockProviderFromDb(path string, createDbFunc CreateDbFunc) (BlockProvid
 
 	return &BlockChainBlockProvider{
 		bc: chain,
+		db: ethDb,
 	}, nil
 }
 


### PR DESCRIPTION
Block 76328 accesses the header from the block 76327. This access failed because the `ChainContext` that was provided to `ApplyTransaction` was based on `statedb` that didn't yet have this information.

I implemented `ChainContext` interface for `BlockProviders` because they always have this info. For the export file, I also had to make a temp database to store them.