### PR TITLE
Start transforming SubTrieLoader into iterator/stream

### DIFF
--- a/cmd/pics/state.go
+++ b/cmd/pics/state.go
@@ -310,6 +310,13 @@ func initialState1() error {
 		// this code generates a log
 		signer = types.HomesteadSigner{}
 	)
+	// Create intermediate hash bucket since it is mandatory now
+	if err := dbBolt.Update(func(tx *bolt.Tx) error {
+		_, err := tx.CreateBucket(dbutils.IntermediateTrieHashBucket, false)
+		return err
+	}); err != nil {
+		return err
+	}
 	snapshotDb := db.MemCopy().(*ethdb.BoltDatabase).KV()
 	genesis := gspec.MustCommit(db)
 	genesisDb := db.MemCopy()

--- a/core/state/database.go
+++ b/core/state/database.go
@@ -554,7 +554,13 @@ func (tds *TrieDbState) resolveAccountAndStorageTouches(accountTouches common.Ha
 	if err != nil {
 		return err
 	}
-	return tds.t.HookSubTries(subTries, hooks)
+	if err := tds.t.HookSubTries(subTries, hooks); err != nil {
+		for i, hash := range subTries.Hashes {
+			log.Error("Info for error", "dbPrefix", dbPrefixes[i], "fixedbits", fixedbits[i], "hash", hash)
+		}
+		return err
+	}
+	return nil
 }
 
 func (tds *TrieDbState) populateAccountBlockProof(accountTouches common.Hashes) {

--- a/core/state/database.go
+++ b/core/state/database.go
@@ -556,7 +556,7 @@ func (tds *TrieDbState) resolveAccountAndStorageTouches(accountTouches common.Ha
 	}
 	if err := tds.t.HookSubTries(subTries, hooks); err != nil {
 		for i, hash := range subTries.Hashes {
-			log.Error("Info for error", "dbPrefix", dbPrefixes[i], "fixedbits", fixedbits[i], "hash", hash)
+			log.Error("Info for error", "dbPrefix", fmt.Sprintf("%x", dbPrefixes[i]), "fixedbits", fixedbits[i], "hash", hash)
 		}
 		return err
 	}

--- a/trie/flatdb_sub_trie_loader.go
+++ b/trie/flatdb_sub_trie_loader.go
@@ -174,6 +174,10 @@ func (fstl *FlatDbSubTrieLoader) iteration(first bool) error {
 			}
 			if cmp < 0 {
 				// This happens after we have just incremented rangeIdx or on the very first iteration
+				if first && len(dbPrefix) > common.HashLength {
+					// Looking for storage sub-tree
+					copy(fstl.accAddrHashWithInc[:], dbPrefix[:common.HashLength+common.IncarnationLength])
+				}
 				fstl.k, fstl.v = fstl.c.SeekTo(dbPrefix)
 				if len(dbPrefix) <= common.HashLength && len(fstl.k) > common.HashLength {
 					// Advance past the storage to the first account

--- a/trie/flatdb_sub_trie_loader.go
+++ b/trie/flatdb_sub_trie_loader.go
@@ -566,7 +566,9 @@ func (fstl *FlatDbSubTrieLoader) LoadSubTries() (SubTries, error) {
 		}
 	}
 	if fstl.tx != nil {
-		fstl.tx.Rollback()
+		if err := fstl.tx.Rollback(); err != nil {
+			return fstl.subTries, err
+		}
 	}
 	if err := fstl.finaliseRoot(fstl.cutoffs[len(fstl.cutoffs)-1]); err != nil {
 		fmt.Println("Err in finalize root, writing down resolve params")

--- a/trie/flatdb_sub_trie_loader.go
+++ b/trie/flatdb_sub_trie_loader.go
@@ -5,7 +5,6 @@ import (
 	"encoding/binary"
 	"fmt"
 	"io"
-	"time"
 
 	"github.com/ledgerwatch/bolt"
 	"github.com/ledgerwatch/turbo-geth/common"
@@ -27,7 +26,7 @@ type FlatDbSubTrieLoader struct {
 	value    bytes.Buffer // Current value to be used as the value tape for the hash builder
 	groups   []uint16
 	hb       *HashBuilder
-	keyIdx   int
+	rangeIdx   int
 	a        accounts.Account
 	leafData GenStructStepLeafData
 	accData  GenStructStepAccountData
@@ -44,19 +43,44 @@ type FlatDbSubTrieLoader struct {
 	valueStorage  bytes.Buffer // Current value to be used as the value tape for the hash builder
 	groupsStorage []uint16
 
-	accAddrHashWithInc []byte // Concatenation of addrHash of the currently build account with its incarnation encoding
+	accAddrHashWithInc [40]byte // Concatenation of addrHash of the currently build account with its incarnation encoding
+	dbPrefixes [][]byte
+	fixedbytes []int
+	masks []byte
+	cutoffs []int
+	tx *bolt.Tx // Manually managed read-only transaction (rolled back when iterator is exhausted)
+	c *bolt.Cursor
+	ih *bolt.Cursor
+	nextAccountKey [32]byte
+	k, v []byte
+	ihK, ihV []byte
+	minKeyAsNibbles bytes.Buffer
+
+	// Storage item buffer
+	storageItemPresent bool
+	storageItemType StreamItem
+	storageKey []byte
+	storageHash []byte
+	storageValue []byte
+
+	// Acount item buffer
+	accountItemPresent bool
+	accountItemType StreamItem
+	accountKey []byte
+	accountHash []byte
+	accountValue *accounts.Account
 }
 
 func NewFlatDbSubTrieLoader() *FlatDbSubTrieLoader {
-	return &FlatDbSubTrieLoader{
+	fstl := &FlatDbSubTrieLoader{
 		hb:                 NewHashBuilder(false),
-		accAddrHashWithInc: make([]byte, 40),
 	}
+	return fstl
 }
 
 // Reset prepares the loader for reuse
-func (fstl *FlatDbSubTrieLoader) Reset() {
-	fstl.keyIdx = 0
+func (fstl *FlatDbSubTrieLoader) Reset(db ethdb.Database, rl *RetainList, dbPrefixes [][]byte, fixedbits []int, trace bool) error {
+	fstl.rangeIdx = 0
 	fstl.rl = NewRetainList(0)
 	fstl.curr.Reset()
 	fstl.succ.Reset()
@@ -69,10 +93,312 @@ func (fstl *FlatDbSubTrieLoader) Reset() {
 	fstl.currStorage.Reset()
 	fstl.succStorage.Reset()
 	fstl.valueStorage.Reset()
+	fstl.minKeyAsNibbles.Reset()
 	fstl.groupsStorage = fstl.groupsStorage[:0]
 	fstl.wasIHStorage = false
 	fstl.subTries = SubTries{}
+	fstl.trace = trace
+	fstl.hb.trace = trace
+	fstl.rl = rl
+	fstl.dbPrefixes = dbPrefixes
+	fstl.storageItemPresent = false
+	fstl.accountItemPresent = false
+	if fstl.trace {
+		fmt.Printf("----------\n")
+		fmt.Printf("RebuildTrie\n")
+	}
+	if fstl.trace {
+		fmt.Printf("fstl.rl: %x\n", fstl.rl.hexes)
+		fmt.Printf("fixedbits: %d\n", fixedbits)
+		fmt.Printf("dbPrefixes(%d): %x\n", len(dbPrefixes), dbPrefixes)
+	}
+	if len(dbPrefixes) == 0 {
+		return nil
+	}
+	var boltDB *bolt.DB
+	if hasBolt, ok := db.(ethdb.HasKV); ok {
+		boltDB = hasBolt.KV()
+	}
+	if boltDB == nil {
+		return fmt.Errorf("only Bolt supported yet, given: %T", db)
+	}
+
+	// Create manually managed read transaction
+	tx, err := boltDB.Begin(false)
+	if err != nil {
+		return fmt.Errorf("opening bolt tx: %v", err)
+	}
+	fstl.tx = tx
+	fixedbytes := make([]int, len(fixedbits))
+	masks := make([]byte, len(fixedbits))
+	cutoffs := make([]int, len(fixedbits))
+	for i, bits := range fixedbits {
+		if bits >= 256 /* addrHash */ +64 /* incarnation */ {
+			cutoffs[i] = bits/4 - 16 // Remove incarnation
+		} else {
+			cutoffs[i] = bits / 4
+		}
+		fixedbytes[i], masks[i] = ethdb.Bytesmask(bits)
+	}
+	fstl.fixedbytes = fixedbytes
+	fstl.masks = masks
+	fstl.cutoffs = cutoffs
+	dbPrefix :=  dbPrefixes[0]
+	if len(dbPrefix) > common.HashLength {
+		// Looking for storage sub-tree
+		copy(fstl.accAddrHashWithInc[:], dbPrefix[:common.HashLength+common.IncarnationLength])
+	}
+
+	ihBucket := tx.Bucket(dbutils.IntermediateTrieHashBucket)
+	if ihBucket != nil {
+		fstl.ih = ihBucket.Cursor()
+	} else {
+		fstl.ih = nil
+	}
+	fstl.c = tx.Bucket(dbutils.CurrentStateBucket).Cursor()
+
+	fstl.k, fstl.v = fstl.c.Seek(dbPrefix)
+	if len(dbPrefix) <= common.HashLength && len(fstl.k) > common.HashLength {
+		// Advance past the storage to the first account
+		if nextAccount(fstl.k, fstl.nextAccountKey[:]) {
+			fstl.k, fstl.v = fstl.c.SeekTo(fstl.nextAccountKey[:])
+		} else {
+			fstl.k = nil
+		}
+	}
+	if fstl.trace {
+		fmt.Printf("c.Seek(%x) = %x\n", dbPrefix, fstl.k)
+	}
+	if fstl.ih != nil {
+		fstl.ihK, fstl.ihV = fstl.ih.Seek(dbPrefix)
+		if len(dbPrefix) <= common.HashLength && len(fstl.ihK) > common.HashLength {
+			// Advance past the storage to the first account
+			if nextAccount(fstl.ihK, fstl.nextAccountKey[:]) {
+				fstl.ihK, fstl.ihV = fstl.ih.SeekTo(fstl.nextAccountKey[:])
+			} else {
+				fstl.ihK = nil
+			}
+		}
+	}
+	return nil
 }
+
+func (fstl *FlatDbSubTrieLoader) iteration() error {
+	isIH, minKey := keyIsBefore(fstl.ihK, fstl.k)
+	fixedbytes := fstl.fixedbytes[fstl.rangeIdx]
+	cutoff := fstl.cutoffs[fstl.rangeIdx]
+	if fixedbytes > 0 {
+		dbPrefix := fstl.dbPrefixes[fstl.rangeIdx]
+		mask := fstl.masks[fstl.rangeIdx]
+		// Adjust rangeIdx if needed
+		cmp := int(-1)
+		for cmp != 0 {
+			if len(minKey) < fixedbytes {
+				cmp = bytes.Compare(minKey, dbPrefix[:len(minKey)])
+				if cmp == 0 {
+					cmp = -1
+				}
+			} else {
+				cmp = bytes.Compare(minKey[:fixedbytes-1], dbPrefix[:fixedbytes-1])
+				if cmp == 0 {
+					k1 := minKey[fixedbytes-1] & mask
+					k2 := dbPrefix[fixedbytes-1] & mask
+					if k1 < k2 {
+						cmp = -1
+					} else if k1 > k2 {
+						cmp = 1
+					}
+				}
+			}
+			if cmp < 0 {
+				// This happens after we have just incremented rangeIdx
+				fstl.k, fstl.v = fstl.c.SeekTo(dbPrefix)
+				if len(dbPrefix) <= common.HashLength && len(fstl.k) > common.HashLength {
+					// Advance past the storage to the first account
+					if nextAccount(fstl.k, fstl.nextAccountKey[:]) {
+						fstl.k, fstl.v = fstl.c.SeekTo(fstl.nextAccountKey[:])
+					} else {
+						fstl.k = nil
+					}
+				}
+				if fstl.ih != nil {
+					fstl.ihK, fstl.ihV = fstl.ih.SeekTo(dbPrefix)
+					if len(dbPrefix) <= common.HashLength && len(fstl.ihK) > common.HashLength {
+						// Advance to the first account
+						if nextAccount(fstl.ihK, fstl.nextAccountKey[:]) {
+							fstl.ihK, fstl.ihV = fstl.ih.SeekTo(fstl.nextAccountKey[:])
+						} else {
+							fstl.ihK = nil
+						}
+					}
+				}
+				if fstl.k == nil && fstl.ihK == nil {
+					return nil
+				}
+				isIH, minKey = keyIsBefore(fstl.ihK, fstl.k)
+			} else if cmp > 0 {
+				fstl.rangeIdx++
+				if fstl.rangeIdx == len(fstl.dbPrefixes) {
+					fstl.k = nil
+					fstl.ihK = nil
+					return nil
+				}
+				if err := fstl.finaliseRoot(cutoff); err != nil {
+					return err
+				}
+				fixedbytes = fstl.fixedbytes[fstl.rangeIdx]
+				mask = fstl.masks[fstl.rangeIdx]
+				dbPrefix = fstl.dbPrefixes[fstl.rangeIdx]
+				if len(dbPrefix) > common.HashLength {
+					// Looking for storage sub-tree
+					copy(fstl.accAddrHashWithInc[:], dbPrefix[:common.HashLength+common.IncarnationLength])
+				}
+				cutoff = fstl.cutoffs[fstl.rangeIdx]
+				fstl.hb.Reset()
+				fstl.wasIH = false
+				fstl.wasIHStorage = false
+				fstl.groups = fstl.groups[:0]
+				fstl.groupsStorage = fstl.groupsStorage[:0]
+				fstl.curr.Reset()
+				fstl.succ.Reset()
+				fstl.currStorage.Reset()
+				fstl.succStorage.Reset()
+			}
+		}
+	}
+
+	if !isIH {
+		if len(fstl.k) > common.HashLength && !bytes.HasPrefix(fstl.k, fstl.accAddrHashWithInc[:]) {
+			if bytes.Compare(fstl.k, fstl.accAddrHashWithInc[:]) < 0 {
+				// Skip all the irrelevant storage in the middle
+				fstl.k, fstl.v = fstl.c.SeekTo(fstl.accAddrHashWithInc[:])
+			} else {
+				if nextAccount(fstl.k, fstl.nextAccountKey[:]) {
+					fstl.k, fstl.v = fstl.c.SeekTo(fstl.nextAccountKey[:])
+				} else {
+					fstl.k = nil
+				}
+			}
+			return nil
+		}
+		if len(fstl.k) > common.HashLength {
+			if err := fstl.WalkerStorage(false, fstl.rangeIdx, fstl.k, fstl.v); err != nil {
+				return err
+			}
+			fstl.k, fstl.v = fstl.c.Next()
+			if fstl.trace {
+				fmt.Printf("k after storageWalker and Next: %x\n", fstl.k)
+			}
+		} else {
+			if err := fstl.WalkerAccount(false, fstl.rangeIdx, fstl.k, fstl.v); err != nil {
+				return err
+			}
+			// Now we know the correct incarnation of the account, and we can skip all irrelevant storage records
+			// Since 0 incarnation if 0xfff...fff, and we do not expect any records like that, this automatically
+			// skips over all storage items
+			fstl.k, fstl.v = fstl.c.SeekTo(fstl.accAddrHashWithInc[:])
+			if fstl.ih != nil {
+				if !bytes.HasPrefix(fstl.ihK, fstl.accAddrHashWithInc[:]) {
+					fstl.ihK, fstl.ihV = fstl.ih.SeekTo(fstl.accAddrHashWithInc[:])
+				}
+			}
+		}
+		return nil
+	}
+
+	// ih part
+	fstl.minKeyAsNibbles.Reset()
+	keyToNibblesWithoutInc(minKey, &fstl.minKeyAsNibbles)
+
+	if fstl.minKeyAsNibbles.Len() < cutoff {
+		fstl.ihK, fstl.ihV = fstl.ih.Next() // go to children, not to sibling
+		return nil
+	}
+
+	retain := fstl.rl.Retain(fstl.minKeyAsNibbles.Bytes())
+	if fstl.trace {
+		fmt.Printf("fstl.rl.Retain(%x)=%t\n", fstl.minKeyAsNibbles.Bytes(), retain)
+	}
+
+	if retain { // can't use ih as is, need go to children
+		fstl.ihK, fstl.ihV = fstl.ih.Next() // go to children, not to sibling
+		return nil
+	}
+
+	if len(fstl.ihK) > common.HashLength && !bytes.HasPrefix(fstl.ihK, fstl.accAddrHashWithInc[:]) {
+		if bytes.Compare(fstl.ihK, fstl.accAddrHashWithInc[:]) < 0 {
+			// Skip all the irrelevant storage in the middle
+			fstl.ihK, fstl.ihV = fstl.ih.SeekTo(fstl.accAddrHashWithInc[:])
+		} else {
+			if nextAccount(fstl.ihK, fstl.nextAccountKey[:]) {
+				fstl.ihK, fstl.ihV = fstl.ih.SeekTo(fstl.nextAccountKey[:])
+			} else {
+				fstl.ihK = nil
+			}
+		}
+		return nil
+	}
+	if len(fstl.ihK) > common.HashLength {
+		if err := fstl.WalkerStorage(true, fstl.rangeIdx, fstl.ihK, fstl.ihV); err != nil {
+			return fmt.Errorf("storageWalker err: %w", err)
+		}
+	} else {
+		if err := fstl.WalkerAccount(true, fstl.rangeIdx, fstl.ihK, fstl.ihV); err != nil {
+			return fmt.Errorf("accWalker err: %w", err)
+		}
+	}
+
+	// skip subtree
+	next, ok := nextSubtree(fstl.ihK)
+	if !ok { // no siblings left
+		if !retain { // last sub-tree was taken from IH, then nothing to look in the main bucket. Can stop.
+			fstl.k = nil
+			fstl.ihK = nil
+			return nil
+		}
+		fstl.ihK, fstl.ihV = nil, nil
+		return nil
+	}
+	if fstl.trace {
+		fmt.Printf("next: %x\n", next)
+	}
+
+	if !bytes.HasPrefix(fstl.k, next) {
+		fstl.k, fstl.v = fstl.c.SeekTo(next)
+	}
+	if len(next) <= common.HashLength && len(fstl.k) > common.HashLength {
+		// Advance past the storage to the first account
+		if nextAccount(fstl.k, fstl.nextAccountKey[:]) {
+			fstl.k, fstl.v = fstl.c.SeekTo(fstl.nextAccountKey[:])
+		} else {
+			fstl.k = nil
+		}
+	}
+	if fstl.trace {
+		fmt.Printf("k after next: %x\n", fstl.k)
+	}
+	if !bytes.HasPrefix(fstl.ihK, next) {
+		fstl.ihK, fstl.ihV = fstl.ih.SeekTo(next)
+	}
+	if len(next) <= common.HashLength && len(fstl.ihK) > common.HashLength {
+		// Advance past the storage to the first account
+		if nextAccount(fstl.ihK, fstl.nextAccountKey[:]) {
+			fstl.ihK, fstl.ihV = fstl.ih.SeekTo(fstl.nextAccountKey[:])
+		} else {
+			fstl.ihK = nil
+		}
+	}
+	if fstl.trace {
+		fmt.Printf("ihK after next: %x\n", fstl.ihK)
+	}
+	return nil
+}
+
+/*
+func (fstl *FlatDbSubTrieLoader) Next() (itemType StreamItem, hex1 []byte, aValue *accounts.Account, hash []byte, value []byte) {
+
+}
+*/
 
 // cutoff specifies how many nibbles have to be cut from the beginning of the storage keys
 // to fit the insertion point.
@@ -184,52 +510,24 @@ func (fstl *FlatDbSubTrieLoader) finaliseStorageRoot(cutoff int) (bool, error) {
 	return false, nil
 }
 
-func (fstl *FlatDbSubTrieLoader) LoadSubTries(db ethdb.Database, rl *RetainList, dbPrefixes [][]byte, fixedbits []int, trace bool) (SubTries, error) {
-	if len(dbPrefixes) == 0 {
+func (fstl *FlatDbSubTrieLoader) LoadSubTries() (SubTries, error) {
+	if len(fstl.dbPrefixes) == 0 {
 		return SubTries{}, nil
 	}
-	defer trieFlatDbSubTrieLoaderTimer.UpdateSince(time.Now())
-	fstl.trace = trace
-	fstl.hb.trace = trace
-	fstl.rl = rl
-
-	if fstl.trace {
-		fmt.Printf("----------\n")
-		fmt.Printf("RebuildTrie\n")
-	}
-
-	if fstl.trace {
-		fmt.Printf("fstl.rl: %x\n", fstl.rl.hexes)
-		fmt.Printf("fixedbits: %d\n", fixedbits)
-		fmt.Printf("dbPrefixes(%d): %x\n", len(dbPrefixes), dbPrefixes)
-	}
-
-	var boltDB *bolt.DB
-	if hasBolt, ok := db.(ethdb.HasKV); ok {
-		boltDB = hasBolt.KV()
-	}
-
-	if boltDB == nil {
-		return SubTries{}, fmt.Errorf("only Bolt supported yet, given: %T", db)
-	}
-
-	cutoffs := make([]int, len(fixedbits))
-	for i, bits := range fixedbits {
-		if bits >= 256 /* addrHash */ +64 /* incarnation */ {
-			cutoffs[i] = bits/4 - 16 // Remove incarnation
-		} else {
-			cutoffs[i] = bits / 4
+	for fstl.k != nil || fstl.ihK != nil {
+		if err := fstl.iteration(); err != nil {
+			return SubTries{}, err
 		}
 	}
-
-	if err := fstl.MultiWalk2(boltDB, dbPrefixes, fixedbits, cutoffs, fstl.WalkerAccount, fstl.WalkerStorage); err != nil {
-		return fstl.subTries, err
+	if fstl.tx != nil {
+		fstl.tx.Rollback()
 	}
-	if err := fstl.finaliseRoot(cutoffs[len(cutoffs)-1]); err != nil {
+	if err := fstl.finaliseRoot(fstl.cutoffs[len(fstl.cutoffs)-1]); err != nil {
 		fmt.Println("Err in finalize root, writing down resolve params")
 		fmt.Printf("fstl.rs: %x\n", fstl.rl.hexes)
-		fmt.Printf("fixedbits: %d\n", fixedbits)
-		fmt.Printf("dbPrefixes: %x\n", dbPrefixes)
+		fmt.Printf("fixedbytes: %d\n", fstl.fixedbytes)
+		fmt.Printf("masks: %b\n", fstl.masks)
+		fmt.Printf("dbPrefixes: %x\n", fstl.dbPrefixes)
 		return fstl.subTries, fmt.Errorf("error in finaliseRoot %w", err)
 	}
 	return fstl.subTries, nil
@@ -255,7 +553,7 @@ func (fstl *FlatDbSubTrieLoader) AttachRequestedCode(db ethdb.Getter, requests [
 	return nil
 }
 
-type walker func(isIH bool, keyIdx int, k, v []byte) error
+type walker func(isIH bool, rangeIdx int, k, v []byte) error
 
 func keyToNibblesWithoutInc(k []byte, w io.ByteWriter) {
 	// Transform k to nibbles, but skip the incarnation part in the middle
@@ -278,9 +576,9 @@ func keyToNibblesWithoutInc(k []byte, w io.ByteWriter) {
 	}
 }
 
-func (fstl *FlatDbSubTrieLoader) WalkerStorage(isIH bool, keyIdx int, k, v []byte) error {
+func (fstl *FlatDbSubTrieLoader) WalkerStorage(isIH bool, rangeIdx int, k, v []byte) error {
 	if fstl.trace {
-		fmt.Printf("WalkerStorage: isIH=%v keyIdx=%d key=%x value=%x\n", isIH, keyIdx, k, v)
+		fmt.Printf("WalkerStorage: isIH=%v rangeIdx=%d key=%x value=%x\n", isIH, rangeIdx, k, v)
 	}
 
 	fstl.currStorage.Reset()
@@ -320,9 +618,9 @@ func (fstl *FlatDbSubTrieLoader) WalkerStorage(isIH bool, keyIdx int, k, v []byt
 }
 
 // Walker - k, v - shouldn't be reused in the caller's code
-func (fstl *FlatDbSubTrieLoader) WalkerAccount(isIH bool, keyIdx int, k, v []byte) error {
+func (fstl *FlatDbSubTrieLoader) WalkerAccount(isIH bool, rangeIdx int, k, v []byte) error {
 	if fstl.trace {
-		fmt.Printf("WalkerAccount: isIH=%v keyIdx=%d key=%x value=%x\n", isIH, keyIdx, k, v)
+		fmt.Printf("WalkerAccount: isIH=%v rangeIdx=%d key=%x value=%x\n", isIH, rangeIdx, k, v)
 	}
 	fstl.curr.Reset()
 	fstl.curr.Write(fstl.succ.Bytes())
@@ -382,8 +680,8 @@ func (fstl *FlatDbSubTrieLoader) WalkerAccount(isIH bool, keyIdx int, k, v []byt
 	if err := fstl.a.DecodeForStorage(v); err != nil {
 		return fmt.Errorf("fail DecodeForStorage: %w", err)
 	}
-	copy(fstl.accAddrHashWithInc, k)
-	binary.BigEndian.PutUint64(fstl.accAddrHashWithInc[32:40], ^fstl.a.Incarnation)
+	copy(fstl.accAddrHashWithInc[:], k)
+	binary.BigEndian.PutUint64(fstl.accAddrHashWithInc[32:], ^fstl.a.Incarnation)
 	// Place code on the stack first, the storage will follow
 	if !fstl.a.IsEmptyCodeHash() {
 		// the first item ends up deepest on the stack, the second item - on the top
@@ -393,267 +691,6 @@ func (fstl *FlatDbSubTrieLoader) WalkerAccount(isIH bool, keyIdx int, k, v []byt
 		}
 	}
 	return nil
-}
-
-// MultiWalk2 - looks similar to db.MultiWalk but works with hardcoded 2-nd bucket IntermediateTrieHashBucket
-func (fstl *FlatDbSubTrieLoader) MultiWalk2(db *bolt.DB, startkeys [][]byte, fixedbits []int, cutoffs []int, accWalker walker, storageWalker walker) error {
-	if len(startkeys) == 0 {
-		return nil
-	}
-
-	var minKeyAsNibbles bytes.Buffer
-	// Key used to advance to the next account (skip remaining storage)
-	nextAccountKey := make([]byte, 32)
-
-	rangeIdx := 0 // What is the current range we are extracting
-	fixedbytes, mask := ethdb.Bytesmask(fixedbits[rangeIdx])
-	startkey := startkeys[rangeIdx]
-	cutoff := cutoffs[rangeIdx]
-	if len(startkey) > common.HashLength {
-		// Looking for storage sub-tree
-		copy(fstl.accAddrHashWithInc, startkey[:common.HashLength+common.IncarnationLength])
-	}
-
-	err := db.View(func(tx *bolt.Tx) error {
-		ihBucket := tx.Bucket(dbutils.IntermediateTrieHashBucket)
-		var ih *bolt.Cursor
-		if ihBucket != nil {
-			ih = ihBucket.Cursor()
-		}
-		c := tx.Bucket(dbutils.CurrentStateBucket).Cursor()
-
-		k, v := c.Seek(startkey)
-		if len(startkey) <= common.HashLength && len(k) > common.HashLength {
-			// Advance past the storage to the first account
-			if nextAccount(k, nextAccountKey) {
-				k, v = c.SeekTo(nextAccountKey)
-			} else {
-				k = nil
-			}
-		}
-		if fstl.trace {
-			fmt.Printf("c.Seek(%x) = %x\n", startkey, k)
-		}
-
-		var ihK, ihV []byte
-		if ih != nil {
-			ihK, ihV = ih.Seek(startkey)
-			if len(startkey) <= common.HashLength && len(ihK) > common.HashLength {
-				// Advance past the storage to the first account
-				if nextAccount(ihK, nextAccountKey) {
-					ihK, ihV = ih.SeekTo(nextAccountKey)
-				} else {
-					ihK = nil
-				}
-			}
-		}
-
-		var minKey []byte
-		var isIH bool
-		for k != nil || ihK != nil {
-			isIH, minKey = keyIsBefore(ihK, k)
-			if fixedbytes > 0 {
-				// Adjust rangeIdx if needed
-				cmp := int(-1)
-				for cmp != 0 {
-					if len(minKey) < fixedbytes {
-						cmp = bytes.Compare(minKey, startkey[:len(minKey)])
-						if cmp == 0 {
-							cmp = -1
-						}
-					} else {
-						cmp = bytes.Compare(minKey[:fixedbytes-1], startkey[:fixedbytes-1])
-						if cmp == 0 {
-							k1 := minKey[fixedbytes-1] & mask
-							k2 := startkey[fixedbytes-1] & mask
-							if k1 < k2 {
-								cmp = -1
-							} else if k1 > k2 {
-								cmp = 1
-							}
-						}
-					}
-					if cmp < 0 {
-						// This happens after we have just incremented rangeIdx
-						k, v = c.SeekTo(startkey)
-						if len(startkey) <= common.HashLength && len(k) > common.HashLength {
-							// Advance past the storage to the first account
-							if nextAccount(k, nextAccountKey) {
-								k, v = c.SeekTo(nextAccountKey)
-							} else {
-								k = nil
-							}
-						}
-						if ih != nil {
-							ihK, ihV = ih.SeekTo(startkey)
-							if len(startkey) <= common.HashLength && len(ihK) > common.HashLength {
-								// Advance to the first account
-								if nextAccount(ihK, nextAccountKey) {
-									ihK, ihV = ih.SeekTo(nextAccountKey)
-								} else {
-									ihK = nil
-								}
-							}
-						}
-						if k == nil && ihK == nil {
-							return nil
-						}
-						isIH, minKey = keyIsBefore(ihK, k)
-					} else if cmp > 0 {
-						rangeIdx++
-						if rangeIdx == len(startkeys) {
-							return nil
-						}
-						if err := fstl.finaliseRoot(cutoff); err != nil {
-							return err
-						}
-						fixedbytes, mask = ethdb.Bytesmask(fixedbits[rangeIdx])
-						startkey = startkeys[rangeIdx]
-						if len(startkey) > common.HashLength {
-							// Looking for storage sub-tree
-							copy(fstl.accAddrHashWithInc, startkey[:common.HashLength+common.IncarnationLength])
-						}
-						cutoff = cutoffs[rangeIdx]
-						fstl.hb.Reset()
-						fstl.wasIH = false
-						fstl.wasIHStorage = false
-						fstl.groups = fstl.groups[:0]
-						fstl.groupsStorage = fstl.groupsStorage[:0]
-						fstl.keyIdx = rangeIdx
-						fstl.curr.Reset()
-						fstl.succ.Reset()
-						fstl.currStorage.Reset()
-						fstl.succStorage.Reset()
-					}
-				}
-			}
-
-			if !isIH {
-				if len(k) > common.HashLength && !bytes.HasPrefix(k, fstl.accAddrHashWithInc) {
-					if bytes.Compare(k, fstl.accAddrHashWithInc) < 0 {
-						// Skip all the irrelevant storage in the middle
-						k, v = c.SeekTo(fstl.accAddrHashWithInc)
-					} else {
-						if nextAccount(k, nextAccountKey) {
-							k, v = c.SeekTo(nextAccountKey)
-						} else {
-							k = nil
-						}
-					}
-					continue
-				}
-				if len(k) > common.HashLength {
-					if err := storageWalker(false, rangeIdx, k, v); err != nil {
-						return err
-					}
-					k, v = c.Next()
-					if fstl.trace {
-						fmt.Printf("k after storageWalker and Next: %x\n", k)
-					}
-				} else {
-					if err := accWalker(false, rangeIdx, k, v); err != nil {
-						return err
-					}
-					// Now we know the correct incarnation of the account, and we can skip all irrelevant storage records
-					// Since 0 incarnation if 0xfff...fff, and we do not expect any records like that, this automatically
-					// skips over all storage items
-					k, v = c.SeekTo(fstl.accAddrHashWithInc)
-					if ih != nil {
-						if !bytes.HasPrefix(ihK, fstl.accAddrHashWithInc) {
-							ihK, ihV = ih.SeekTo(fstl.accAddrHashWithInc)
-						}
-					}
-				}
-				continue
-			}
-
-			// ih part
-			minKeyAsNibbles.Reset()
-			keyToNibblesWithoutInc(minKey, &minKeyAsNibbles)
-
-			if minKeyAsNibbles.Len() < cutoff {
-				ihK, ihV = ih.Next() // go to children, not to sibling
-				continue
-			}
-
-			retain := fstl.rl.Retain(minKeyAsNibbles.Bytes())
-			if fstl.trace {
-				fmt.Printf("fstl.rl.Retain(%x)=%t\n", minKeyAsNibbles.Bytes(), retain)
-			}
-
-			if retain { // can't use ih as is, need go to children
-				ihK, ihV = ih.Next() // go to children, not to sibling
-				continue
-			}
-
-			if len(ihK) > common.HashLength && !bytes.HasPrefix(ihK, fstl.accAddrHashWithInc) {
-				if bytes.Compare(ihK, fstl.accAddrHashWithInc) < 0 {
-					// Skip all the irrelevant storage in the middle
-					ihK, ihV = ih.SeekTo(fstl.accAddrHashWithInc)
-				} else {
-					if nextAccount(ihK, nextAccountKey) {
-						ihK, ihV = ih.SeekTo(nextAccountKey)
-					} else {
-						ihK = nil
-					}
-				}
-				continue
-			}
-			if len(ihK) > common.HashLength {
-				if err := storageWalker(true, rangeIdx, ihK, ihV); err != nil {
-					return fmt.Errorf("storageWalker err: %w", err)
-				}
-			} else {
-				if err := accWalker(true, rangeIdx, ihK, ihV); err != nil {
-					return fmt.Errorf("accWalker err: %w", err)
-				}
-			}
-
-			// skip subtree
-			next, ok := nextSubtree(ihK)
-			if !ok { // no siblings left
-				if !retain { // last sub-tree was taken from IH, then nothing to look in the main bucket. Can stop.
-					break
-				}
-				ihK, ihV = nil, nil
-				continue
-			}
-			if fstl.trace {
-				fmt.Printf("next: %x\n", next)
-			}
-
-			if !bytes.HasPrefix(k, next) {
-				k, v = c.SeekTo(next)
-			}
-			if len(next) <= common.HashLength && len(k) > common.HashLength {
-				// Advance past the storage to the first account
-				if nextAccount(k, nextAccountKey) {
-					k, v = c.SeekTo(nextAccountKey)
-				} else {
-					k = nil
-				}
-			}
-			if fstl.trace {
-				fmt.Printf("k after next: %x\n", k)
-			}
-			if !bytes.HasPrefix(ihK, next) {
-				ihK, ihV = ih.SeekTo(next)
-			}
-			if len(next) <= common.HashLength && len(ihK) > common.HashLength {
-				// Advance past the storage to the first account
-				if nextAccount(ihK, nextAccountKey) {
-					ihK, ihV = ih.SeekTo(nextAccountKey)
-				} else {
-					ihK = nil
-				}
-			}
-			if fstl.trace {
-				fmt.Printf("ihK after next: %x\n", ihK)
-			}
-		}
-		return nil
-	})
-	return err
 }
 
 // nextSubtree does []byte++. Returns false if overflow.

--- a/trie/flatdb_sub_trie_loader.go
+++ b/trie/flatdb_sub_trie_loader.go
@@ -601,8 +601,6 @@ func (fstl *FlatDbSubTrieLoader) AttachRequestedCode(db ethdb.Getter, requests [
 	return nil
 }
 
-type walker func(isIH bool, rangeIdx int, k, v []byte) error
-
 func keyToNibbles(k []byte, w io.ByteWriter) {
 	for _, b := range k {
 		//nolint:errcheck

--- a/trie/stream.go
+++ b/trie/stream.go
@@ -43,6 +43,9 @@ const (
 	// SHashStreamItem used for marking a key-value pair in the stream as belonging to an intermediate hash
 	// within the storage items (storage tries)
 	SHashStreamItem
+	// CutoffStremItem used for marking the end of the subtrie of contract storage. There is no value
+	// attached to it
+	CutoffStreamItem
 )
 
 // Stream represents the collection of key-value pairs, sorted by keys, where values may belong
@@ -82,8 +85,12 @@ func (s *Stream) Reset() {
 	}
 }
 
+type StreamIterator interface {
+	Next() (itemType StreamItem, hex1 []byte, aValue *accounts.Account, hash []byte, value []byte)
+}
+
 // Iterator helps iterate over a trie according to a given resolve set
-type Iterator struct {
+type TrieIterator struct {
 	rl           *RetainList
 	hex          []byte
 	nodeStack    []node
@@ -96,8 +103,8 @@ type Iterator struct {
 }
 
 // NewIterator creates a new iterator from scratch from a given trie and resolve set
-func NewIterator(t *Trie, rl *RetainList, trace bool) *Iterator {
-	return &Iterator{
+func NewTrieIterator(t *Trie, rl *RetainList, trace bool) *TrieIterator {
+	return &TrieIterator{
 		rl:           rl,
 		hex:          []byte{},
 		nodeStack:    []node{t.root},
@@ -111,7 +118,7 @@ func NewIterator(t *Trie, rl *RetainList, trace bool) *Iterator {
 }
 
 // Reset prepares iterator to be reused
-func (it *Iterator) Reset(t *Trie, rl *RetainList, trace bool) {
+func (it *TrieIterator) Reset(t *Trie, rl *RetainList, trace bool) {
 	it.rl = rl
 	it.hex = it.hex[:0]
 	if len(it.nodeStack) > 0 {
@@ -135,7 +142,7 @@ func (it *Iterator) Reset(t *Trie, rl *RetainList, trace bool) {
 }
 
 // Next delivers the next item from the iterator
-func (it *Iterator) Next() (itemType StreamItem, hex1 []byte, aValue *accounts.Account, hash []byte, value []byte) {
+func (it *TrieIterator) Next() (itemType StreamItem, hex1 []byte, aValue *accounts.Account, hash []byte, value []byte) {
 	for {
 		if it.top == 0 {
 			return NoItem, nil, nil, nil, nil
@@ -422,7 +429,7 @@ func (it *Iterator) Next() (itemType StreamItem, hex1 []byte, aValue *accounts.A
 
 // StreamMergeIterator merges an Iterator and a Stream
 type StreamMergeIterator struct {
-	it          *Iterator
+	it          *TrieIterator
 	s           *Stream
 	trace       bool
 	ki, ai, si  int
@@ -439,7 +446,7 @@ type StreamMergeIterator struct {
 }
 
 // NewStreamMergeIterator create a brand new StreamMergeIterator
-func NewStreamMergeIterator(it *Iterator, s *Stream, trace bool) *StreamMergeIterator {
+func NewStreamMergeIterator(it *TrieIterator, s *Stream, trace bool) *StreamMergeIterator {
 	smi := &StreamMergeIterator{
 		it:    it,
 		s:     s,
@@ -450,7 +457,7 @@ func NewStreamMergeIterator(it *Iterator, s *Stream, trace bool) *StreamMergeIte
 }
 
 // Reset prepares StreamMergeIterator for reuse
-func (smi *StreamMergeIterator) Reset(it *Iterator, s *Stream, trace bool) {
+func (smi *StreamMergeIterator) Reset(it *TrieIterator, s *Stream, trace bool) {
 	smi.it = it
 	smi.s = s
 	smi.trace = trace
@@ -841,7 +848,7 @@ func HashWithModifications(
 	// Now we merge old and new streams, preferring the new
 	newStream.Reset()
 
-	oldIt := NewIterator(t, rl, trace)
+	oldIt := NewTrieIterator(t, rl, trace)
 
 	it := NewStreamMergeIterator(oldIt, &stream, trace)
 	return StreamHash(it, storagePrefixLen, hb, trace)

--- a/trie/sub_trie_loader.go
+++ b/trie/sub_trie_loader.go
@@ -61,7 +61,6 @@ func (stl *SubTrieLoader) LoadSubTries(db ethdb.Database, blockNr uint64, rl *Re
 
 func (stl *SubTrieLoader) LoadFromFlatDb(db ethdb.Database, rl *RetainList, dbPrefixes [][]byte, fixedbits []int, trace bool) (SubTries, error) {
 	loader := NewFlatDbSubTrieLoader()
-	trace = true
 	loader.Reset(db, rl, dbPrefixes, fixedbits, trace)
 	subTries, err := loader.LoadSubTries()
 	if err != nil {

--- a/trie/sub_trie_loader.go
+++ b/trie/sub_trie_loader.go
@@ -61,6 +61,7 @@ func (stl *SubTrieLoader) LoadSubTries(db ethdb.Database, blockNr uint64, rl *Re
 
 func (stl *SubTrieLoader) LoadFromFlatDb(db ethdb.Database, rl *RetainList, dbPrefixes [][]byte, fixedbits []int, trace bool) (SubTries, error) {
 	loader := NewFlatDbSubTrieLoader()
+	trace = true
 	loader.Reset(db, rl, dbPrefixes, fixedbits, trace)
 	subTries, err := loader.LoadSubTries()
 	if err != nil {

--- a/trie/sub_trie_loader.go
+++ b/trie/sub_trie_loader.go
@@ -61,7 +61,8 @@ func (stl *SubTrieLoader) LoadSubTries(db ethdb.Database, blockNr uint64, rl *Re
 
 func (stl *SubTrieLoader) LoadFromFlatDb(db ethdb.Database, rl *RetainList, dbPrefixes [][]byte, fixedbits []int, trace bool) (SubTries, error) {
 	loader := NewFlatDbSubTrieLoader()
-	subTries, err := loader.LoadSubTries(db, rl, dbPrefixes, fixedbits, trace)
+	loader.Reset(db, rl, dbPrefixes, fixedbits, trace)
+	subTries, err := loader.LoadSubTries()
 	if err != nil {
 		return subTries, err
 	}

--- a/trie/sub_trie_loader.go
+++ b/trie/sub_trie_loader.go
@@ -61,7 +61,9 @@ func (stl *SubTrieLoader) LoadSubTries(db ethdb.Database, blockNr uint64, rl *Re
 
 func (stl *SubTrieLoader) LoadFromFlatDb(db ethdb.Database, rl *RetainList, dbPrefixes [][]byte, fixedbits []int, trace bool) (SubTries, error) {
 	loader := NewFlatDbSubTrieLoader()
-	loader.Reset(db, rl, dbPrefixes, fixedbits, trace)
+	if err1 := loader.Reset(db, rl, dbPrefixes, fixedbits, trace); err1 != nil {
+		return SubTries{}, err1
+	}
 	subTries, err := loader.LoadSubTries()
 	if err != nil {
 		return subTries, err


### PR DESCRIPTION
Just a first step. Here, the processing is moved from automated transactions `bolt.DB.View(func(tx *bolt.Tx) error {...})` to manual transaction `tx := bolt.DB.Begin(false);....;tx.Rollback()`, which allows the introduction of an iterator, at a cost of the risk of not closing the transaction and causing the deadlock in the system (which will hopefully be apparent very quickly).