### PR TITLE
Issue 489 stateless prototype resume

### DIFF
--- a/cmd/state/stateless/stateless.go
+++ b/cmd/state/stateless/stateless.go
@@ -198,9 +198,9 @@ func Stateless(
 	engine := ethash.NewFullFaker()
 
 	if blockNum > 1 {
-		bc, errBc := core.NewBlockChain(stateDb, nil, chainConfig, engine, vm.Config{}, nil)
+		blockProvider.FastFwd(blockNum - 1)
+		block, errBc := blockProvider.NextBlock()
 		check(errBc)
-		block := bc.GetBlockByNumber(blockNum - 1)
 		fmt.Printf("Block number: %d\n", blockNum-1)
 		fmt.Printf("Block root hash: %x\n", block.Root())
 		preRoot = block.Root()
@@ -518,6 +518,6 @@ func Stateless(
 		}
 	}
 	fmt.Printf("Processed %d blocks\n", blockNum)
-	fmt.Printf("Next time specify -block %d\n", blockNum)
+	fmt.Printf("Next time specify --block %d\n", blockNum)
 	fmt.Printf("Stateless client analysis took %s\n", time.Since(startTime))
 }

--- a/cmd/state/stateless/stateless.go
+++ b/cmd/state/stateless/stateless.go
@@ -198,7 +198,9 @@ func Stateless(
 	engine := ethash.NewFullFaker()
 
 	if blockNum > 1 {
-		blockProvider.FastFwd(blockNum - 1)
+		if errBc := blockProvider.FastFwd(blockNum - 1); errBc != nil {
+			check(errBc)
+		}
 		block, errBc := blockProvider.NextBlock()
 		check(errBc)
 		fmt.Printf("Block number: %d\n", blockNum-1)

--- a/cmd/state/stateless/stateless_block_providers.go
+++ b/cmd/state/stateless/stateless_block_providers.go
@@ -100,11 +100,13 @@ func (p *BlockChainBlockProvider) NextBlock() (*types.Block, error) {
 }
 
 type ExportFileBlockProvider struct {
-	stream    *rlp.Stream
-	engine    consensus.Engine
-	headersDb ethdb.Database
-	batch     ethdb.DbWithPendingMutations
-	fh        io.Closer
+	stream          *rlp.Stream
+	engine          consensus.Engine
+	headersDb       ethdb.Database
+	batch           ethdb.DbWithPendingMutations
+	fh              *os.File
+	reader          io.Reader
+	lastBlockNumber uint64
 }
 
 func NewBlockProviderFromExportFile(fn string) (BlockProvider, error) {
@@ -124,7 +126,7 @@ func NewBlockProviderFromExportFile(fn string) (BlockProvider, error) {
 	engine := ethash.NewFullFaker()
 	// keeping all the past block headers in memory
 	headersDb := mustCreateTempDatabase()
-	return &ExportFileBlockProvider{stream, engine, headersDb, nil, fh}, nil
+	return &ExportFileBlockProvider{stream, engine, headersDb, nil, fh, reader, 0}, nil
 }
 
 func getTempFileName() string {
@@ -164,7 +166,27 @@ func (p *ExportFileBlockProvider) WriteHeader(h *types.Header) {
 	}
 }
 
+func (p *ExportFileBlockProvider) resetStream() {
+	p.fh.Seek(0, 0)
+	if p.reader != p.fh {
+		p.reader.(*gzip.Reader).Reset(p.fh)
+	}
+	p.stream = rlp.NewStream(p.reader, 0)
+	p.lastBlockNumber = 0
+}
+
 func (p *ExportFileBlockProvider) FastFwd(to uint64) error {
+	if to == 0 {
+		fmt.Println("fastfwd: reseting stream")
+		p.resetStream()
+	}
+	if p.lastBlockNumber == to-1 {
+		fmt.Println("fastfwd: nothing to do there")
+		return nil
+	} else if p.lastBlockNumber > to-1 {
+		fmt.Println("fastfwd: resetting stream")
+		p.resetStream()
+	}
 	var b types.Block
 	for {
 		if err := p.stream.Decode(&b); err == io.EOF {
@@ -173,6 +195,7 @@ func (p *ExportFileBlockProvider) FastFwd(to uint64) error {
 			return fmt.Errorf("error fast fwd: %v", err)
 		} else {
 			p.WriteHeader(b.Header())
+			p.lastBlockNumber = b.NumberU64()
 			if b.NumberU64() >= to-1 {
 				return nil
 			}
@@ -188,6 +211,7 @@ func (p *ExportFileBlockProvider) NextBlock() (*types.Block, error) {
 		return nil, fmt.Errorf("error fast fwd: %v", err)
 	}
 
+	p.lastBlockNumber = b.NumberU64()
 	p.WriteHeader(b.Header())
 	return &b, nil
 }


### PR DESCRIPTION
fixes #489

As I figured out, we don't store blocks in the state snapshot, only the current state.
Now we get pre-root from the block provider.

NB! if you use an export file, there still can be issues due to the fact that the headers database is re-created every time.