### PR TITLE
Optimise resolver

### DIFF
--- a/cmd/hack/hack.go
+++ b/cmd/hack/hack.go
@@ -821,15 +821,15 @@ func testResolve(chaindata string) {
 		prevBlock := bc.GetBlockByNumber(currentBlockNr - 2)
 		fmt.Printf("Prev block root hash: %x\n", prevBlock.Root())
 	*/
-	currentBlockNr := uint64(2792476)
+	currentBlockNr := uint64(286798)
 	var contract []byte
 	//contract = common.FromHex("8416044c93d8fdf2d06a5bddbea65234695a3d4d278d5c824776c8b31702505dfffffffffffffffe")
 	r := trie.NewResolver(currentBlockNr)
 	var key []byte
-	key = common.FromHex("03000901060b000504000f0d0f07040b010b0e0f030d010a09070e010002080800060301070401030601020b0d0f0300040f0f070f0a0e0c020b06050507020f")
-	resolveHash := common.FromHex("d7fda3e6f7cac10aa7c0756d91deda9e8bc5728bca544457555ef59ac05d8f7c")
+	key = common.FromHex("0a080d05070c0604040302030508050100020105040e05080c0a0f030d0d050f08070a050b0c08090b02040e0e0200030f0c0b0f0704060a0d0703050009010f")
+	resolveHash := common.FromHex("321131c74d582ebe29075d573023accd809234e4dbdee29e814bacedd3467279")
 	t := trie.New(common.Hash{})
-	req := t.NewResolveRequest(contract, key, 4, resolveHash)
+	req := t.NewResolveRequest(contract, key, 3, resolveHash)
 	r.AddRequest(req)
 	err = r.ResolveWithDb(ethDb, currentBlockNr, true)
 	if err != nil {

--- a/trie/resolver_stateful.go
+++ b/trie/resolver_stateful.go
@@ -423,96 +423,53 @@ func (tr *ResolverStateful) WalkerStorage(isIH bool, keyIdx int, k, v []byte) er
 		fmt.Printf("WalkerStorage: isIH=%v keyIdx=%d key=%x value=%x\n", isIH, keyIdx, k, v)
 	}
 
-	if keyIdx != tr.keyIdx {
-		if err := tr.finaliseRoot(); err != nil {
+	tr.currStorage.Reset()
+	tr.currStorage.Write(tr.succStorage.Bytes())
+	tr.succStorage.Reset()
+	skip := tr.currentReq.extResolvePos // how many first nibbles to skip
+
+	if skip < 80 {
+		skip = 80
+	}
+
+	i := 0
+	for _, b := range k {
+		if i >= skip {
+			tr.succStorage.WriteByte(b / 16)
+		}
+		i++
+		if i >= skip {
+			tr.succStorage.WriteByte(b % 16)
+		}
+		i++
+	}
+
+	if !isIH {
+		tr.succStorage.WriteByte(16)
+	}
+
+	if tr.currStorage.Len() > 0 {
+		var err error
+		var data GenStructStepData
+		if tr.trace {
+			fmt.Printf("tr.wasIHStorage=%t\n", tr.wasIHStorage)
+		}
+		if tr.wasIHStorage {
+			tr.hashData.Hash = common.BytesToHash(tr.valueStorage.Bytes())
+			data = &tr.hashData
+		} else {
+			tr.leafData.Value = rlphacks.RlpSerializableBytes(tr.valueStorage.Bytes())
+			data = &tr.leafData
+		}
+		tr.groupsStorage, err = GenStructStep(tr.rssChopped[tr.keyIdx].HashOnly, tr.currStorage.Bytes(), tr.succStorage.Bytes(), tr.hbStorage, data, tr.groupsStorage, false)
+		if err != nil {
 			return err
 		}
-		tr.hb.Reset()
-		tr.wasIH = false
-		tr.groups = nil
-		tr.keyIdx = keyIdx
-		tr.currentReq = tr.requests[tr.reqIndices[keyIdx]]
-		tr.currentRs = tr.rss[keyIdx]
-		tr.currentRsChopped = tr.rssChopped[keyIdx]
-		tr.curr.Reset()
-		tr.hbStorage.Reset()
-		tr.wasIHStorage = false
-		if tr.trace {
-			fmt.Printf("Reset hbStorage from WalkerStorage\n")
-		}
-		tr.groupsStorage = nil
-		tr.currStorage.Reset()
-		tr.succStorage.Reset()
-		tr.seenAccount = false
 	}
-
-	// skip storage keys:
-	// - if it has wrong incarnation
-	// - if it abandoned (account deleted)
-	if tr.seenAccount && tr.a.Incarnation == 0 { // skip all storage if incarnation is 0
-		if tr.trace {
-			fmt.Printf("WalkerStorage: skip %x, because 0 incarnation\n", k)
-		}
-		return nil
-	}
-
-	// skip ih or storage if it has another incarnation
-	if !bytes.HasPrefix(k, tr.accAddrHashWithInc) {
-		if tr.trace {
-			fmt.Printf("WalkerStorage: skip, not match accWithInc=%x\n", tr.accAddrHashWithInc)
-		}
-		return nil
-	}
-
-	if len(v) > 0 {
-		tr.currStorage.Reset()
-		tr.currStorage.Write(tr.succStorage.Bytes())
-		tr.succStorage.Reset()
-		skip := tr.currentReq.extResolvePos // how many first nibbles to skip
-
-		if skip < 80 {
-			skip = 80
-		}
-
-		i := 0
-		for _, b := range k {
-			if i >= skip {
-				tr.succStorage.WriteByte(b / 16)
-			}
-			i++
-			if i >= skip {
-				tr.succStorage.WriteByte(b % 16)
-			}
-			i++
-		}
-
-		if !isIH {
-			tr.succStorage.WriteByte(16)
-		}
-
-		if tr.currStorage.Len() > 0 {
-			var err error
-			var data GenStructStepData
-			if tr.trace {
-				fmt.Printf("tr.wasIHStorage=%t\n", tr.wasIHStorage)
-			}
-			if tr.wasIHStorage {
-				tr.hashData.Hash = common.BytesToHash(tr.valueStorage.Bytes())
-				data = &tr.hashData
-			} else {
-				tr.leafData.Value = rlphacks.RlpSerializableBytes(tr.valueStorage.Bytes())
-				data = &tr.leafData
-			}
-			tr.groupsStorage, err = GenStructStep(tr.rssChopped[tr.keyIdx].HashOnly, tr.currStorage.Bytes(), tr.succStorage.Bytes(), tr.hbStorage, data, tr.groupsStorage, false)
-			if err != nil {
-				return err
-			}
-		}
-		// Remember the current key and value
-		tr.wasIHStorage = isIH
-		tr.valueStorage.Reset()
-		tr.valueStorage.Write(v)
-	}
+	// Remember the current key and value
+	tr.wasIHStorage = isIH
+	tr.valueStorage.Reset()
+	tr.valueStorage.Write(v)
 
 	return nil
 }
@@ -523,144 +480,119 @@ func (tr *ResolverStateful) WalkerAccount(isIH bool, keyIdx int, k, v []byte) er
 		fmt.Printf("WalkerAccount: isIH=%v keyIdx=%d key=%x value=%x\n", isIH, keyIdx, k, v)
 	}
 
-	if keyIdx != tr.keyIdx {
-		if err := tr.finaliseRoot(); err != nil {
-			return err
-		}
-		tr.hb.Reset()
-		tr.wasIH = false
-		tr.groups = nil
-		tr.keyIdx = keyIdx
-		tr.currentReq = tr.requests[tr.reqIndices[keyIdx]]
-		tr.currentRs = tr.rss[keyIdx]
-		tr.currentRsChopped = tr.rssChopped[keyIdx]
-		tr.curr.Reset()
+	tr.curr.Reset()
+	tr.curr.Write(tr.succ.Bytes())
+	tr.succ.Reset()
+	skip := tr.currentReq.extResolvePos // how many first nibbles to skip
 
+	i := 0
+	for _, b := range k {
+		if i >= skip {
+			tr.succ.WriteByte(b / 16)
+		}
+		i++
+		if i >= skip {
+			tr.succ.WriteByte(b % 16)
+		}
+		i++
+	}
+
+	if !isIH {
+		tr.succ.WriteByte(16)
+	}
+
+	if tr.curr.Len() > 0 {
+		var err error
+		var data GenStructStepData
+		if tr.wasIH {
+			tr.hashData.Hash = common.BytesToHash(tr.value.Bytes())
+			data = &tr.hashData
+		} else {
+			var storageNode node
+			if tr.a.Incarnation == 0 {
+				tr.a.Root = EmptyRoot
+			} else {
+				if tr.trace {
+					fmt.Printf("Finalising storage root for %x\n", tr.accAddrHashWithInc)
+				}
+				err = tr.finaliseStorageRoot()
+				if err != nil {
+					return err
+				}
+
+				if tr.hbStorage.hasRoot() {
+					tr.a.Root.SetBytes(tr.hbStorage.rootHash().Bytes())
+					storageNode = tr.hbStorage.root()
+					if tr.trace {
+						fmt.Printf("Got root: %x\n", tr.a.Root)
+					}
+				} else {
+					tr.a.Root = EmptyRoot
+					if tr.trace {
+						fmt.Printf("Got empty root\n")
+					}
+				}
+			}
+			tr.accData.FieldSet = 0
+			if !tr.a.IsEmptyCodeHash() {
+				tr.accData.FieldSet |= AccountFieldCodeOnly
+			}
+			if storageNode != nil || !tr.a.IsEmptyRoot() {
+				tr.accData.FieldSet |= AccountFieldStorageOnly
+			}
+
+			tr.accData.Balance.Set(&tr.a.Balance)
+			if tr.a.Balance.Sign() != 0 {
+				tr.accData.FieldSet |= AccountFieldBalanceOnly
+			}
+			tr.accData.Nonce = tr.a.Nonce
+			if tr.a.Nonce != 0 {
+				tr.accData.FieldSet |= AccountFieldNonceOnly
+			}
+			tr.accData.Incarnation = tr.a.Incarnation
+			data = &tr.accData
+			if !tr.a.IsEmptyCodeHash() {
+				// the first item ends up deepest on the stack, the second item - on the top
+				err = tr.hb.hash(tr.a.CodeHash[:])
+				if err != nil {
+					return err
+				}
+			}
+			if storageNode != nil || !tr.a.IsEmptyRoot() {
+				tr.hb.hashStack = append(tr.hb.hashStack, 0x80+common.HashLength)
+				tr.hb.hashStack = append(tr.hb.hashStack, tr.a.Root[:]...)
+				tr.hb.nodeStack = append(tr.hb.nodeStack, storageNode)
+			}
+		}
 		tr.hbStorage.Reset()
 		tr.wasIHStorage = false
 		if tr.trace {
-			//fmt.Printf("Reset hbStorage from WalkerAccount\n")
+			//fmt.Printf("Reset hbStorage from WalkerAccount - past\n")
 		}
 		tr.groupsStorage = nil
 		tr.currStorage.Reset()
 		tr.succStorage.Reset()
+		tr.groups, err = GenStructStep(tr.currentRsChopped.HashOnly, tr.curr.Bytes(), tr.succ.Bytes(), tr.hb, data, tr.groups, false)
+		if err != nil {
+			return err
+		}
+	}
+	// Remember the current key and value
+	tr.wasIH = isIH
+
+	if isIH {
+		tr.value.Reset()
+		tr.value.Write(v)
 		tr.seenAccount = false
+		return nil
 	}
-	if len(v) > 0 {
-		tr.curr.Reset()
-		tr.curr.Write(tr.succ.Bytes())
-		tr.succ.Reset()
-		skip := tr.currentReq.extResolvePos // how many first nibbles to skip
 
-		i := 0
-		for _, b := range k {
-			if i >= skip {
-				tr.succ.WriteByte(b / 16)
-			}
-			i++
-			if i >= skip {
-				tr.succ.WriteByte(b % 16)
-			}
-			i++
-		}
-
-		if !isIH {
-			tr.succ.WriteByte(16)
-		}
-
-		if tr.curr.Len() > 0 {
-			var err error
-			var data GenStructStepData
-			if tr.wasIH {
-				tr.hashData.Hash = common.BytesToHash(tr.value.Bytes())
-				data = &tr.hashData
-			} else {
-				var storageNode node
-				if tr.a.Incarnation == 0 {
-					tr.a.Root = EmptyRoot
-				} else {
-					if tr.trace {
-						fmt.Printf("Finalising storage root for %x\n", tr.accAddrHashWithInc)
-					}
-					err = tr.finaliseStorageRoot()
-					if err != nil {
-						return err
-					}
-
-					if tr.hbStorage.hasRoot() {
-						tr.a.Root.SetBytes(tr.hbStorage.rootHash().Bytes())
-						storageNode = tr.hbStorage.root()
-						if tr.trace {
-							fmt.Printf("Got root: %x\n", tr.a.Root)
-						}
-					} else {
-						tr.a.Root = EmptyRoot
-						if tr.trace {
-							fmt.Printf("Got empty root\n")
-						}
-					}
-				}
-				tr.accData.FieldSet = 0
-				if !tr.a.IsEmptyCodeHash() {
-					tr.accData.FieldSet |= AccountFieldCodeOnly
-				}
-				if storageNode != nil || !tr.a.IsEmptyRoot() {
-					tr.accData.FieldSet |= AccountFieldStorageOnly
-				}
-
-				tr.accData.Balance.Set(&tr.a.Balance)
-				if tr.a.Balance.Sign() != 0 {
-					tr.accData.FieldSet |= AccountFieldBalanceOnly
-				}
-				tr.accData.Nonce = tr.a.Nonce
-				if tr.a.Nonce != 0 {
-					tr.accData.FieldSet |= AccountFieldNonceOnly
-				}
-				tr.accData.Incarnation = tr.a.Incarnation
-				data = &tr.accData
-				if !tr.a.IsEmptyCodeHash() {
-					// the first item ends up deepest on the stack, the second item - on the top
-					err = tr.hb.hash(tr.a.CodeHash[:])
-					if err != nil {
-						return err
-					}
-				}
-				if storageNode != nil || !tr.a.IsEmptyRoot() {
-					tr.hb.hashStack = append(tr.hb.hashStack, 0x80+common.HashLength)
-					tr.hb.hashStack = append(tr.hb.hashStack, tr.a.Root[:]...)
-					tr.hb.nodeStack = append(tr.hb.nodeStack, storageNode)
-				}
-			}
-			tr.hbStorage.Reset()
-			tr.wasIHStorage = false
-			if tr.trace {
-				//fmt.Printf("Reset hbStorage from WalkerAccount - past\n")
-			}
-			tr.groupsStorage = nil
-			tr.currStorage.Reset()
-			tr.succStorage.Reset()
-			tr.groups, err = GenStructStep(tr.currentRsChopped.HashOnly, tr.curr.Bytes(), tr.succ.Bytes(), tr.hb, data, tr.groups, false)
-			if err != nil {
-				return err
-			}
-		}
-		// Remember the current key and value
-		tr.wasIH = isIH
-
-		if isIH {
-			tr.value.Reset()
-			tr.value.Write(v)
-			tr.seenAccount = false
-			return nil
-		}
-
-		if err := tr.a.DecodeForStorage(v); err != nil {
-			return fmt.Errorf("fail DecodeForStorage: %w", err)
-		}
-		tr.seenAccount = true
-		copy(tr.accAddrHashWithInc, k)
-		binary.BigEndian.PutUint64(tr.accAddrHashWithInc[32:40], ^tr.a.Incarnation)
+	if err := tr.a.DecodeForStorage(v); err != nil {
+		return fmt.Errorf("fail DecodeForStorage: %w", err)
 	}
+	tr.seenAccount = true
+	copy(tr.accAddrHashWithInc, k)
+	binary.BigEndian.PutUint64(tr.accAddrHashWithInc[32:40], ^tr.a.Incarnation)
 
 	return nil
 }
@@ -673,6 +605,8 @@ func (tr *ResolverStateful) MultiWalk2(db *bolt.DB, startkeys [][]byte, fixedbit
 
 	minKeyAsNibbles := pool.GetBuffer(256)
 	defer pool.PutBuffer(minKeyAsNibbles)
+	// Key used to advance to the next account (skip remaining storage)
+	nextAccountKey := make([]byte, 32)
 
 	rangeIdx := 0 // What is the current range we are extracting
 	fixedbytes, mask := ethdb.Bytesmask(fixedbits[rangeIdx])
@@ -681,6 +615,7 @@ func (tr *ResolverStateful) MultiWalk2(db *bolt.DB, startkeys [][]byte, fixedbit
 		// Looking for storage sub-tree
 		copy(tr.accAddrHashWithInc, startkey[:common.HashLength+common.IncarnationLength])
 	}
+
 	err := db.View(func(tx *bolt.Tx) error {
 		ihBucket := tx.Bucket(dbutils.IntermediateTrieHashBucket)
 		var ih *bolt.Cursor
@@ -690,8 +625,12 @@ func (tr *ResolverStateful) MultiWalk2(db *bolt.DB, startkeys [][]byte, fixedbit
 		c := tx.Bucket(dbutils.CurrentStateBucket).Cursor()
 
 		k, v := c.Seek(startkey)
-		if len(startkey) <= common.HashLength {
-			for ; k != nil && len(k) > common.HashLength; k, v = c.Next() {
+		if len(startkey) <= common.HashLength && len(k) > common.HashLength {
+			// Advance past the storage to the first account
+			if nextAccount(k, nextAccountKey) {
+				k, v = c.SeekTo(nextAccountKey)
+			} else {
+				k = nil
 			}
 		}
 		if tr.trace {
@@ -701,6 +640,14 @@ func (tr *ResolverStateful) MultiWalk2(db *bolt.DB, startkeys [][]byte, fixedbit
 		var ihK, ihV []byte
 		if ih != nil {
 			ihK, ihV = ih.Seek(startkey)
+			if len(startkey) <= common.HashLength && len(ihK) > common.HashLength {
+				// Advance past the storage to the first account
+				if nextAccount(ihK, nextAccountKey) {
+					ihK, ihV = ih.SeekTo(nextAccountKey)
+				} else {
+					ihK = nil
+				}
+			}
 		}
 
 		var minKey []byte
@@ -729,13 +676,26 @@ func (tr *ResolverStateful) MultiWalk2(db *bolt.DB, startkeys [][]byte, fixedbit
 						}
 					}
 					if cmp < 0 {
+						// This happens after we have just incremented rangeIdx
 						k, v = c.SeekTo(startkey)
-						if len(startkey) <= common.HashLength {
-							for ; k != nil && len(k) > common.HashLength; k, v = c.Next() {
+						if len(startkey) <= common.HashLength && len(k) > common.HashLength {
+							// Advance past the storage to the first account
+							if nextAccount(k, nextAccountKey) {
+								k, v = c.SeekTo(nextAccountKey)
+							} else {
+								k = nil
 							}
 						}
 						if ih != nil {
 							ihK, ihV = ih.SeekTo(startkey)
+							if len(startkey) <= common.HashLength && len(ihK) > common.HashLength {
+								// Advance to the first account
+								if nextAccount(ihK, nextAccountKey) {
+									ihK, ihV = ih.SeekTo(nextAccountKey)
+								} else {
+									ihK = nil
+								}
+							}
 						}
 						if k == nil && ihK == nil {
 							return nil
@@ -752,16 +712,51 @@ func (tr *ResolverStateful) MultiWalk2(db *bolt.DB, startkeys [][]byte, fixedbit
 							// Looking for storage sub-tree
 							copy(tr.accAddrHashWithInc, startkey[:common.HashLength+common.IncarnationLength])
 						}
+						if err := tr.finaliseRoot(); err != nil {
+							return err
+						}
+						tr.hb.Reset()
+						tr.wasIH = false
+						tr.groups = nil
+						tr.keyIdx = rangeIdx
+						tr.currentReq = tr.requests[tr.reqIndices[rangeIdx]]
+						tr.currentRs = tr.rss[rangeIdx]
+						tr.currentRsChopped = tr.rssChopped[rangeIdx]
+						tr.curr.Reset()
+						tr.hbStorage.Reset()
+						tr.wasIHStorage = false
+						tr.groupsStorage = nil
+						tr.currStorage.Reset()
+						tr.succStorage.Reset()
+						tr.seenAccount = false
 					}
 				}
 			}
 
 			if !isIH {
-				if len(k) > 32 {
+				if len(k) > common.HashLength && !bytes.HasPrefix(k, tr.accAddrHashWithInc) {
+					if bytes.Compare(k, tr.accAddrHashWithInc) < 0 {
+						// Skip all the irrelevant storage in the middle
+						k, v = c.SeekTo(tr.accAddrHashWithInc)
+					} else {
+						if nextAccount(k, nextAccountKey) {
+							k, v = c.SeekTo(nextAccountKey)
+						} else {
+							k = nil
+						}
+					}
+					if k == nil {
+						continue
+					}
+				}
+				if len(k) > common.HashLength {
 					if err := storageWalker(false, rangeIdx, k, v); err != nil {
 						return err
 					}
 					k, v = c.Next()
+					if tr.trace {
+						fmt.Printf("k after storageWalker and Next: %x\n", k)
+					}
 				} else {
 					if err := accWalker(false, rangeIdx, k, v); err != nil {
 						return err
@@ -809,7 +804,22 @@ func (tr *ResolverStateful) MultiWalk2(db *bolt.DB, startkeys [][]byte, fixedbit
 				continue
 			}
 
-			if len(ihK) > 32 {
+			if len(ihK) > common.HashLength && !bytes.HasPrefix(ihK, tr.accAddrHashWithInc) {
+				if bytes.Compare(ihK, tr.accAddrHashWithInc) < 0 {
+					// Skip all the irrelevant storage in the middle
+					ihK, ihV = ih.SeekTo(tr.accAddrHashWithInc)
+				} else {
+					if nextAccount(ihK, nextAccountKey) {
+						ihK, ihV = ih.SeekTo(nextAccountKey)
+					} else {
+						ihK = nil
+					}
+				}
+				if ihK == nil {
+					continue
+				}
+			}
+			if len(ihK) > common.HashLength {
 				if err := storageWalker(true, rangeIdx, ihK, ihV); err != nil {
 					return fmt.Errorf("storageWalker err: %w", err)
 				}
@@ -835,8 +845,12 @@ func (tr *ResolverStateful) MultiWalk2(db *bolt.DB, startkeys [][]byte, fixedbit
 			if !bytes.HasPrefix(k, next) {
 				k, v = c.SeekTo(next)
 			}
-			if len(next) <= common.HashLength {
-				for ; k != nil && len(k) > common.HashLength; k, v = c.Next() {
+			if len(next) <= common.HashLength && len(k) > common.HashLength {
+				// Advance past the storage to the first account
+				if nextAccount(k, nextAccountKey) {
+					k, v = c.SeekTo(nextAccountKey)
+				} else {
+					k = nil
 				}
 			}
 			if tr.trace {
@@ -844,6 +858,14 @@ func (tr *ResolverStateful) MultiWalk2(db *bolt.DB, startkeys [][]byte, fixedbit
 			}
 			if !bytes.HasPrefix(ihK, next) {
 				ihK, ihV = ih.SeekTo(next)
+			}
+			if len(next) <= common.HashLength && len(ihK) > common.HashLength {
+				// Advance past the storage to the first account
+				if nextAccount(ihK, nextAccountKey) {
+					ihK, ihV = ih.SeekTo(nextAccountKey)
+				} else {
+					ihK = nil
+				}
 			}
 			if tr.trace {
 				fmt.Printf("ihK after next: %x\n", ihK)
@@ -867,6 +889,18 @@ func nextSubtree(in []byte) ([]byte, bool) {
 		r[i] = 0
 	}
 	return nil, false
+}
+
+func nextAccount(in, out []byte) bool {
+	copy(out, in)
+	for i := len(out) - 1; i >= 0; i-- {
+		if out[i] != 255 {
+			out[i]++
+			return true
+		}
+		out[i] = 0
+	}
+	return false
 }
 
 // keyIsBefore - kind of bytes.Compare, but nil is the last key. And return

--- a/trie/resolver_stateful.go
+++ b/trie/resolver_stateful.go
@@ -566,9 +566,6 @@ func (tr *ResolverStateful) WalkerAccount(isIH bool, keyIdx int, k, v []byte) er
 		}
 		tr.hbStorage.Reset()
 		tr.wasIHStorage = false
-		if tr.trace {
-			//fmt.Printf("Reset hbStorage from WalkerAccount - past\n")
-		}
 		tr.groupsStorage = nil
 		tr.currStorage.Reset()
 		tr.succStorage.Reset()

--- a/trie/resolver_stateful.go
+++ b/trie/resolver_stateful.go
@@ -742,9 +742,7 @@ func (tr *ResolverStateful) MultiWalk2(db *bolt.DB, startkeys [][]byte, fixedbit
 							k = nil
 						}
 					}
-					if k == nil {
-						continue
-					}
+					continue
 				}
 				if len(k) > common.HashLength {
 					if err := storageWalker(false, rangeIdx, k, v); err != nil {
@@ -812,9 +810,7 @@ func (tr *ResolverStateful) MultiWalk2(db *bolt.DB, startkeys [][]byte, fixedbit
 						ihK = nil
 					}
 				}
-				if ihK == nil {
-					continue
-				}
+				continue
 			}
 			if len(ihK) > common.HashLength {
 				if err := storageWalker(true, rangeIdx, ihK, ihV); err != nil {


### PR DESCRIPTION
This change replaces loops with `cursor.Next()` with calls to `cursor.SeekTo` that would allow the resolver to skip over large ranges of deleted storage items efficiently