### PR TITLE
IH: don't check parent type and avoid store EmptyRoot

### DIFF
--- a/core/state/intermediate_hashes.go
+++ b/core/state/intermediate_hashes.go
@@ -40,7 +40,7 @@ func (ih *IntermediateHashes) WillUnloadBranchNode(prefixAsNibbles []byte, nodeH
 	trie.CompressNibbles(prefixAsNibbles, &buf.B)
 
 	var key []byte
-	if len(buf.B) > common.HashLength {
+	if len(buf.B) >= common.HashLength {
 		key = dbutils.GenerateCompositeStoragePrefix(buf.B[:common.HashLength], incarnation, buf.B[common.HashLength:])
 	} else {
 		key = common.CopyBytes(buf.B)
@@ -63,7 +63,7 @@ func (ih *IntermediateHashes) BranchNodeLoaded(prefixAsNibbles []byte, incarnati
 	trie.CompressNibbles(prefixAsNibbles, &buf.B)
 
 	var key []byte
-	if len(buf.B) > common.HashLength {
+	if len(buf.B) >= common.HashLength {
 		key = dbutils.GenerateCompositeStoragePrefix(buf.B[:common.HashLength], incarnation, buf.B[common.HashLength:])
 	} else {
 		key = common.CopyBytes(buf.B)

--- a/trie/trie.go
+++ b/trie/trie.go
@@ -1208,13 +1208,19 @@ func (t *Trie) EvictNode(hex []byte) {
 	hnode := hashNode(hn[:])
 	t.observers.WillUnloadNode(hex, hn)
 
+	switch nd.(type) {
+	case *fullNode, *duoNode:
+		t.observers.WillUnloadBranchNode(hex, hn, incarnation)
+	default:
+		// nothing to do
+	}
+
 	switch p := parent.(type) {
 	case nil:
 		t.root = hnode
 	case *shortNode:
 		p.Val = hnode
 	case *duoNode:
-		t.observers.WillUnloadBranchNode(hex, hn, incarnation)
 		i1, i2 := p.childrenIdx()
 		switch hex[len(hex)-1] {
 		case i1:
@@ -1223,7 +1229,6 @@ func (t *Trie) EvictNode(hex []byte) {
 			p.child2 = hnode
 		}
 	case *fullNode:
-		t.observers.WillUnloadBranchNode(hex, hn, incarnation)
 		idx := hex[len(hex)-1]
 		p.Children[idx] = hnode
 	case *accountNode:


### PR DESCRIPTION
- parent node type - doesn't matter for IH - just check that node itself is fullNode or duoNode is enough (I introduced this check very long time ago, I think it "hided" some bug in resolver - after removal always had problems with resolving, but now looks like it works)
- in unloading - 64 nibbles - it's hex of a.storage, but not a - then 64 nibbles hex must be stored in IH with incarnation
- EmptyRoot can't come to `WillUnloadBranchNode` method - because if account has no storage - then accountNode will have no branches in a.storage, a.storage will equal to `hashNode(EmptyRoot)` - and we don't unload hashNodes (only fullNode/duoNode). 

- I wonder if next assertion needed?
```go
if len(prefixAsNibbles) == 64 && nodeHash == trie.EmptyRoot {
	panic("unexpected input of WillUnloadBranchNode method, only fullNode/duoNode can be unloaded")
}	
```