### PR TITLE
Parallel signature verification

### DIFF
--- a/core/types/transaction_signing.go
+++ b/core/types/transaction_signing.go
@@ -168,7 +168,7 @@ func (s EIP155Signer) ChainId() *big.Int {
 // homestead rules.
 type HomesteadSigner struct{ FrontierSigner }
 
-func (s HomesteadSigner) Equal(s2 Signer) bool {
+func (hs HomesteadSigner) Equal(s2 Signer) bool {
 	_, ok := s2.(HomesteadSigner)
 	return ok
 }
@@ -189,7 +189,7 @@ func (hs HomesteadSigner) SenderWithContext(context *secp256k1.Context, tx *Tran
 
 type FrontierSigner struct{}
 
-func (s FrontierSigner) Equal(s2 Signer) bool {
+func (fs FrontierSigner) Equal(s2 Signer) bool {
 	_, ok := s2.(FrontierSigner)
 	return ok
 }

--- a/crypto/secp256k1/secp256.go
+++ b/crypto/secp256k1/secp256.go
@@ -46,15 +46,15 @@ func init() {
 func initContext() *C.secp256k1_context {
 	fmt.Println("init context called")
 	// around 20 ms on a modern CPU.
-	context := C.secp256k1_context_create_sign_verify()
-	C.secp256k1_context_set_illegal_callback(context, C.callbackFunc(C.secp256k1GoPanicIllegal), nil)
-	C.secp256k1_context_set_error_callback(context, C.callbackFunc(C.secp256k1GoPanicError), nil)
+	ctx := C.secp256k1_context_create_sign_verify()
+	C.secp256k1_context_set_illegal_callback(ctx, C.callbackFunc(C.secp256k1GoPanicIllegal), nil)
+	C.secp256k1_context_set_error_callback(ctx, C.callbackFunc(C.secp256k1GoPanicError), nil)
 	return context
 }
 
 func NewContext() *Context {
-	context := initContext()
-	return &Context{context}
+	ctx := initContext()
+	return &Context{ctx}
 }
 
 var (

--- a/crypto/secp256k1/secp256.go
+++ b/crypto/secp256k1/secp256.go
@@ -47,7 +47,7 @@ func initContext() *C.secp256k1_context {
 	ctx := C.secp256k1_context_create_sign_verify()
 	C.secp256k1_context_set_illegal_callback(ctx, C.callbackFunc(C.secp256k1GoPanicIllegal), nil)
 	C.secp256k1_context_set_error_callback(ctx, C.callbackFunc(C.secp256k1GoPanicError), nil)
-	return context
+	return ctx
 }
 
 func NewContext() *Context {

--- a/crypto/secp256k1/secp256.go
+++ b/crypto/secp256k1/secp256.go
@@ -52,6 +52,11 @@ func initContext() *C.secp256k1_context {
 	return context
 }
 
+func NewContext() *Context {
+	context := initContext()
+	return &Context{context}
+}
+
 var (
 	ErrInvalidMsgLen       = errors.New("invalid message length, need 32 bytes")
 	ErrInvalidSignatureLen = errors.New("invalid signature length")

--- a/crypto/secp256k1/secp256.go
+++ b/crypto/secp256k1/secp256.go
@@ -26,7 +26,6 @@ import "C"
 
 import (
 	"errors"
-	"fmt"
 	"math/big"
 	"unsafe"
 )
@@ -44,7 +43,6 @@ func init() {
 }
 
 func initContext() *C.secp256k1_context {
-	fmt.Println("init context called")
 	// around 20 ms on a modern CPU.
 	ctx := C.secp256k1_context_create_sign_verify()
 	C.secp256k1_context_set_illegal_callback(ctx, C.callbackFunc(C.secp256k1GoPanicIllegal), nil)

--- a/crypto/signature_cgo.go
+++ b/crypto/signature_cgo.go
@@ -32,6 +32,11 @@ func Ecrecover(hash, sig []byte) ([]byte, error) {
 	return secp256k1.RecoverPubkey(hash, sig)
 }
 
+// Ecrecover returns the uncompressed public key that created the given signature.
+func EcrecoverWithContext(context *secp256k1.Context, hash, sig []byte) ([]byte, error) {
+	return secp256k1.RecoverPubkeyWithContext(context, hash, sig)
+}
+
 // SigToPub returns the public key that created the given signature.
 func SigToPub(hash, sig []byte) (*ecdsa.PublicKey, error) {
 	s, err := Ecrecover(hash, sig)

--- a/eth/downloader/stagedsync_state_senders.go
+++ b/eth/downloader/stagedsync_state_senders.go
@@ -11,6 +11,7 @@ import (
 	"github.com/ledgerwatch/turbo-geth/common"
 	"github.com/ledgerwatch/turbo-geth/core/rawdb"
 	"github.com/ledgerwatch/turbo-geth/core/types"
+	"github.com/ledgerwatch/turbo-geth/crypto/secp256k1"
 	"github.com/ledgerwatch/turbo-geth/log"
 )
 
@@ -108,6 +109,7 @@ type senderRecoveryJob struct {
 }
 
 func recoverSenders(in chan *senderRecoveryJob, out chan *senderRecoveryJob) {
+	cryptoContext := secp256k1.NewContext()
 	var job *senderRecoveryJob
 	for {
 		job = <-in
@@ -115,7 +117,7 @@ func recoverSenders(in chan *senderRecoveryJob, out chan *senderRecoveryJob) {
 			return
 		}
 		for _, tx := range job.blockBody.Transactions {
-			from, err := types.Sender(job.signer, tx)
+			from, err := job.signer.SenderWithContext(cryptoContext, tx)
 			if err != nil {
 				job.err = errors.Wrap(err, fmt.Sprintf("error recovering sender for tx=%x\n", tx.Hash()))
 				break

--- a/ethclient/signer.go
+++ b/ethclient/signer.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/ledgerwatch/turbo-geth/common"
 	"github.com/ledgerwatch/turbo-geth/core/types"
+	"github.com/ledgerwatch/turbo-geth/crypto/secp256k1"
 )
 
 // senderFromServer is a types.Signer that remembers the sender address returned by the RPC
@@ -45,6 +46,10 @@ func (s *senderFromServer) Equal(other types.Signer) bool {
 }
 
 func (s *senderFromServer) Sender(tx *types.Transaction) (common.Address, error) {
+	return s.SenderWithContext(nil, tx)
+}
+
+func (s *senderFromServer) SenderWithContext(_ *secp256k1.Context, tx *types.Transaction) (common.Address, error) {
 	if s.blockhash == (common.Hash{}) {
 		return common.Address{}, errNotCached
 	}


### PR DESCRIPTION
an attempt to fix a bottleneck when `secp256k1_context` was shared between goroutines, possibly making the procedure "less parallel" than we would like too