### PR TITLE
Staged Sync: check trie root hash stage

### DIFF
--- a/eth/downloader/stagedsync_downloader.go
+++ b/eth/downloader/stagedsync_downloader.go
@@ -36,7 +36,9 @@ func (d *Downloader) doStagedSyncWithFetchers(p *peerConnection, headersFetchers
 	/*
 	* Stage 3. Execute block bodies w/o calculating trie roots
 	 */
-	if err = d.spawnExecuteBlocksStage(); err != nil {
+	syncHeadNumber := uint64(0)
+	syncHeadNumber, err = d.spawnExecuteBlocksStage()
+	if err != nil {
 		return err
 	}
 
@@ -44,10 +46,10 @@ func (d *Downloader) doStagedSyncWithFetchers(p *peerConnection, headersFetchers
 
 	// Further stages go there
 	log.Info("Sync stage 4/4. Validating final hash")
-	if err = d.spawnCheckFinalHashStage(); err != nil {
+	if err = d.spawnCheckFinalHashStage(syncHeadNumber); err != nil {
 		return err
 	}
-	log.Info("Sync stage 4/4. Validating final hash... NOT IMPLEMENTED")
+	log.Info("Sync stage 4/4. Validating final hash... Complete!")
 
 	return err
 }

--- a/eth/downloader/stagedsync_downloader.go
+++ b/eth/downloader/stagedsync_downloader.go
@@ -44,6 +44,9 @@ func (d *Downloader) doStagedSyncWithFetchers(p *peerConnection, headersFetchers
 
 	// Further stages go there
 	log.Info("Sync stage 4/4. Validating final hash")
+	if err = d.spawnCheckFinalHashStage(); err != nil {
+		return err
+	}
 	log.Info("Sync stage 4/4. Validating final hash... NOT IMPLEMENTED")
 
 	return err

--- a/eth/downloader/stagedsync_stage_execute.go
+++ b/eth/downloader/stagedsync_stage_execute.go
@@ -6,13 +6,13 @@ import (
 	"github.com/ledgerwatch/turbo-geth/log"
 )
 
-func (d *Downloader) spawnExecuteBlocksStage() error {
-	origin, err := GetStageProgress(d.stateDB, Execution)
+func (d *Downloader) spawnExecuteBlocksStage() (uint64, error) {
+	lastProcessedBlockNumber, err := GetStageProgress(d.stateDB, Execution)
 	if err != nil {
-		return err
+		return 0, err
 	}
 
-	currentBlockNumber := origin + 1
+	nextBlockNumber := lastProcessedBlockNumber + 1
 
 	mutation := d.stateDB.NewBatch()
 	defer func() {
@@ -25,37 +25,38 @@ func (d *Downloader) spawnExecuteBlocksStage() error {
 	var incarnationMap = make(map[common.Address]uint64)
 
 	for {
-		block := d.blockchain.GetBlockByNumber(currentBlockNumber)
+		block := d.blockchain.GetBlockByNumber(nextBlockNumber)
 		if block == nil {
 			break
 		}
 
 		stateReader := state.NewDbStateReader(mutation)
-		stateWriter := state.NewDbStateWriter(mutation, currentBlockNumber, incarnationMap)
+		stateWriter := state.NewDbStateWriter(mutation, nextBlockNumber, incarnationMap)
 
-		if currentBlockNumber%1000 == 0 {
-			log.Info("Executed blocks:", "blockNumber", currentBlockNumber)
+		if nextBlockNumber%1000 == 0 {
+			log.Info("Executed blocks:", "blockNumber", nextBlockNumber)
 		}
 
 		// where the magic happens
 		err = d.blockchain.ExecuteBlockEuphemerally(block, stateReader, stateWriter)
 		if err != nil {
-			return err
+			return 0, err
 		}
 
-		if err = SaveStageProgress(mutation, Execution, currentBlockNumber); err != nil {
-			return err
+		if err = SaveStageProgress(mutation, Execution, nextBlockNumber); err != nil {
+			return 0, err
 		}
 
-		currentBlockNumber++
+		nextBlockNumber++
 
 		if mutation.BatchSize() >= mutation.IdealBatchSize() {
 			if _, err = mutation.Commit(); err != nil {
-				return err
+				return 0, err
 			}
 			mutation = d.stateDB.NewBatch()
 			incarnationMap = make(map[common.Address]uint64)
 		}
 	}
-	return nil
+
+	return nextBlockNumber - 1 /* the last processed block */, nil
 }

--- a/eth/downloader/stagedsync_stage_hashcheck.go
+++ b/eth/downloader/stagedsync_stage_hashcheck.go
@@ -39,7 +39,5 @@ func (d *Downloader) spawnCheckFinalHashStage(syncHeadNumber uint64) error {
 		return errors.Wrap(err, "checking root hash failed")
 	}
 
-	SaveStageProgress(d.stateDB, HashCheck, blockNr)
-
-	return nil
+	return SaveStageProgress(d.stateDB, HashCheck, blockNr)
 }

--- a/eth/downloader/stagedsync_stage_hashcheck.go
+++ b/eth/downloader/stagedsync_stage_hashcheck.go
@@ -1,0 +1,33 @@
+package downloader
+
+import (
+	"fmt"
+
+	"github.com/ledgerwatch/turbo-geth/core/state"
+)
+
+func (d *Downloader) spawnCheckFinalHashStage() error {
+	// TODO: fix this
+	syncHeadNumber, err := GetStageProgress(d.stateDB, Execution)
+	if err != nil {
+		return err
+	}
+	fmt.Printf("getting head as %v\n", syncHeadNumber)
+	syncHeadBlock := d.blockchain.GetBlockByNumber(syncHeadNumber)
+
+	fmt.Printf("getting head block as %v\n", syncHeadBlock)
+
+	// make sure that we won't write the the real DB
+	// should never be commited
+	euphemeralMutation := d.stateDB.NewBatch()
+
+	tds := state.NewTrieDbState(syncHeadBlock.Header().Hash(), euphemeralMutation, syncHeadBlock.Header().Number.Uint64())
+
+	_, err = tds.ResolveStateTrie(false, false)
+	fmt.Printf("resolving state trie err=%v\n", err)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/eth/downloader/stagedsync_stage_hashcheck.go
+++ b/eth/downloader/stagedsync_stage_hashcheck.go
@@ -24,6 +24,9 @@ func (d *Downloader) spawnCheckFinalHashStage() error {
 
 	blockNr := syncHeadBlock.Header().Number.Uint64()
 
+	fmt.Printf("HEAD block:\n\thash=%x\n\troot=%x\n\theaderHash=%x\n",
+		syncHeadBlock.Hash(), syncHeadBlock.Root(), syncHeadBlock.Header().Hash())
+
 	tr := trie.New(syncHeadBlock.Root())
 
 	// FIXME: miner of the first block on Ethereum mainnet
@@ -37,10 +40,13 @@ func (d *Downloader) spawnCheckFinalHashStage() error {
 		panic("should need :-D")
 	}
 	r.AddRequest(rr)
-	err = r.ResolveStateful(euphemeralMutation, blockNr, true)
+	err = r.ResolveStateful(euphemeralMutation, blockNr, false)
 	if err != nil {
+		fmt.Printf(" >>>>>> failed root check\n")
 		return err
 	}
+
+	fmt.Printf(" >>>>>> success root check\n")
 
 	return nil
 }

--- a/eth/downloader/stagedsync_stages.go
+++ b/eth/downloader/stagedsync_stages.go
@@ -31,6 +31,7 @@ const (
 	Headers   SyncStage = iota // Headers are downloaded, their Proof-Of-Work validity and chaining is verified
 	Bodies                     // Block bodies are downloaded, TxHash and UncleHash are getting verified, "From" recovered from signatures
 	Execution                  // Executing each block w/o buildinf a trie
+	HashCheck                  // Checking the root hash
 	Finish                     // Nominal stage after all other stages
 )
 


### PR DESCRIPTION
After we executed blocks until N, we build the root hash of the current state and compare it to the block root hash, stored in the header.

That way, we are ensuring that everything was executed correctly. It is very unlikely that we can get the same root hash for the trie at the block N, but with a different path.