### PR TITLE
Staged Sync: Execution phase should use "plain state"

### DIFF
--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -91,6 +91,7 @@ var (
 		utils.TxPoolGlobalQueueFlag,
 		utils.TxPoolLifetimeFlag,
 		utils.SyncModeFlag,
+		utils.StagedSyncPlainExecFlag,
 		utils.ExitWhenSyncedFlag,
 		//utils.GCModePruningFlag,
 		utils.GCModeLimitFlag,

--- a/cmd/geth/usage.go
+++ b/cmd/geth/usage.go
@@ -76,6 +76,7 @@ var AppHelpFlagGroups = []flagGroup{
 			utils.RinkebyFlag,
 			utils.RopstenFlag,
 			utils.SyncModeFlag,
+			utils.StagedSyncPlainExecFlag,
 			utils.ExitWhenSyncedFlag,
 			//utils.GCModePruningFlag,
 			utils.GCModeLimitFlag,

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -224,6 +224,10 @@ var (
 		Usage: `Blockchain sync mode ("fast", "full", "staged", or "light")`,
 		Value: &defaultSyncMode,
 	}
+	StagedSyncPlainExecFlag = cli.BoolFlag{
+		Name:  "plainstate",
+		Usage: "use plain state when doing staged sync (affects only syncmode=staged)",
+	}
 	GCModePruningFlag = cli.BoolFlag{
 		Name:  "pruning",
 		Usage: `Enable storage pruning`,
@@ -1502,6 +1506,9 @@ func SetEthConfig(ctx *cli.Context, stack *node.Node, cfg *eth.Config) {
 	setMiner(ctx, &cfg.Miner)
 	setWhitelist(ctx, cfg)
 	setLes(ctx, cfg)
+
+	downloader.UsePlainStateExecution = ctx.Bool(StagedSyncPlainExecFlag.Name)
+	log.Info("setting up plain text execution", "plain", downloader.UsePlainStateExecution)
 
 	if ctx.GlobalIsSet(SyncModeFlag.Name) {
 		cfg.SyncMode = *GlobalTextMarshaler(ctx, SyncModeFlag.Name).(*downloader.SyncMode)

--- a/common/changeset/account_changeset.go
+++ b/common/changeset/account_changeset.go
@@ -1,13 +1,10 @@
 package changeset
 
 import (
-	"bytes"
-	"encoding/binary"
-	"errors"
-	"fmt"
 	"github.com/ledgerwatch/turbo-geth/common"
-	"sort"
 )
+
+/* Hashed changesets (key is a hash of common.Address) */
 
 func NewAccountChangeSet() *ChangeSet {
 	return &ChangeSet{
@@ -16,186 +13,57 @@ func NewAccountChangeSet() *ChangeSet {
 	}
 }
 
-type AccountChangeSetBytes []byte
-
-const accountKeySize = common.HashLength
-
-/*
-AccountChangeSet is serialized in the following manner in order to facilitate binary search:
-1. The number of keys N (uint32, 4 bytes).
-2. Contiguous array of keys (N*M bytes).
-3. Contiguous array of accumulating value indexes:
-len(val0), len(val0)+len(val1), ..., len(val0)+len(val1)+...+len(val_{N-1})
-(4*N bytes since the lengths are treated as uint32).
-4. Contiguous array of values.
-
-uint32 integers are serialized as big-endian.
-*/
 func EncodeAccounts(s *ChangeSet) ([]byte, error) {
-	sort.Sort(s)
-	buf := new(bytes.Buffer)
-	intArr := make([]byte, 4)
-	n := s.Len()
-	binary.BigEndian.PutUint32(intArr, uint32(n))
-	_, err := buf.Write(intArr)
+	return encodeAccounts(s)
+}
+
+func DecodeAccounts(b []byte) (*ChangeSet, error) {
+	h := NewAccountChangeSet()
+	err := decodeAccountsWithKeyLen(b, common.HashLength, h)
 	if err != nil {
 		return nil, err
 	}
-
-	for i := 0; i < n; i++ {
-		_, err = buf.Write(s.Changes[i].Key)
-		if err != nil {
-			return nil, err
-		}
-	}
-
-	var l int
-	for i := 0; i < n; i++ {
-		l += len(s.Changes[i].Value)
-		binary.BigEndian.PutUint32(intArr, uint32(l))
-		_, err = buf.Write(intArr)
-		if err != nil {
-			return nil, err
-		}
-	}
-
-	for i := 0; i < n; i++ {
-		_, err = buf.Write(s.Changes[i].Value)
-		if err != nil {
-			return nil, err
-		}
-	}
-
-	return buf.Bytes(), nil
+	return h, nil
 }
 
+type AccountChangeSetBytes []byte
+
 func (b AccountChangeSetBytes) Walk(f func(k, v []byte) error) error {
-	if len(b) == 0 {
-		return nil
-	}
-	if len(b) < 4 {
-		return fmt.Errorf("decode: input too short (%d bytes)", len(b))
-	}
-
-	n := binary.BigEndian.Uint32(b[0:4])
-
-	if n == 0 {
-		return nil
-	}
-	valOffset := 4 + n*accountKeySize + 4*n
-	if uint32(len(b)) < valOffset {
-		fmt.Println("walkAccounts account")
-		return fmt.Errorf("decode: input too short (%d bytes, expected at least %d bytes)", len(b), valOffset)
-	}
-
-	totalValLength := binary.BigEndian.Uint32(b[valOffset-4 : valOffset])
-	if uint32(len(b)) < valOffset+totalValLength {
-		return fmt.Errorf("decode: input too short (%d bytes, expected at least %d bytes)", len(b), valOffset+totalValLength)
-	}
-
-	for i := uint32(0); i < n; i++ {
-		key := b[4+i*accountKeySize : 4+(i+1)*accountKeySize]
-		idx0 := uint32(0)
-		if i > 0 {
-			idx0 = binary.BigEndian.Uint32(b[4+n*accountKeySize+4*(i-1) : 4+n*accountKeySize+4*i])
-		}
-		idx1 := binary.BigEndian.Uint32(b[4+n*accountKeySize+4*i : 4+n*accountKeySize+4*(i+1)])
-		val := b[valOffset+idx0 : valOffset+idx1]
-
-		err := f(key, val)
-		if err != nil {
-			return err
-		}
-	}
-	return nil
+	return walkAccountChangeSet(b, common.HashLength, f)
 }
 
 func (b AccountChangeSetBytes) FindLast(k []byte) ([]byte, error) {
-	if len(b) == 0 {
-		return nil, nil
-	}
-
-	if len(b) < 8 {
-		return nil, fmt.Errorf("decode: input too short (%d bytes)", len(b))
-	}
-
-	n := binary.BigEndian.Uint32(b[0:4])
-
-	if n == 0 {
-		return nil, nil
-	}
-
-	valOffset := 4 + n*accountKeySize + 4*n
-	if uint32(len(b)) < valOffset {
-		fmt.Println("FindLastAccounts account")
-		return nil, fmt.Errorf("decode: input too short (%d bytes, expected at least %d bytes)", len(b), valOffset)
-	}
-
-	totalValLength := binary.BigEndian.Uint32(b[valOffset-4 : valOffset])
-	if uint32(len(b)) < valOffset+totalValLength {
-		return nil, fmt.Errorf("decode: input too short (%d bytes, expected at least %d bytes)", len(b), valOffset+totalValLength)
-	}
-
-	for i := n - 1; int(i) >= 0; i-- {
-		key := b[4+i*accountKeySize : 4+(i+1)*accountKeySize]
-		idx0 := uint32(0)
-		if i > 0 {
-			idx0 = binary.BigEndian.Uint32(b[4+n*accountKeySize+4*(i-1) : 4+n*accountKeySize+4*i])
-		}
-		idx1 := binary.BigEndian.Uint32(b[4+n*accountKeySize+4*i : 4+n*accountKeySize+4*(i+1)])
-		val := b[valOffset+idx0 : valOffset+idx1]
-
-		if bytes.Equal(key, k) {
-			return val, nil
-		}
-	}
-	return nil, errors.New("not found")
+	return findLastKeyInAccountChangeSet(b, k, common.HashLength)
 }
 
-////////////////////////////////////////////////
-func DecodeAccounts(b []byte) (*ChangeSet, error) {
-	h := NewAccountChangeSet()
-	h.Changes = make([]Change, 0)
-	if len(b) == 0 {
-		return h, nil
+/* Plain changesets (key is a common.Address) */
+
+func NewAccountChangeSetPlain() *ChangeSet {
+	return &ChangeSet{
+		Changes: make([]Change, 0),
+		keyLen:  common.AddressLength,
 	}
+}
 
-	if len(b) < 4 {
-		return h, fmt.Errorf("decode: input too short (%d bytes)", len(b))
+func EncodeAccountsPlain(s *ChangeSet) ([]byte, error) {
+	return encodeAccounts(s)
+}
+
+func DecodeAccountsPlain(b []byte) (*ChangeSet, error) {
+	h := NewAccountChangeSetPlain()
+	err := decodeAccountsWithKeyLen(b, common.AddressLength, h)
+	if err != nil {
+		return nil, err
 	}
-
-	numOfAccounts := binary.BigEndian.Uint32(b[0:4])
-
-	if numOfAccounts == 0 {
-		return h, nil
-	}
-
-	h.Changes = make([]Change, numOfAccounts)
-
-	valOffset := 4 + numOfAccounts*accountKeySize + 4*numOfAccounts
-	if uint32(len(b)) < valOffset {
-		fmt.Println("DecodeAccounts account")
-		return h, fmt.Errorf("decode: input too short (%d bytes, expected at least %d bytes)", len(b), valOffset)
-	}
-
-	totalValLength := binary.BigEndian.Uint32(b[valOffset-4 : valOffset])
-	if uint32(len(b)) < valOffset+totalValLength {
-		return h, fmt.Errorf("decode: input too short (%d bytes, expected at least %d bytes)", len(b), valOffset+totalValLength)
-	}
-
-	for i := uint32(0); i < numOfAccounts; i++ {
-		key := b[4+i*accountKeySize : 4+(i+1)*accountKeySize]
-		idx0 := uint32(0)
-		if i > 0 {
-			idx0 = binary.BigEndian.Uint32(b[4+numOfAccounts*accountKeySize+4*(i-1) : 4+numOfAccounts*accountKeySize+4*i])
-		}
-		idx1 := binary.BigEndian.Uint32(b[4+numOfAccounts*accountKeySize+4*i : 4+numOfAccounts*accountKeySize+4*(i+1)])
-		val := b[valOffset+idx0 : valOffset+idx1]
-
-		h.Changes[i].Key = common.CopyBytes(key)
-		h.Changes[i].Value = common.CopyBytes(val)
-	}
-
-	sort.Sort(h)
 	return h, nil
+}
+
+type AccountChangeSetPlainBytes []byte
+
+func (b AccountChangeSetPlainBytes) Walk(f func(k, v []byte) error) error {
+	return walkAccountChangeSet(b, common.AddressLength, f)
+}
+
+func (b AccountChangeSetPlainBytes) FindLast(k []byte) ([]byte, error) {
+	return findLastKeyInAccountChangeSet(b, k, common.AddressLength)
 }

--- a/common/changeset/account_changeset_utils.go
+++ b/common/changeset/account_changeset_utils.go
@@ -1,0 +1,190 @@
+package changeset
+
+import (
+	"bytes"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"sort"
+
+	"github.com/ledgerwatch/turbo-geth/common"
+)
+
+// walkAccountChangeSet iterates the account bytes with the keys of provided size
+func walkAccountChangeSet(b []byte, keyLen uint32, f func(k, v []byte) error) error {
+	if len(b) == 0 {
+		return nil
+	}
+	if len(b) < 4 {
+		return fmt.Errorf("decode: input too short (%d bytes)", len(b))
+	}
+
+	n := binary.BigEndian.Uint32(b[0:4])
+
+	if n == 0 {
+		return nil
+	}
+	valOffset := 4 + n*keyLen + 4*n
+	if uint32(len(b)) < valOffset {
+		fmt.Println("walkAccounts account")
+		return fmt.Errorf("decode: input too short (%d bytes, expected at least %d bytes)", len(b), valOffset)
+	}
+
+	totalValLength := binary.BigEndian.Uint32(b[valOffset-4 : valOffset])
+	if uint32(len(b)) < valOffset+totalValLength {
+		return fmt.Errorf("decode: input too short (%d bytes, expected at least %d bytes)", len(b), valOffset+totalValLength)
+	}
+
+	for i := uint32(0); i < n; i++ {
+		key := b[4+i*keyLen : 4+(i+1)*keyLen]
+		idx0 := uint32(0)
+		if i > 0 {
+			idx0 = binary.BigEndian.Uint32(b[4+n*keyLen+4*(i-1) : 4+n*keyLen+4*i])
+		}
+		idx1 := binary.BigEndian.Uint32(b[4+n*keyLen+4*i : 4+n*keyLen+4*(i+1)])
+		val := b[valOffset+idx0 : valOffset+idx1]
+
+		err := f(key, val)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func findLastKeyInAccountChangeSet(b []byte, k []byte, keyLen uint32) ([]byte, error) {
+	if len(b) == 0 {
+		return nil, nil
+	}
+
+	if len(b) < 8 {
+		return nil, fmt.Errorf("decode: input too short (%d bytes)", len(b))
+	}
+
+	n := binary.BigEndian.Uint32(b[0:4])
+
+	if n == 0 {
+		return nil, nil
+	}
+
+	valOffset := 4 + n*keyLen + 4*n
+	if uint32(len(b)) < valOffset {
+		fmt.Println("FindLastAccounts account")
+		return nil, fmt.Errorf("decode: input too short (%d bytes, expected at least %d bytes)", len(b), valOffset)
+	}
+
+	totalValLength := binary.BigEndian.Uint32(b[valOffset-4 : valOffset])
+	if uint32(len(b)) < valOffset+totalValLength {
+		return nil, fmt.Errorf("decode: input too short (%d bytes, expected at least %d bytes)", len(b), valOffset+totalValLength)
+	}
+
+	for i := n - 1; int(i) >= 0; i-- {
+		key := b[4+i*keyLen : 4+(i+1)*keyLen]
+		idx0 := uint32(0)
+		if i > 0 {
+			idx0 = binary.BigEndian.Uint32(b[4+n*keyLen+4*(i-1) : 4+n*keyLen+4*i])
+		}
+		idx1 := binary.BigEndian.Uint32(b[4+n*keyLen+4*i : 4+n*keyLen+4*(i+1)])
+		val := b[valOffset+idx0 : valOffset+idx1]
+
+		if bytes.Equal(key, k) {
+			return val, nil
+		}
+	}
+	return nil, errors.New("not found")
+}
+
+func decodeAccountsWithKeyLen(b []byte, keyLen uint32, h *ChangeSet) error {
+	h.Changes = make([]Change, 0)
+	if len(b) == 0 {
+		return nil
+	}
+
+	if len(b) < 4 {
+		return fmt.Errorf("decode: input too short (%d bytes)", len(b))
+	}
+
+	numOfAccounts := binary.BigEndian.Uint32(b[0:4])
+
+	if numOfAccounts == 0 {
+		return nil
+	}
+
+	h.Changes = make([]Change, numOfAccounts)
+
+	valOffset := 4 + numOfAccounts*keyLen + 4*numOfAccounts
+	if uint32(len(b)) < valOffset {
+		fmt.Println("DecodeAccounts account")
+		return fmt.Errorf("decode: input too short (%d bytes, expected at least %d bytes)", len(b), valOffset)
+	}
+
+	totalValLength := binary.BigEndian.Uint32(b[valOffset-4 : valOffset])
+	if uint32(len(b)) < valOffset+totalValLength {
+		return fmt.Errorf("decode: input too short (%d bytes, expected at least %d bytes)", len(b), valOffset+totalValLength)
+	}
+
+	for i := uint32(0); i < numOfAccounts; i++ {
+		key := b[4+i*keyLen : 4+(i+1)*keyLen]
+		idx0 := uint32(0)
+		if i > 0 {
+			idx0 = binary.BigEndian.Uint32(b[4+numOfAccounts*keyLen+4*(i-1) : 4+numOfAccounts*keyLen+4*i])
+		}
+		idx1 := binary.BigEndian.Uint32(b[4+numOfAccounts*keyLen+4*i : 4+numOfAccounts*keyLen+4*(i+1)])
+		val := b[valOffset+idx0 : valOffset+idx1]
+
+		h.Changes[i].Key = common.CopyBytes(key)
+		h.Changes[i].Value = common.CopyBytes(val)
+	}
+
+	sort.Sort(h)
+	return nil
+}
+
+/*
+AccountChangeSet is serialized in the following manner in order to facilitate binary search:
+1. The number of keys N (uint32, 4 bytes).
+2. Contiguous array of keys (N*M bytes).
+3. Contiguous array of accumulating value indexes:
+len(val0), len(val0)+len(val1), ..., len(val0)+len(val1)+...+len(val_{N-1})
+(4*N bytes since the lengths are treated as uint32).
+4. Contiguous array of values.
+
+uint32 integers are serialized as big-endian.
+*/
+func encodeAccounts(s *ChangeSet) ([]byte, error) {
+	sort.Sort(s)
+	buf := new(bytes.Buffer)
+	intArr := make([]byte, 4)
+	n := s.Len()
+	binary.BigEndian.PutUint32(intArr, uint32(n))
+	_, err := buf.Write(intArr)
+	if err != nil {
+		return nil, err
+	}
+
+	for i := 0; i < n; i++ {
+		_, err = buf.Write(s.Changes[i].Key)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	var l int
+	for i := 0; i < n; i++ {
+		l += len(s.Changes[i].Value)
+		binary.BigEndian.PutUint32(intArr, uint32(l))
+		_, err = buf.Write(intArr)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	for i := 0; i < n; i++ {
+		_, err = buf.Write(s.Changes[i].Value)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return buf.Bytes(), nil
+}

--- a/common/changeset/storage_changeset.go
+++ b/common/changeset/storage_changeset.go
@@ -1,11 +1,7 @@
 package changeset
 
 import (
-	"bytes"
-	"encoding/binary"
 	"errors"
-	"fmt"
-	"sort"
 
 	"github.com/ledgerwatch/turbo-geth/common"
 )
@@ -20,6 +16,8 @@ var (
 	ErrFindValue     = errors.New("find value error")
 )
 
+/* Hashed changesets (key is a hash of common.Address) */
+
 func NewStorageChangeSet() *ChangeSet {
 	return &ChangeSet{
 		Changes: make([]Change, 0),
@@ -27,445 +25,65 @@ func NewStorageChangeSet() *ChangeSet {
 	}
 }
 
-/**
-numOfElements uint32
-numOfUniqueContracts uint16
-[]{
-	addrhash common.Hash
-	numOfStorageKeysToSkip uint16
-}
-keys     []common.Hash numOfElements
- lenToValue []uint16,
-numOfUint8Values uint16
-numOfUint16Values uint16
-numOfUint32Values uint16
-[len(val0), len(val0)+len(val1), ..., len(val0)+len(val1)+...+len(val_{numOfUint8Values-1})] []uint8
-[len(valnumOfUint8Values), len(val0)+len(val1), ..., len(val0)+len(val1)+...+len(val_{numOfUint16Values-1})] []uint16
-[len(valnumOfUint16Values), len(val0)+len(val1), ..., len(val0)+len(val1)+...+len(val_{numOfUint32Values-1})] []uint32
-[elementNum:incarnation] -  optional [uint32:uint64...]
-
-*/
-
 func EncodeStorage(s *ChangeSet) ([]byte, error) {
-	sort.Sort(s)
-	var err error
-	buf := new(bytes.Buffer)
-	uint16Arr := make([]byte, 2)
-	uint32Arr := make([]byte, 4)
-	numOfElements := s.Len()
-
-	keys := make([]contractKeys, 0, numOfElements)
-	valLengthes := make([]byte, 0, numOfElements)
-	var (
-		currentContract contractKeys
-		numOfUint8      uint32
-		numOfUint16     uint32
-		numOfUint32     uint32
-		lengthOfValues  uint32
-	)
-	var nonDefaultIncarnationCounter uint32
-	//first 4 bytes - len. body -  []{idOfAddrHash(4) +  incarnation(8)}
-	notDefaultIncarnationsBytes := make([]byte, 4)
-	b := make([]byte, 12)
-
-	currentKey := -1
-	for i, change := range s.Changes {
-		addrHash := change.Key[0:common.HashLength]
-		incarnation := ^binary.BigEndian.Uint64(change.Key[common.HashLength:])
-		keyHash := change.Key[common.HashLength+common.IncarnationLength : 2*common.HashLength+common.IncarnationLength]
-		//found new contract address
-		if i == 0 || !bytes.Equal(currentContract.AddrHash, addrHash) || currentContract.Incarnation != incarnation {
-			currentKey++
-			currentContract.AddrHash = addrHash
-			currentContract.Incarnation = incarnation
-			//add to incarnations part only if it's not default
-			if incarnation != DefaultIncarnation {
-				binary.BigEndian.PutUint32(b[0:], uint32(currentKey))
-				binary.BigEndian.PutUint64(b[4:], ^incarnation)
-				notDefaultIncarnationsBytes = append(notDefaultIncarnationsBytes, b...)
-				nonDefaultIncarnationCounter++
-			}
-			currentContract.Keys = [][]byte{keyHash}
-			currentContract.Vals = [][]byte{change.Value}
-			keys = append(keys, currentContract)
-		} else {
-			//add key and value
-			currentContract.Keys = append(currentContract.Keys, keyHash)
-			currentContract.Vals = append(currentContract.Vals, change.Value)
-		}
-
-		//calculate lengthes of values
-		lengthOfValues += uint32(len(change.Value))
-		switch {
-		case lengthOfValues <= 255:
-			valLengthes = append(valLengthes, uint8(lengthOfValues))
-			numOfUint8++
-
-		case lengthOfValues <= 65535:
-			binary.BigEndian.PutUint16(uint16Arr, uint16(lengthOfValues))
-			valLengthes = append(valLengthes, uint16Arr...)
-			numOfUint16++
-
-		default:
-			binary.BigEndian.PutUint32(uint32Arr, lengthOfValues)
-			valLengthes = append(valLengthes, uint32Arr...)
-			numOfUint32++
-		}
-
-		//save to array
-		keys[currentKey] = currentContract
-	}
-
-	// save numOfUniqueContracts
-	binary.BigEndian.PutUint32(uint32Arr, uint32(len(keys)))
-	if _, err = buf.Write(uint32Arr); err != nil {
-		return nil, err
-	}
-
-	if len(keys) == 0 {
-		return nil, errIncorrectData
-	}
-
-	// save addrHashes + endOfKeys
-	var endNumOfKeys int
-	for i := 0; i < len(keys); i++ {
-		if _, err = buf.Write(keys[i].AddrHash); err != nil {
-			return nil, err
-		}
-		endNumOfKeys += len(keys[i].Keys)
-
-		//end of keys
-		binary.BigEndian.PutUint32(uint32Arr, uint32(endNumOfKeys))
-		if _, err = buf.Write(uint32Arr); err != nil {
-			return nil, err
-		}
-	}
-
-	if endNumOfKeys != numOfElements {
-		return nil, fmt.Errorf("incorrect number of elements must:%v current:%v", numOfElements, endNumOfKeys)
-	}
-
-	// save not default incarnations
-	binary.BigEndian.PutUint32(notDefaultIncarnationsBytes, nonDefaultIncarnationCounter)
-	if _, err = buf.Write(notDefaultIncarnationsBytes); err != nil {
-		return nil, err
-	}
-
-	// save keys
-	for _, group := range keys {
-		for _, v := range group.Keys {
-			if _, err = buf.Write(v); err != nil {
-				return nil, err
-			}
-		}
-	}
-
-	// save lengths of values
-	binary.BigEndian.PutUint32(uint32Arr, numOfUint8)
-	if _, err = buf.Write(uint32Arr); err != nil {
-		return nil, err
-	}
-
-	binary.BigEndian.PutUint32(uint32Arr, numOfUint16)
-	if _, err = buf.Write(uint32Arr); err != nil {
-		return nil, err
-	}
-
-	binary.BigEndian.PutUint32(uint32Arr, numOfUint32)
-	if _, err = buf.Write(uint32Arr); err != nil {
-		return nil, err
-	}
-
-	if _, err = buf.Write(valLengthes); err != nil {
-		return nil, err
-	}
-
-	// save values
-	for _, v := range keys {
-		for _, val := range v.Vals {
-			if _, err = buf.Write(val); err != nil {
-				return nil, err
-			}
-		}
-	}
-	return buf.Bytes(), nil
+	return encodeStorage(s, common.HashLength)
 }
 
 func DecodeStorage(b []byte) (*ChangeSet, error) {
-	numOfUniqueElements := int(binary.BigEndian.Uint32(b))
-	if numOfUniqueElements == 0 {
-		return &ChangeSet{
-			Changes: make([]Change, 0),
-			keyLen:  72,
-		}, nil
-	}
-
-	keys := make([]contractKeys, numOfUniqueElements)
-	numOfSkipKeys := make([]int, numOfUniqueElements+1)
-	for i := 0; i < numOfUniqueElements; i++ {
-		start := 4 + i*(common.HashLength+4)
-		keys[i].AddrHash = b[start : start+common.HashLength]
-		numOfSkipKeys[i+1] = int(binary.BigEndian.Uint32(b[start+common.HashLength:]))
-		keys[i].Incarnation = DefaultIncarnation
-	}
-	numOfElements := numOfSkipKeys[numOfUniqueElements]
-	incarnatonsInfo := 4 + numOfUniqueElements*(common.HashLength+4)
-	numOfNotDefaultIncarnations := int(binary.BigEndian.Uint32(b[incarnatonsInfo:]))
-
-	incarnationsStart := incarnatonsInfo + 4
-	if numOfNotDefaultIncarnations > 0 {
-		for i := 0; i < numOfNotDefaultIncarnations; i++ {
-			id := binary.BigEndian.Uint32(b[incarnationsStart+i*12:])
-			keys[id].Incarnation = ^binary.BigEndian.Uint64(b[incarnationsStart+i*12+4:])
-		}
-	}
-
-	keysStart := incarnationsStart + numOfNotDefaultIncarnations*12
-
-	for i := 0; i < numOfUniqueElements; i++ {
-		keys[i].Keys = make([][]byte, 0, numOfSkipKeys[i+1]-numOfSkipKeys[i])
-		for j := numOfSkipKeys[i]; j < numOfSkipKeys[i+1]; j++ {
-			keys[i].Keys = append(keys[i].Keys, b[keysStart+j*common.HashLength:keysStart+(j+1)*common.HashLength])
-		}
-	}
-
-	valsInfoStart := keysStart + numOfElements*common.HashLength
 	cs := NewStorageChangeSet()
-	cs.Changes = make([]Change, numOfElements)
-	id := 0
-	for _, v := range keys {
-		for i := range v.Keys {
-			k := make([]byte, common.HashLength*2+common.IncarnationLength)
-			copy(k[:common.HashLength], v.AddrHash)
-			binary.BigEndian.PutUint64(k[common.HashLength:], ^v.Incarnation)
-			copy(k[common.HashLength+common.IncarnationLength:common.HashLength*2+common.IncarnationLength], v.Keys[i])
-			val, innerErr := FindValue(b[valsInfoStart:], id)
-			if innerErr != nil {
-				return nil, innerErr
-			}
-			cs.Changes[id] = Change{
-				Key:   k,
-				Value: val,
-			}
-
-			id++
-		}
+	err := decodeStorage(b, common.HashLength, cs)
+	if err != nil {
+		return nil, err
 	}
-
 	return cs, nil
-}
-
-func FindValue(b []byte, i int) ([]byte, error) {
-	numOfUint8 := int(binary.BigEndian.Uint32(b[0:]))
-	numOfUint16 := int(binary.BigEndian.Uint32(b[4:]))
-	numOfUint32 := int(binary.BigEndian.Uint32(b[8:]))
-	//after num of values
-	lenOfValsStartPointer := 12
-	valsPointer := lenOfValsStartPointer + numOfUint8 + numOfUint16*2 + numOfUint32*4
-	var (
-		lenOfValStart int
-		lenOfValEnd   int
-	)
-
-	switch {
-	case i < numOfUint8:
-		lenOfValEnd = int(b[lenOfValsStartPointer+i])
-		if i > 0 {
-			lenOfValStart = int(b[lenOfValsStartPointer+i-1])
-		}
-	case i < numOfUint8+numOfUint16:
-		one := (i-numOfUint8)*2 + numOfUint8
-		lenOfValEnd = int(binary.BigEndian.Uint16(b[lenOfValsStartPointer+one : lenOfValsStartPointer+one+2]))
-		if i-1 < numOfUint8 {
-			lenOfValStart = int(b[lenOfValsStartPointer+i-1])
-		} else {
-			one = (i-1)*2 - numOfUint8
-			lenOfValStart = int(binary.BigEndian.Uint16(b[lenOfValsStartPointer+one : lenOfValsStartPointer+one+2]))
-		}
-	case i < numOfUint8+numOfUint16+numOfUint32:
-		one := lenOfValsStartPointer + numOfUint8 + numOfUint16*2 + (i-numOfUint8-numOfUint16)*4
-		lenOfValEnd = int(binary.BigEndian.Uint32(b[one : one+4]))
-		if i-1 < numOfUint8+numOfUint16 {
-			one = lenOfValsStartPointer + (i-1)*2 - numOfUint8
-			lenOfValStart = int(binary.BigEndian.Uint16(b[one : one+2]))
-		} else {
-			one = lenOfValsStartPointer + numOfUint8 + numOfUint16*2 + (i-1-numOfUint8-numOfUint16)*4
-			lenOfValStart = int(binary.BigEndian.Uint32(b[one : one+4]))
-		}
-	default:
-		return nil, ErrFindValue
-	}
-	return b[valsPointer+lenOfValStart : valsPointer+lenOfValEnd], nil
 }
 
 type StorageChangeSetBytes []byte
 
 func (b StorageChangeSetBytes) Walk(f func(k, v []byte) error) error {
-	if len(b) == 0 {
-		return nil
-	}
-
-	if len(b) < 4 {
-		return fmt.Errorf("decode: input too short (%d bytes)", len(b))
-	}
-
-	numOfUniqueElements := int(binary.BigEndian.Uint32(b))
-	if numOfUniqueElements == 0 {
-		return nil
-	}
-	incarnatonsInfo := 4 + numOfUniqueElements*(common.HashLength+4)
-	numOfNotDefaultIncarnations := int(binary.BigEndian.Uint32(b[incarnatonsInfo:]))
-	incarnatonsStart := incarnatonsInfo + 4
-
-	notDefaultIncarnations := make(map[uint32]uint64, numOfNotDefaultIncarnations)
-	if numOfNotDefaultIncarnations > 0 {
-		for i := 0; i < numOfNotDefaultIncarnations; i++ {
-			notDefaultIncarnations[binary.BigEndian.Uint32(b[incarnatonsStart+i*12:])] = ^binary.BigEndian.Uint64(b[incarnatonsStart+i*12+4:])
-		}
-	}
-
-	keysStart := incarnatonsStart + numOfNotDefaultIncarnations*12
-	numOfElements := int(binary.BigEndian.Uint32(b[incarnatonsInfo-4:]))
-	valsInfoStart := keysStart + numOfElements*common.HashLength
-
-	var addressHashID uint32
-	var id int
-	k := make([]byte, common.HashLength*2+common.IncarnationLength)
-	for i := 0; i < numOfUniqueElements; i++ {
-		var (
-			startKeys int
-			endKeys   int
-		)
-
-		if i > 0 {
-			startKeys = int(binary.BigEndian.Uint32(b[4+i*(common.HashLength)+(i-1)*4 : 4+i*(common.HashLength)+(i)*4]))
-		}
-		endKeys = int(binary.BigEndian.Uint32(b[4+(i+1)*(common.HashLength)+i*4:]))
-		addrHash := b[4+i*(common.HashLength)+i*4:]
-		incarnation := DefaultIncarnation
-		if inc, ok := notDefaultIncarnations[addressHashID]; ok {
-			incarnation = inc
-		}
-
-		for j := startKeys; j < endKeys; j++ {
-			copy(k[:common.HashLength], addrHash[:common.HashLength])
-			copy(k[common.HashLength+common.IncarnationLength:2*common.HashLength+common.IncarnationLength], b[keysStart+j*common.HashLength:])
-			binary.BigEndian.PutUint64(k[common.HashLength:], ^incarnation)
-			val, innerErr := FindValue(b[valsInfoStart:], id)
-			if innerErr != nil {
-				return innerErr
-			}
-			err := f(k, val)
-			if err != nil {
-				return err
-			}
-			id++
-		}
-		addressHashID++
-	}
-
-	return nil
+	return walkStorageChangeSet(b, common.HashLength, f)
 }
 
 func (b StorageChangeSetBytes) Find(k []byte) ([]byte, error) {
-	if len(b) == 0 {
-		return nil, nil
-	}
-	if len(b) < 4 {
-		return nil, fmt.Errorf("decode: input too short (%d bytes)", len(b))
-	}
-
-	numOfUniqueElements := int(binary.BigEndian.Uint32(b))
-	if numOfUniqueElements == 0 {
-		return nil, ErrNotFound
-	}
-
-	incarnatonsInfo := 4 + numOfUniqueElements*(common.HashLength+4)
-	numOfElements := int(binary.BigEndian.Uint32(b[incarnatonsInfo-4:]))
-	numOfNotDefaultIncarnations := int(binary.BigEndian.Uint32(b[incarnatonsInfo:]))
-	incarnatonsStart := incarnatonsInfo + 4
-	keysStart := incarnatonsStart + numOfNotDefaultIncarnations*12
-	valsInfoStart := keysStart + numOfElements*common.HashLength
-
-	addHashID := sort.Search(numOfUniqueElements, func(i int) bool {
-		addrHash := b[4+i*(4+common.HashLength) : 4+i*(4+common.HashLength)+common.HashLength]
-		cmp := bytes.Compare(addrHash, k[0:common.HashLength])
-		return cmp >= 0
-	})
-
-	if addHashID == numOfUniqueElements {
-		return nil, ErrNotFound
-	}
-
-	from := 0
-	if addHashID > 0 {
-		from = int(binary.BigEndian.Uint32(b[4+addHashID*(common.HashLength+4)-4:]))
-	}
-	to := int(binary.BigEndian.Uint32(b[4+addHashID*(common.HashLength+4)+common.HashLength:]))
-
-	keyIndex := sort.Search(to-from, func(i int) bool {
-		index := from + i
-		key := b[keysStart+common.HashLength*index : keysStart+common.HashLength*index+common.HashLength]
-		cmp := bytes.Compare(key, k[common.HashLength+common.IncarnationLength:2*common.HashLength+common.IncarnationLength])
-		return cmp >= 0
-	})
-	index := from + keyIndex
-	if index == to {
-		return nil, ErrNotFound
-	}
-	return FindValue(b[valsInfoStart:], index)
+	return findInStorageChangeSet(b, common.HashLength, k)
 }
 
 func (b StorageChangeSetBytes) FindWithoutIncarnation(addrHashToFind []byte, keyHashToFind []byte) ([]byte, error) {
-	if len(b) == 0 {
-		return nil, nil
-	}
-	if len(b) < 4 {
-		return nil, fmt.Errorf("decode: input too short (%d bytes)", len(b))
-	}
-
-	numOfUniqueElements := int(binary.BigEndian.Uint32(b))
-	if numOfUniqueElements == 0 {
-		return nil, nil
-	}
-	incarnatonsInfo := 4 + numOfUniqueElements*(common.HashLength+4)
-	numOfElements := int(binary.BigEndian.Uint32(b[incarnatonsInfo-4:]))
-	numOfNotDefaultIncarnations := int(binary.BigEndian.Uint32(b[incarnatonsInfo:]))
-	incarnatonsStart := incarnatonsInfo + 4
-	keysStart := incarnatonsStart + numOfNotDefaultIncarnations*12
-	valsInfoStart := keysStart + numOfElements*common.HashLength
-
-	addHashID := sort.Search(numOfUniqueElements, func(i int) bool {
-		addrHash := b[4+i*(common.HashLength+4) : 4+i*(common.HashLength+4)+common.HashLength]
-		cmp := bytes.Compare(addrHash, addrHashToFind)
-		return cmp >= 0
-	})
-
-	if addHashID == numOfUniqueElements {
-		return nil, ErrNotFound
-	}
-	from := 0
-	if addHashID > 0 {
-		from = int(binary.BigEndian.Uint32(b[4+addHashID*(common.HashLength+4)-4:]))
-	}
-	to := int(binary.BigEndian.Uint32(b[4+addHashID*(common.HashLength+4)+common.HashLength:]))
-	keyIndex := sort.Search(to-from, func(i int) bool {
-		index := from + i
-		key := b[keysStart+common.HashLength*index : keysStart+common.HashLength*index+common.HashLength]
-		cmp := bytes.Compare(key, keyHashToFind)
-		return cmp >= 0
-	})
-	index := from + keyIndex
-	if index == to {
-		return nil, ErrNotFound
-	}
-
-	return FindValue(b[valsInfoStart:], index)
+	return findWithoutIncarnationInStorageChangeSet(b, common.HashLength, addrHashToFind, keyHashToFind)
 }
 
-type contractKeys struct {
-	AddrHash    []byte
-	Incarnation uint64
-	Keys        [][]byte
-	Vals        [][]byte
+/* Plain changesets (key is a common.Address) */
+
+func NewStorageChangeSetPlain() *ChangeSet {
+	return &ChangeSet{
+		Changes: make([]Change, 0),
+		keyLen:  common.AddressLength + common.HashLength + common.IncarnationLength,
+	}
+}
+
+func EncodeStoragePlain(s *ChangeSet) ([]byte, error) {
+	return encodeStorage(s, common.AddressLength)
+}
+
+func DecodeStoragePlain(b []byte) (*ChangeSet, error) {
+	cs := NewStorageChangeSetPlain()
+	err := decodeStorage(b, common.AddressLength, cs)
+	if err != nil {
+		return nil, err
+	}
+	return cs, nil
+}
+
+type StorageChangeSetPlainBytes []byte
+
+func (b StorageChangeSetPlainBytes) Walk(f func(k, v []byte) error) error {
+	return walkStorageChangeSet(b, common.AddressLength, f)
+}
+
+func (b StorageChangeSetPlainBytes) Find(k []byte) ([]byte, error) {
+	return findInStorageChangeSet(b, common.AddressLength, k)
+}
+
+func (b StorageChangeSetPlainBytes) FindWithoutIncarnation(addressToFind []byte, keyToFind []byte) ([]byte, error) {
+	return findWithoutIncarnationInStorageChangeSet(b, common.AddressLength, addressToFind, keyToFind)
 }

--- a/common/changeset/storage_changeset_test.go
+++ b/common/changeset/storage_changeset_test.go
@@ -16,7 +16,7 @@ const (
 	defaultIncarnation = 1
 )
 
-var numOfChanges = []int{1, 3, 10, 100, 1000}
+var numOfChanges = []int{1, 3, 10, 100}
 
 func getDefaultIncarnation() uint64 { return defaultIncarnation }
 func getRandomIncarnation() uint64  { return rand.Uint64() }

--- a/common/changeset/storage_changeset_test.go
+++ b/common/changeset/storage_changeset_test.go
@@ -178,15 +178,6 @@ func doTestEncodingStorageNew(
 	t.Run(formatTestName(100, 1000), func(t *testing.T) {
 		f(t, 100, 1000)
 	})
-	t.Run(formatTestName(1000, 1000), func(t *testing.T) {
-		f(t, 1000, 1000)
-	})
-	t.Run(formatTestName(5, 10000), func(t *testing.T) {
-		f(t, 5, 10000)
-	})
-	t.Run(formatTestName(20, 30000), func(t *testing.T) {
-		f(t, 20, 30000)
-	})
 }
 
 func TestEncodingStorageNewWithoutNotDefaultIncarnationWalkHashed(t *testing.T) {
@@ -260,18 +251,8 @@ func doTestWalk(
 	t.Run(formatTestName(50, 1000), func(t *testing.T) {
 		f(t, 50, 1000)
 	})
-	t.Run(formatTestName(5, 10000), func(t *testing.T) {
-		f(t, 5, 10000)
-	})
-
-	t.Run(formatTestName(100, 1000), func(t *testing.T) {
-		f(t, 100, 1000)
-	})
-	t.Run(formatTestName(1000, 1000), func(t *testing.T) {
-		f(t, 1000, 1000)
-	})
-	t.Run(formatTestName(20, 30000), func(t *testing.T) {
-		f(t, 20, 30000)
+	t.Run(formatTestName(5, 1000), func(t *testing.T) {
+		f(t, 5, 1000)
 	})
 }
 
@@ -369,18 +350,9 @@ func doTestFind(
 	t.Run(formatTestName(50, 1000), func(t *testing.T) {
 		f(t, 50, 1000)
 	})
-	t.Run(formatTestName(5, 10000), func(t *testing.T) {
-		f(t, 5, 10000)
-	})
 
 	t.Run(formatTestName(100, 1000), func(t *testing.T) {
 		f(t, 100, 1000)
-	})
-	t.Run(formatTestName(1000, 1000), func(t *testing.T) {
-		f(t, 1000, 1000)
-	})
-	t.Run(formatTestName(20, 30000), func(t *testing.T) {
-		f(t, 20, 30000)
 	})
 }
 

--- a/common/changeset/storage_changeset_test.go
+++ b/common/changeset/storage_changeset_test.go
@@ -16,6 +16,8 @@ const (
 	defaultIncarnation = 1
 )
 
+var numOfChanges = []int{1, 3, 10, 100, 1000}
+
 func getDefaultIncarnation() uint64 { return defaultIncarnation }
 func getRandomIncarnation() uint64  { return rand.Uint64() }
 
@@ -41,8 +43,6 @@ func getHashedBytes(b []byte) csStorageBytes {
 func getPlainBytes(b []byte) csStorageBytes {
 	return StorageChangeSetPlainBytes(b)
 }
-
-var numOfChanges = []int{1, 3, 10, 100, 1000, 10000}
 
 func getTestDataAtIndex(i, j int, inc uint64, generator func(common.Address, uint64, common.Hash) []byte) []byte {
 	address := common.HexToAddress(fmt.Sprintf("0xBe828AD8B538D1D691891F6c725dEdc5989abBc%d", i))

--- a/common/changeset/storage_changeset_utils.go
+++ b/common/changeset/storage_changeset_utils.go
@@ -1,0 +1,428 @@
+package changeset
+
+import (
+	"bytes"
+	"encoding/binary"
+	"fmt"
+	"sort"
+
+	"github.com/ledgerwatch/turbo-geth/common"
+)
+
+/**
+numOfElements uint32
+numOfUniqueContracts uint16
+[]{
+	addrhash common.Hash
+	numOfStorageKeysToSkip uint16
+}
+keys     []common.Hash numOfElements
+ lenToValue []uint16,
+numOfUint8Values uint16
+numOfUint16Values uint16
+numOfUint32Values uint16
+[len(val0), len(val0)+len(val1), ..., len(val0)+len(val1)+...+len(val_{numOfUint8Values-1})] []uint8
+[len(valnumOfUint8Values), len(val0)+len(val1), ..., len(val0)+len(val1)+...+len(val_{numOfUint16Values-1})] []uint16
+[len(valnumOfUint16Values), len(val0)+len(val1), ..., len(val0)+len(val1)+...+len(val_{numOfUint32Values-1})] []uint32
+[elementNum:incarnation] -  optional [uint32:uint64...]
+
+*/
+
+// encodeStorage encodes a storage changeset into a stream of bytes
+// storage changesets use composite length
+// provided `keyPrefixLen` is a length of the 1st part of the key
+// - for hashed changesets it is common.HashLength (key: hash + incarnation + hash)
+// - for plain changesets it is common.AddressLength (key: address + incarnation + hash)
+func encodeStorage(s *ChangeSet, keyPrefixLen uint32) ([]byte, error) {
+	sort.Sort(s)
+	var err error
+	buf := new(bytes.Buffer)
+	uint16Arr := make([]byte, 2)
+	uint32Arr := make([]byte, 4)
+	numOfElements := s.Len()
+
+	keys := make([]contractKeys, 0, numOfElements)
+	valLengthes := make([]byte, 0, numOfElements)
+	var (
+		currentContract contractKeys
+		numOfUint8      uint32
+		numOfUint16     uint32
+		numOfUint32     uint32
+		lengthOfValues  uint32
+	)
+	var nonDefaultIncarnationCounter uint32
+	//first 4 bytes - len. body -  []{idOfAddrHash(4) +  incarnation(8)}
+	notDefaultIncarnationsBytes := make([]byte, 4)
+	b := make([]byte, 12)
+
+	currentKey := -1
+	for i, change := range s.Changes {
+		addrBytes := change.Key[0:keyPrefixLen] // hash or raw address
+		incarnation := ^binary.BigEndian.Uint64(change.Key[keyPrefixLen:])
+		keyBytes := change.Key[keyPrefixLen+common.IncarnationLength : keyPrefixLen+common.HashLength+common.IncarnationLength] // hash or raw key
+		//found new contract address
+		if i == 0 || !bytes.Equal(currentContract.AddrBytes, addrBytes) || currentContract.Incarnation != incarnation {
+			currentKey++
+			currentContract.AddrBytes = addrBytes
+			currentContract.Incarnation = incarnation
+			//add to incarnations part only if it's not default
+			if incarnation != DefaultIncarnation {
+				binary.BigEndian.PutUint32(b[0:], uint32(currentKey))
+				binary.BigEndian.PutUint64(b[4:], ^incarnation)
+				notDefaultIncarnationsBytes = append(notDefaultIncarnationsBytes, b...)
+				nonDefaultIncarnationCounter++
+			}
+			currentContract.Keys = [][]byte{keyBytes}
+			currentContract.Vals = [][]byte{change.Value}
+			keys = append(keys, currentContract)
+		} else {
+			//add key and value
+			currentContract.Keys = append(currentContract.Keys, keyBytes)
+			currentContract.Vals = append(currentContract.Vals, change.Value)
+		}
+
+		//calculate lengthes of values
+		lengthOfValues += uint32(len(change.Value))
+		switch {
+		case lengthOfValues <= 255:
+			valLengthes = append(valLengthes, uint8(lengthOfValues))
+			numOfUint8++
+
+		case lengthOfValues <= 65535:
+			binary.BigEndian.PutUint16(uint16Arr, uint16(lengthOfValues))
+			valLengthes = append(valLengthes, uint16Arr...)
+			numOfUint16++
+
+		default:
+			binary.BigEndian.PutUint32(uint32Arr, lengthOfValues)
+			valLengthes = append(valLengthes, uint32Arr...)
+			numOfUint32++
+		}
+
+		//save to array
+		keys[currentKey] = currentContract
+	}
+
+	// save numOfUniqueContracts
+	binary.BigEndian.PutUint32(uint32Arr, uint32(len(keys)))
+	if _, err = buf.Write(uint32Arr); err != nil {
+		return nil, err
+	}
+
+	if len(keys) == 0 {
+		return nil, errIncorrectData
+	}
+
+	// save addrHashes + endOfKeys
+	var endNumOfKeys int
+	for i := 0; i < len(keys); i++ {
+		if _, err = buf.Write(keys[i].AddrBytes); err != nil {
+			return nil, err
+		}
+		endNumOfKeys += len(keys[i].Keys)
+
+		//end of keys
+		binary.BigEndian.PutUint32(uint32Arr, uint32(endNumOfKeys))
+		if _, err = buf.Write(uint32Arr); err != nil {
+			return nil, err
+		}
+	}
+
+	if endNumOfKeys != numOfElements {
+		return nil, fmt.Errorf("incorrect number of elements must:%v current:%v", numOfElements, endNumOfKeys)
+	}
+
+	// save not default incarnations
+	binary.BigEndian.PutUint32(notDefaultIncarnationsBytes, nonDefaultIncarnationCounter)
+	if _, err = buf.Write(notDefaultIncarnationsBytes); err != nil {
+		return nil, err
+	}
+
+	// save keys
+	for _, group := range keys {
+		for _, v := range group.Keys {
+			if _, err = buf.Write(v); err != nil {
+				return nil, err
+			}
+		}
+	}
+
+	// save lengths of values
+	binary.BigEndian.PutUint32(uint32Arr, numOfUint8)
+	if _, err = buf.Write(uint32Arr); err != nil {
+		return nil, err
+	}
+
+	binary.BigEndian.PutUint32(uint32Arr, numOfUint16)
+	if _, err = buf.Write(uint32Arr); err != nil {
+		return nil, err
+	}
+
+	binary.BigEndian.PutUint32(uint32Arr, numOfUint32)
+	if _, err = buf.Write(uint32Arr); err != nil {
+		return nil, err
+	}
+
+	if _, err = buf.Write(valLengthes); err != nil {
+		return nil, err
+	}
+
+	// save values
+	for _, v := range keys {
+		for _, val := range v.Vals {
+			if _, err = buf.Write(val); err != nil {
+				return nil, err
+			}
+		}
+	}
+	return buf.Bytes(), nil
+}
+
+// decodeStorage decodes a stream of bytes to a storage changeset using
+// specified `keyPrefixLen` (see `encodeStorage` in this file for explanation)
+func decodeStorage(b []byte, keyPrefixLen int, cs *ChangeSet) error {
+	numOfUniqueElements := int(binary.BigEndian.Uint32(b))
+	if numOfUniqueElements == 0 {
+		return nil
+	}
+
+	keys := make([]contractKeys, numOfUniqueElements)
+	numOfSkipKeys := make([]int, numOfUniqueElements+1)
+	for i := 0; i < numOfUniqueElements; i++ {
+		start := 4 + i*(keyPrefixLen+4)
+		keys[i].AddrBytes = b[start : start+keyPrefixLen]
+		numOfSkipKeys[i+1] = int(binary.BigEndian.Uint32(b[start+keyPrefixLen:]))
+		keys[i].Incarnation = DefaultIncarnation
+	}
+	numOfElements := numOfSkipKeys[numOfUniqueElements]
+	incarnatonsInfo := 4 + numOfUniqueElements*(keyPrefixLen+4)
+	numOfNotDefaultIncarnations := int(binary.BigEndian.Uint32(b[incarnatonsInfo:]))
+
+	incarnationsStart := incarnatonsInfo + 4
+	if numOfNotDefaultIncarnations > 0 {
+		for i := 0; i < numOfNotDefaultIncarnations; i++ {
+			id := binary.BigEndian.Uint32(b[incarnationsStart+i*12:])
+			keys[id].Incarnation = ^binary.BigEndian.Uint64(b[incarnationsStart+i*12+4:])
+		}
+	}
+
+	keysStart := incarnationsStart + numOfNotDefaultIncarnations*12
+
+	for i := 0; i < numOfUniqueElements; i++ {
+		keys[i].Keys = make([][]byte, 0, numOfSkipKeys[i+1]-numOfSkipKeys[i])
+		for j := numOfSkipKeys[i]; j < numOfSkipKeys[i+1]; j++ {
+			keys[i].Keys = append(keys[i].Keys, b[keysStart+j*common.HashLength:keysStart+(j+1)*common.HashLength])
+		}
+	}
+
+	valsInfoStart := keysStart + numOfElements*common.HashLength
+	cs.Changes = make([]Change, numOfElements)
+	id := 0
+	for _, v := range keys {
+		for i := range v.Keys {
+			k := make([]byte, keyPrefixLen+common.IncarnationLength+common.HashLength)
+			copy(k[:keyPrefixLen], v.AddrBytes)
+			binary.BigEndian.PutUint64(k[keyPrefixLen:], ^v.Incarnation)
+			copy(k[keyPrefixLen+common.IncarnationLength:keyPrefixLen+common.HashLength+common.IncarnationLength], v.Keys[i])
+			val, innerErr := findValue(b[valsInfoStart:], id)
+			if innerErr != nil {
+				return innerErr
+			}
+			cs.Changes[id] = Change{
+				Key:   k,
+				Value: val,
+			}
+
+			id++
+		}
+	}
+
+	return nil
+}
+
+func findValue(b []byte, i int) ([]byte, error) {
+	numOfUint8 := int(binary.BigEndian.Uint32(b[0:]))
+	numOfUint16 := int(binary.BigEndian.Uint32(b[4:]))
+	numOfUint32 := int(binary.BigEndian.Uint32(b[8:]))
+	//after num of values
+	lenOfValsStartPointer := 12
+	valsPointer := lenOfValsStartPointer + numOfUint8 + numOfUint16*2 + numOfUint32*4
+	var (
+		lenOfValStart int
+		lenOfValEnd   int
+	)
+
+	switch {
+	case i < numOfUint8:
+		lenOfValEnd = int(b[lenOfValsStartPointer+i])
+		if i > 0 {
+			lenOfValStart = int(b[lenOfValsStartPointer+i-1])
+		}
+	case i < numOfUint8+numOfUint16:
+		one := (i-numOfUint8)*2 + numOfUint8
+		lenOfValEnd = int(binary.BigEndian.Uint16(b[lenOfValsStartPointer+one : lenOfValsStartPointer+one+2]))
+		if i-1 < numOfUint8 {
+			lenOfValStart = int(b[lenOfValsStartPointer+i-1])
+		} else {
+			one = (i-1)*2 - numOfUint8
+			lenOfValStart = int(binary.BigEndian.Uint16(b[lenOfValsStartPointer+one : lenOfValsStartPointer+one+2]))
+		}
+	case i < numOfUint8+numOfUint16+numOfUint32:
+		one := lenOfValsStartPointer + numOfUint8 + numOfUint16*2 + (i-numOfUint8-numOfUint16)*4
+		lenOfValEnd = int(binary.BigEndian.Uint32(b[one : one+4]))
+		if i-1 < numOfUint8+numOfUint16 {
+			one = lenOfValsStartPointer + (i-1)*2 - numOfUint8
+			lenOfValStart = int(binary.BigEndian.Uint16(b[one : one+2]))
+		} else {
+			one = lenOfValsStartPointer + numOfUint8 + numOfUint16*2 + (i-1-numOfUint8-numOfUint16)*4
+			lenOfValStart = int(binary.BigEndian.Uint32(b[one : one+4]))
+		}
+	default:
+		return nil, ErrFindValue
+	}
+	return b[valsPointer+lenOfValStart : valsPointer+lenOfValEnd], nil
+}
+
+func walkStorageChangeSet(b []byte, keyPrefixLen int, f func(k, v []byte) error) error {
+	if len(b) == 0 {
+		return nil
+	}
+
+	if len(b) < 4 {
+		return fmt.Errorf("decode: input too short (%d bytes)", len(b))
+	}
+
+	numOfUniqueElements := int(binary.BigEndian.Uint32(b))
+	if numOfUniqueElements == 0 {
+		return nil
+	}
+	incarnatonsInfo := 4 + numOfUniqueElements*(keyPrefixLen+4)
+	numOfNotDefaultIncarnations := int(binary.BigEndian.Uint32(b[incarnatonsInfo:]))
+	incarnatonsStart := incarnatonsInfo + 4
+
+	notDefaultIncarnations := make(map[uint32]uint64, numOfNotDefaultIncarnations)
+	if numOfNotDefaultIncarnations > 0 {
+		for i := 0; i < numOfNotDefaultIncarnations; i++ {
+			notDefaultIncarnations[binary.BigEndian.Uint32(b[incarnatonsStart+i*12:])] = ^binary.BigEndian.Uint64(b[incarnatonsStart+i*12+4:])
+		}
+	}
+
+	keysStart := incarnatonsStart + numOfNotDefaultIncarnations*12
+	numOfElements := int(binary.BigEndian.Uint32(b[incarnatonsInfo-4:]))
+	valsInfoStart := keysStart + numOfElements*common.HashLength
+
+	var addressHashID uint32
+	var id int
+	k := make([]byte, keyPrefixLen+common.HashLength+common.IncarnationLength)
+	for i := 0; i < numOfUniqueElements; i++ {
+		var (
+			startKeys int
+			endKeys   int
+		)
+
+		if i > 0 {
+			startKeys = int(binary.BigEndian.Uint32(b[4+i*(keyPrefixLen)+(i-1)*4 : 4+i*(keyPrefixLen)+(i)*4]))
+		}
+		endKeys = int(binary.BigEndian.Uint32(b[4+(i+1)*(keyPrefixLen)+i*4:]))
+		addrBytes := b[4+i*(keyPrefixLen)+i*4:] // hash or raw address
+		incarnation := DefaultIncarnation
+		if inc, ok := notDefaultIncarnations[addressHashID]; ok {
+			incarnation = inc
+		}
+
+		for j := startKeys; j < endKeys; j++ {
+			copy(k[:keyPrefixLen], addrBytes[:keyPrefixLen])
+			binary.BigEndian.PutUint64(k[keyPrefixLen:], ^incarnation)
+			copy(k[keyPrefixLen+common.IncarnationLength:keyPrefixLen+common.HashLength+common.IncarnationLength], b[keysStart+j*common.HashLength:])
+			val, innerErr := findValue(b[valsInfoStart:], id)
+			if innerErr != nil {
+				return innerErr
+			}
+			err := f(k, val)
+			if err != nil {
+				return err
+			}
+			id++
+		}
+		addressHashID++
+	}
+
+	return nil
+}
+
+func findInStorageChangeSet(b []byte, keyPrefixLen int, k []byte) ([]byte, error) {
+	return doSearch(
+		b,
+		keyPrefixLen,
+		k[0:keyPrefixLen],
+		k[keyPrefixLen+common.IncarnationLength:keyPrefixLen+common.HashLength+common.IncarnationLength],
+	)
+}
+
+func findWithoutIncarnationInStorageChangeSet(b []byte, keyPrefixLen int, addrBytesToFind []byte, keyBytesToFind []byte) ([]byte, error) {
+	return doSearch(
+		b,
+		keyPrefixLen,
+		addrBytesToFind,
+		keyBytesToFind,
+	)
+}
+
+func doSearch(
+	b []byte,
+	keyPrefixLen int,
+	addrBytesToFind []byte,
+	keyBytesToFind []byte,
+) ([]byte, error) {
+	if len(b) == 0 {
+		return nil, nil
+	}
+	if len(b) < 4 {
+		return nil, fmt.Errorf("decode: input too short (%d bytes)", len(b))
+	}
+
+	numOfUniqueElements := int(binary.BigEndian.Uint32(b))
+	if numOfUniqueElements == 0 {
+		return nil, nil
+	}
+	incarnatonsInfo := 4 + numOfUniqueElements*(keyPrefixLen+4)
+	numOfElements := int(binary.BigEndian.Uint32(b[incarnatonsInfo-4:]))
+	numOfNotDefaultIncarnations := int(binary.BigEndian.Uint32(b[incarnatonsInfo:]))
+	incarnatonsStart := incarnatonsInfo + 4
+	keysStart := incarnatonsStart + numOfNotDefaultIncarnations*12
+	valsInfoStart := keysStart + numOfElements*common.HashLength
+
+	addrID := sort.Search(numOfUniqueElements, func(i int) bool {
+		addrBytes := b[4+i*(4+keyPrefixLen) : 4+i*(4+keyPrefixLen)+keyPrefixLen]
+		cmp := bytes.Compare(addrBytes, addrBytesToFind)
+		return cmp >= 0
+	})
+
+	if addrID == numOfUniqueElements {
+		return nil, ErrNotFound
+	}
+	from := 0
+	if addrID > 0 {
+		from = int(binary.BigEndian.Uint32(b[4+addrID*(keyPrefixLen+4)-4:]))
+	}
+	to := int(binary.BigEndian.Uint32(b[4+addrID*(keyPrefixLen+4)+keyPrefixLen:]))
+	keyIndex := sort.Search(to-from, func(i int) bool {
+		index := from + i
+		key := b[keysStart+common.HashLength*index : keysStart+common.HashLength*index+common.HashLength]
+		cmp := bytes.Compare(key, keyBytesToFind)
+		return cmp >= 0
+	})
+	index := from + keyIndex
+	if index == to {
+		return nil, ErrNotFound
+	}
+
+	return findValue(b[valsInfoStart:], index)
+}
+
+type contractKeys struct {
+	AddrBytes   []byte // either a hash of address or raw address
+	Incarnation uint64
+	Keys        [][]byte
+	Vals        [][]byte
+}

--- a/common/dbutils/bucket.go
+++ b/common/dbutils/bucket.go
@@ -4,6 +4,31 @@ import "github.com/ledgerwatch/turbo-geth/metrics"
 
 // The fields below define the low level database schema prefixing.
 var (
+	// "Plain State". The same as CurrentStateBucket, but the keys arent' hashed.
+
+	// Contains Accounts:
+	//   key - address (unhashed)
+	//   value - account encoded for storage
+	// Contains Storage:
+	//   key - address (unhashed) + incarnation + storage key (unhashed)
+	//   value - storage value(common.hash)
+	PlainStateBucket = []byte("PLAIN-CST")
+
+	// "Plain State"
+	//key - address+incarnation
+	//value - code hash
+	PlainContractCodeBucket = []byte("PLAIN-contractCode")
+
+	// PlainAccountChangeSetBucket keeps changesets of accounts ("plain state")
+	// key - encoded timestamp(block number)
+	// value - encoded ChangeSet{k - address v - account(encoded).
+	PlainAccountChangeSetBucket = []byte("PLAIN-ACS")
+
+	// PlainStorageChangeSetBucket keeps changesets of storage ("plain state")
+	// key - encoded timestamp(block number)
+	// value - encoded ChangeSet{k - plainCompositeKey(for storage) v - originalValue(common.Hash)}.
+	PlainStorageChangeSetBucket = []byte("PLAIN-SCS")
+
 	// Contains Accounts:
 	// key - address hash
 	// value - account encoded for storage

--- a/common/dbutils/composite_keys_test.go
+++ b/common/dbutils/composite_keys_test.go
@@ -42,3 +42,55 @@ func TestHeaderTypeDetection(t *testing.T) {
 	assert.False(t, IsHeaderHashKey(notRelatedInput))
 
 }
+
+func TestPlainParseStoragePrefix(t *testing.T) {
+	expectedAddr := common.HexToAddress("0x5A0b54D5dc17e0AadC383d2db43B0a0D3E029c4c")
+	expectedIncarnation := uint64(999000999)
+
+	prefix := PlainGenerateStoragePrefix(expectedAddr, expectedIncarnation)
+
+	addr, incarnation := PlainParseStoragePrefix(prefix)
+
+	assert.Equal(t, expectedAddr, addr, "address should be extracted")
+	assert.Equal(t, expectedIncarnation, incarnation, "incarnation should be extracted")
+}
+
+func TestPlainParseCompositeStorageKey(t *testing.T) {
+	expectedAddr := common.HexToAddress("0x5A0b54D5dc17e0AadC383d2db43B0a0D3E029c4c")
+	expectedIncarnation := uint64(999000999)
+	expectedKey := common.HexToHash("0x58833f949125129fb8c6c93d2c6003c5bab7c0b116d695f4ca137b1debf4e472")
+
+	compositeKey := PlainGenerateCompositeStorageKey(expectedAddr, expectedIncarnation, expectedKey)
+
+	addr, incarnation, key := PlainParseCompositeStorageKey(compositeKey)
+
+	assert.Equal(t, expectedAddr, addr, "address should be extracted")
+	assert.Equal(t, expectedIncarnation, incarnation, "incarnation should be extracted")
+	assert.Equal(t, expectedKey, key, "key should be extracted")
+}
+
+func TestParseStoragePrefix(t *testing.T) {
+	expectedAddrHash, _ := common.HashData(common.HexToAddress("0x5A0b54D5dc17e0AadC383d2db43B0a0D3E029c4c").Bytes())
+	expectedIncarnation := uint64(999000999)
+
+	prefix := GenerateStoragePrefix(expectedAddrHash[:], expectedIncarnation)
+
+	addrHash, incarnation := ParseStoragePrefix(prefix)
+
+	assert.Equal(t, expectedAddrHash, addrHash, "address should be extracted")
+	assert.Equal(t, expectedIncarnation, incarnation, "incarnation should be extracted")
+}
+
+func TestParseCompositeStorageKey(t *testing.T) {
+	expectedAddrHash, _ := common.HashData(common.HexToAddress("0x5A0b54D5dc17e0AadC383d2db43B0a0D3E029c4c").Bytes())
+	expectedIncarnation := uint64(999000999)
+	expectedKey := common.HexToHash("0x58833f949125129fb8c6c93d2c6003c5bab7c0b116d695f4ca137b1debf4e472")
+
+	compositeKey := GenerateCompositeStorageKey(expectedAddrHash, expectedIncarnation, expectedKey)
+
+	addrHash, incarnation, key := ParseCompositeStorageKey(compositeKey)
+
+	assert.Equal(t, expectedAddrHash, addrHash, "address should be extracted")
+	assert.Equal(t, expectedIncarnation, incarnation, "incarnation should be extracted")
+	assert.Equal(t, expectedKey, key, "key should be extracted")
+}

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -2463,7 +2463,7 @@ func ExecuteBlockEuphemerally(
 	engine consensus.Engine,
 	block *types.Block,
 	stateReader state.StateReader,
-	stateWriter *state.DbStateWriter,
+	stateWriter state.WriterWithChangeSets,
 ) error {
 	ibs := state.New(stateReader)
 	header := block.Header()

--- a/core/rawdb/accessors_account.go
+++ b/core/rawdb/accessors_account.go
@@ -40,10 +40,7 @@ func WriteAccount(db DatabaseWriter, addrHash common.Hash, acc accounts.Account)
 	addrHashBytes := addrHash[:]
 	value := make([]byte, acc.EncodingLengthForStorage())
 	acc.EncodeForStorage(value)
-	if err := db.Put(dbutils.CurrentStateBucket, addrHashBytes, value); err != nil {
-		return err
-	}
-	return nil
+	return db.Put(dbutils.CurrentStateBucket, addrHashBytes, value)
 }
 
 type DatabaseReaderDeleter interface {

--- a/core/state/database.go
+++ b/core/state/database.go
@@ -37,6 +37,8 @@ import (
 	"github.com/ledgerwatch/turbo-geth/trie"
 )
 
+var _ StateWriter = (*TrieStateWriter)(nil)
+
 // MaxTrieCacheSize is the trie cache size limit after which to evict trie nodes from memory.
 var MaxTrieCacheSize = uint64(1024 * 1024)
 
@@ -57,10 +59,15 @@ type StateReader interface {
 
 type StateWriter interface {
 	UpdateAccountData(ctx context.Context, address common.Address, original, account *accounts.Account) error
-	UpdateAccountCode(addrHash common.Hash, incarnation uint64, codeHash common.Hash, code []byte) error
+	UpdateAccountCode(address common.Address, incarnation uint64, codeHash common.Hash, code []byte) error
 	DeleteAccount(ctx context.Context, address common.Address, original *accounts.Account) error
 	WriteAccountStorage(ctx context.Context, address common.Address, incarnation uint64, key, original, value *common.Hash) error
 	CreateContract(address common.Address) error
+}
+
+type WriterWithChangeSets interface {
+	StateWriter
+	WriteChangeSets() error
 }
 
 type NoopWriter struct {
@@ -78,7 +85,7 @@ func (nw *NoopWriter) DeleteAccount(_ context.Context, address common.Address, o
 	return nil
 }
 
-func (nw *NoopWriter) UpdateAccountCode(addrHash common.Hash, incarnation uint64, codeHash common.Hash, code []byte) error {
+func (nw *NoopWriter) UpdateAccountCode(address common.Address, incarnation uint64, codeHash common.Hash, code []byte) error {
 	return nil
 }
 
@@ -1320,9 +1327,13 @@ func (tsw *TrieStateWriter) DeleteAccount(_ context.Context, address common.Addr
 	return nil
 }
 
-func (tsw *TrieStateWriter) UpdateAccountCode(addrHash common.Hash, incarnation uint64, codeHash common.Hash, code []byte) error {
+func (tsw *TrieStateWriter) UpdateAccountCode(address common.Address, incarnation uint64, codeHash common.Hash, code []byte) error {
 	if tsw.tds.resolveReads {
 		tsw.tds.retainListBuilder.CreateCode(codeHash)
+	}
+	addrHash, err := common.HashData(address.Bytes())
+	if err != nil {
+		return err
 	}
 	tsw.tds.currentBuffer.codeUpdates[addrHash] = code
 	return nil

--- a/core/state/db_state_reader.go
+++ b/core/state/db_state_reader.go
@@ -12,13 +12,13 @@ import (
 
 // Implements StateReader by wrapping database only, without trie
 type DbStateReader struct {
-	db ethdb.Getter
+	db             ethdb.Getter
 	incarnationMap map[common.Address]uint64
 }
 
 func NewDbStateReader(db ethdb.Getter, incarnationMap map[common.Address]uint64) *DbStateReader {
 	return &DbStateReader{
-		db: db,
+		db:             db,
 		incarnationMap: incarnationMap,
 	}
 }
@@ -53,7 +53,7 @@ func (dbr *DbStateReader) ReadAccountStorage(address common.Address, incarnation
 	return enc, nil
 }
 
-func (dbr *DbStateReader) ReadAccountCode(address common.Address, codeHash common.Hash) (code []byte, err error) {
+func (dbr *DbStateReader) ReadAccountCode(_ common.Address, codeHash common.Hash) (code []byte, err error) {
 	if bytes.Equal(codeHash[:], emptyCodeHash) {
 		return nil, nil
 	}
@@ -61,7 +61,7 @@ func (dbr *DbStateReader) ReadAccountCode(address common.Address, codeHash commo
 	return code, err
 }
 
-func (dbr *DbStateReader) ReadAccountCodeSize(address common.Address, codeHash common.Hash) (codeSize int, err error) {
+func (dbr *DbStateReader) ReadAccountCodeSize(_ common.Address, codeHash common.Hash) (codeSize int, err error) {
 	if bytes.Equal(codeHash[:], emptyCodeHash) {
 		return 0, nil
 	}

--- a/core/state/intra_block_state.go
+++ b/core/state/intra_block_state.go
@@ -590,7 +590,6 @@ func (sdb *IntraBlockState) Suicide(addr common.Address) bool {
 	return true
 }
 
-
 var nullLocation = common.Hash{}
 var nullValue = common.Big0
 
@@ -788,12 +787,7 @@ func updateAccount(ctx context.Context, stateWriter StateWriter, addr common.Add
 	} else if isDirty {
 		// Write any contract code associated with the state object
 		if stateObject.code != nil && stateObject.dirtyCode {
-			addrHash, err := common.HashData(addr.Bytes())
-			if err != nil {
-				log.Error("Hashing address error", "err", err)
-				return err
-			}
-			if err := stateWriter.UpdateAccountCode(addrHash, stateObject.data.Incarnation, common.BytesToHash(stateObject.CodeHash()), stateObject.code); err != nil {
+			if err := stateWriter.UpdateAccountCode(addr, stateObject.data.Incarnation, common.BytesToHash(stateObject.CodeHash()), stateObject.code); err != nil {
 				return err
 			}
 		}

--- a/core/state/plain_state_reader.go
+++ b/core/state/plain_state_reader.go
@@ -1,0 +1,84 @@
+package state
+
+import (
+	"github.com/ledgerwatch/turbo-geth/common"
+	"github.com/ledgerwatch/turbo-geth/common/dbutils"
+	"github.com/ledgerwatch/turbo-geth/core/types/accounts"
+	"github.com/ledgerwatch/turbo-geth/ethdb"
+)
+
+var _ StateReader = (*PlainStateReader)(nil)
+
+// PlainStateReader reads data from so called "plain state".
+// Data in the plain state is stored using un-hashed account/storage items
+// as opposed to the "normal" state that uses hashes of merkle paths to store items.
+type PlainStateReader struct {
+	// Typically, the data will be scattered across "normal" and "plain" states.
+	// therefore we need fallback in case the data isn't found in the "plain" state.
+	fallback StateReader
+
+	db                     ethdb.Getter
+	uncommitedIncarnations map[common.Address]uint64
+}
+
+func NewPlainStateReaderWithFallback(db ethdb.Getter, incarnations map[common.Address]uint64, fallback StateReader) *PlainStateReader {
+	return &PlainStateReader{
+		fallback:               fallback,
+		db:                     db,
+		uncommitedIncarnations: incarnations,
+	}
+}
+
+func (r *PlainStateReader) ReadAccountData(address common.Address) (*accounts.Account, error) {
+	enc, err := r.db.Get(dbutils.PlainStateBucket, address[:])
+	if err == nil {
+		acc := &accounts.Account{}
+		if err = acc.DecodeForStorage(enc); err != nil {
+			return nil, err
+		}
+		return acc, nil
+	} else if !entryNotFound(err) {
+		return nil, err
+	}
+	return r.fallback.ReadAccountData(address)
+}
+
+func (r *PlainStateReader) ReadAccountStorage(address common.Address, incarnation uint64, key *common.Hash) ([]byte, error) {
+	enc, err := r.db.Get(dbutils.PlainStateBucket, dbutils.PlainGenerateCompositeStorageKey(address, incarnation, *key))
+	if err == nil {
+		return enc, nil
+	} else if !entryNotFound(err) {
+		return nil, err
+	}
+	return r.fallback.ReadAccountStorage(address, incarnation, key)
+}
+
+func (r *PlainStateReader) ReadAccountCode(address common.Address, codeHash common.Hash) ([]byte, error) {
+	// intentionally left blank: we read the code by `codeHash` only
+	return r.fallback.ReadAccountCode(address, codeHash)
+}
+
+func (r *PlainStateReader) ReadAccountCodeSize(address common.Address, codeHash common.Hash) (int, error) {
+	// intentionally left blank: we read the code size by `codeHash` only
+	return r.fallback.ReadAccountCodeSize(address, codeHash)
+}
+
+func (r *PlainStateReader) ReadAccountIncarnation(address common.Address) (uint64, error) {
+	if inc, ok := r.uncommitedIncarnations[address]; ok {
+		return inc, nil
+	}
+
+	incarnation, found, err := ethdb.PlainGetCurrentAccountIncarnation(r.db, address)
+	if err != nil {
+		return 0, err
+	}
+	if found {
+		return incarnation, nil
+	}
+
+	return r.fallback.ReadAccountIncarnation(address)
+}
+
+func entryNotFound(err error) bool {
+	return err == ethdb.ErrKeyNotFound
+}

--- a/core/state/plain_state_writer.go
+++ b/core/state/plain_state_writer.go
@@ -103,7 +103,7 @@ func (w *PlainStateWriter) WriteChangeSets() error {
 		return err
 	}
 	var accountSerialised []byte
-	accountSerialised, err = changeset.EncodeAccounts(accountChanges)
+	accountSerialised, err = changeset.EncodeAccountsPlain(accountChanges)
 	if err != nil {
 		return err
 	}
@@ -117,7 +117,7 @@ func (w *PlainStateWriter) WriteChangeSets() error {
 	}
 	var storageSerialized []byte
 	if storageChanges.Len() > 0 {
-		storageSerialized, err = changeset.EncodeStorage(storageChanges)
+		storageSerialized, err = changeset.EncodeStoragePlain(storageChanges)
 		if err != nil {
 			return err
 		}

--- a/core/state/plain_state_writer.go
+++ b/core/state/plain_state_writer.go
@@ -1,0 +1,129 @@
+package state
+
+import (
+	"context"
+
+	"github.com/ledgerwatch/turbo-geth/common"
+	"github.com/ledgerwatch/turbo-geth/common/changeset"
+	"github.com/ledgerwatch/turbo-geth/common/dbutils"
+	"github.com/ledgerwatch/turbo-geth/core/types/accounts"
+	"github.com/ledgerwatch/turbo-geth/ethdb"
+)
+
+var _ WriterWithChangeSets = (*PlainStateWriter)(nil)
+
+type PlainStateWriter struct {
+	db                     ethdb.Database
+	uncommitedIncarnations map[common.Address]uint64
+	csw                    *ChangeSetWriter
+	blockNumber            uint64
+}
+
+func NewPlainStateWriter(db ethdb.Database, blockNumber uint64, uncommitedIncarnations map[common.Address]uint64) *PlainStateWriter {
+	return &PlainStateWriter{
+		db:                     db,
+		uncommitedIncarnations: uncommitedIncarnations,
+		csw:                    NewChangeSetWriterPlain(),
+		blockNumber:            blockNumber,
+	}
+}
+
+func (w *PlainStateWriter) UpdateAccountData(ctx context.Context, address common.Address, original, account *accounts.Account) error {
+	if err := w.csw.UpdateAccountData(ctx, address, original, account); err != nil {
+		return err
+	}
+
+	value := make([]byte, account.EncodingLengthForStorage())
+	account.EncodeForStorage(value)
+	return w.db.Put(dbutils.PlainStateBucket, address[:], value)
+}
+
+func (w *PlainStateWriter) UpdateAccountCode(address common.Address, incarnation uint64, codeHash common.Hash, code []byte) error {
+	if err := w.csw.UpdateAccountCode(address, incarnation, codeHash, code); err != nil {
+		return err
+	}
+	if err := w.db.Put(dbutils.CodeBucket, codeHash[:], code); err != nil {
+		return err
+	}
+
+	return w.db.Put(dbutils.PlainContractCodeBucket, dbutils.PlainGenerateStoragePrefix(address, incarnation), codeHash[:])
+}
+
+func (w *PlainStateWriter) DeleteAccount(ctx context.Context, address common.Address, original *accounts.Account) error {
+	if err := w.csw.DeleteAccount(ctx, address, original); err != nil {
+		return err
+	}
+
+	if original.Incarnation > 0 {
+		w.uncommitedIncarnations[address] = original.Incarnation
+	}
+
+	if err := w.db.Delete(dbutils.PlainStateBucket, address[:]); err != nil {
+		if err != ethdb.ErrKeyNotFound {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (w *PlainStateWriter) WriteAccountStorage(ctx context.Context, address common.Address, incarnation uint64, key, original, value *common.Hash) error {
+	if err := w.csw.WriteAccountStorage(ctx, address, incarnation, key, original, value); err != nil {
+		return err
+	}
+	if *original == *value {
+		return nil
+	}
+
+	compositeKey := dbutils.PlainGenerateCompositeStorageKey(address, incarnation, *key)
+
+	v := cleanUpTrailingZeroes(value[:])
+
+	if len(v) == 0 {
+		if err := w.db.Delete(dbutils.PlainStateBucket, compositeKey); err != nil {
+			if err != ethdb.ErrKeyNotFound {
+				return err
+			}
+		}
+		return nil
+	}
+
+	vv := make([]byte, len(v))
+	copy(vv, v)
+	return w.db.Put(dbutils.PlainStateBucket, compositeKey, vv)
+}
+
+func (w *PlainStateWriter) CreateContract(address common.Address) error {
+	return w.csw.CreateContract(address)
+}
+
+func (w *PlainStateWriter) WriteChangeSets() error {
+	accountChanges, err := w.csw.GetAccountChanges()
+	if err != nil {
+		return err
+	}
+	var accountSerialised []byte
+	accountSerialised, err = changeset.EncodeAccounts(accountChanges)
+	if err != nil {
+		return err
+	}
+	key := dbutils.EncodeTimestamp(w.blockNumber)
+	if err = w.db.Put(dbutils.PlainAccountChangeSetBucket, key, accountSerialised); err != nil {
+		return err
+	}
+	storageChanges, err := w.csw.GetStorageChanges()
+	if err != nil {
+		return err
+	}
+	var storageSerialized []byte
+	if storageChanges.Len() > 0 {
+		storageSerialized, err = changeset.EncodeStorage(storageChanges)
+		if err != nil {
+			return err
+		}
+		if err = w.db.Put(dbutils.PlainStorageChangeSetBucket, key, storageSerialized); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/core/state/readonly.go
+++ b/core/state/readonly.go
@@ -32,6 +32,9 @@ import (
 	"github.com/petar/GoLLRB/llrb"
 )
 
+var _ StateReader = (*DbState)(nil)
+var _ StateWriter = (*DbState)(nil)
+
 type storageItem struct {
 	key, seckey, value common.Hash
 }
@@ -251,7 +254,7 @@ func (dbs *DbState) DeleteAccount(_ context.Context, address common.Address, ori
 	return nil
 }
 
-func (dbs *DbState) UpdateAccountCode(addrHash common.Hash, incarnation uint64, codeHash common.Hash, code []byte) error {
+func (dbs *DbState) UpdateAccountCode(address common.Address, incarnation uint64, codeHash common.Hash, code []byte) error {
 	return nil
 }
 

--- a/core/state/stateless.go
+++ b/core/state/stateless.go
@@ -29,6 +29,11 @@ import (
 	"github.com/ledgerwatch/turbo-geth/trie"
 )
 
+var (
+	_ StateReader = (*Stateless)(nil)
+	_ StateWriter = (*Stateless)(nil)
+)
+
 // Stateless is the inter-block cache for stateless client prototype, iteration 2
 // It creates the initial state trie during the construction, and then updates it
 // during the execution of block(s)
@@ -196,12 +201,11 @@ func (s *Stateless) DeleteAccount(_ context.Context, address common.Address, ori
 
 // UpdateAccountCode is a part of the StateWriter interface
 // This implementation adds the code to the codeMap to make it available for further accesses
-func (s *Stateless) UpdateAccountCode(addrHash common.Hash, incarnation uint64, codeHash common.Hash, code []byte) error {
-
+func (s *Stateless) UpdateAccountCode(address common.Address, incarnation uint64, codeHash common.Hash, code []byte) error {
 	s.codeUpdates[codeHash] = code
 
 	if s.trace {
-		fmt.Printf("Stateless: UpdateAccountCode %x codeHash %x\n", addrHash, codeHash)
+		fmt.Printf("Stateless: UpdateAccountCode %x codeHash %x\n", address, codeHash)
 	}
 	return nil
 }

--- a/core/state/util.go
+++ b/core/state/util.go
@@ -1,0 +1,7 @@
+package state
+
+import "bytes"
+
+func cleanUpTrailingZeroes(value []byte) []byte {
+	return bytes.TrimLeft(value[:], "\x00")
+}

--- a/eth/downloader/stagedsync_downloader.go
+++ b/eth/downloader/stagedsync_downloader.go
@@ -2,8 +2,11 @@ package downloader
 
 import (
 	"fmt"
+
 	"github.com/ledgerwatch/turbo-geth/log"
 )
+
+const enableHashChecks = false // FIXME: when we can move the hashed state forward.
 
 func (d *Downloader) doStagedSyncWithFetchers(p *peerConnection, headersFetchers []func() error) error {
 	log.Info("Sync stage 1/5. Downloading headers...")
@@ -34,9 +37,11 @@ func (d *Downloader) doStagedSyncWithFetchers(p *peerConnection, headersFetchers
 		case Senders:
 			err = d.unwindSendersStage(unwindPoint)
 		case Execution:
-			err = d.unwindExecutionStage(unwindPoint)
+			err = unwindExecutionStage(unwindPoint, d.stateDB)
 		case HashCheck:
-			err = d.unwindHashCheckStage(unwindPoint)
+			if enableHashChecks {
+				err = d.unwindHashCheckStage(unwindPoint)
+			}
 		default:
 			return fmt.Errorf("unrecognized stage for unwinding: %d", stage)
 		}
@@ -76,8 +81,9 @@ func (d *Downloader) doStagedSyncWithFetchers(p *peerConnection, headersFetchers
 	/*
 	* Stage 4. Execute block bodies w/o calculating trie roots
 	 */
-	syncHeadNumber := uint64(0)
-	syncHeadNumber, err = d.spawnExecuteBlocksStage()
+
+	var syncHeadNumber uint64
+	syncHeadNumber, err = spawnExecuteBlocksStage(d.stateDB, d.blockchain)
 	if err != nil {
 		return err
 	}
@@ -86,8 +92,10 @@ func (d *Downloader) doStagedSyncWithFetchers(p *peerConnection, headersFetchers
 
 	// Further stages go there
 	log.Info("Sync stage 5/5. Validating final hash")
-	if err = d.spawnCheckFinalHashStage(syncHeadNumber); err != nil {
-		return err
+	if enableHashChecks {
+		if err = d.spawnCheckFinalHashStage(syncHeadNumber); err != nil {
+			return err
+		}
 	}
 	log.Info("Sync stage 5/5. Validating final hash... Complete!")
 

--- a/eth/downloader/stagedsync_downloader.go
+++ b/eth/downloader/stagedsync_downloader.go
@@ -6,7 +6,8 @@ import (
 	"github.com/ledgerwatch/turbo-geth/log"
 )
 
-var UsePlainStateExecution = true // FIXME: when we can move the hashed state forward.
+var UsePlainStateExecution = false // FIXME: when we can move the hashed state forward.
+//  ^--- will be overriden e when parsing flags anyway
 
 func (d *Downloader) doStagedSyncWithFetchers(p *peerConnection, headersFetchers []func() error) error {
 	log.Info("Sync stage 1/5. Downloading headers...")

--- a/eth/downloader/stagedsync_downloader.go
+++ b/eth/downloader/stagedsync_downloader.go
@@ -6,7 +6,7 @@ import (
 	"github.com/ledgerwatch/turbo-geth/log"
 )
 
-const enableHashChecks = false // FIXME: when we can move the hashed state forward.
+var UsePlainStateExecution = true // FIXME: when we can move the hashed state forward.
 
 func (d *Downloader) doStagedSyncWithFetchers(p *peerConnection, headersFetchers []func() error) error {
 	log.Info("Sync stage 1/5. Downloading headers...")
@@ -39,7 +39,7 @@ func (d *Downloader) doStagedSyncWithFetchers(p *peerConnection, headersFetchers
 		case Execution:
 			err = unwindExecutionStage(unwindPoint, d.stateDB)
 		case HashCheck:
-			if enableHashChecks {
+			if !UsePlainStateExecution {
 				err = d.unwindHashCheckStage(unwindPoint)
 			}
 		default:
@@ -92,7 +92,7 @@ func (d *Downloader) doStagedSyncWithFetchers(p *peerConnection, headersFetchers
 
 	// Further stages go there
 	log.Info("Sync stage 5/5. Validating final hash")
-	if enableHashChecks {
+	if !UsePlainStateExecution {
 		if err = d.spawnCheckFinalHashStage(syncHeadNumber); err != nil {
 			return err
 		}

--- a/eth/downloader/stagedsync_stage_execute.go
+++ b/eth/downloader/stagedsync_stage_execute.go
@@ -61,8 +61,8 @@ func (l *progressLogger) Stop() {
 	close(l.quit)
 }
 
-func (d *Downloader) spawnExecuteBlocksStage() (uint64, error) {
-	lastProcessedBlockNumber, err := GetStageProgress(d.stateDB, Execution)
+func spawnExecuteBlocksStage(stateDB ethdb.Database, blockchain BlockChain) (uint64, error) {
+	lastProcessedBlockNumber, err := GetStageProgress(stateDB, Execution)
 	if err != nil {
 		return 0, err
 	}
@@ -84,30 +84,34 @@ func (d *Downloader) spawnExecuteBlocksStage() (uint64, error) {
 		}
 	*/
 
-	mutation := d.stateDB.NewBatch()
+	mutation := stateDB.NewBatch()
 
 	progressLogger := NewProgressLogger(logInterval)
 	progressLogger.Start(&nextBlockNumber)
 	defer progressLogger.Stop()
-	// incarnationMap holds incarnations for accounts that were deleted, but their storage
-	// is not yet committed
-	var incarnationMap = make(map[common.Address]uint64)
 
-	chainConfig := d.blockchain.Config()
-	engine := d.blockchain.Engine()
-	vmConfig := d.blockchain.GetVMConfig()
+	// uncommitedIncarnations map holds incarnations for accounts that were deleted,
+	// but their storage is not yet committed
+	var uncommitedIncarnations = make(map[common.Address]uint64)
+
+	chainConfig := blockchain.Config()
+	engine := blockchain.Engine()
+	vmConfig := blockchain.GetVMConfig()
 	for {
 		blockNum := atomic.LoadUint64(&nextBlockNumber)
 
-		block := d.blockchain.GetBlockByNumber(blockNum)
+		block := blockchain.GetBlockByNumber(blockNum)
 		if block == nil {
 			break
 		}
-		stateReader := state.NewDbStateReader(mutation, incarnationMap)
-		stateWriter := state.NewDbStateWriter(mutation, blockNum, incarnationMap)
+		stateReader := state.NewDbStateReader(mutation, uncommitedIncarnations)
+		plainStateReader := state.NewPlainStateReaderWithFallback(
+			mutation, uncommitedIncarnations, stateReader)
+
+		stateWriter := state.NewDbStateWriter(mutation, blockNum, uncommitedIncarnations)
 
 		// where the magic happens
-		err = core.ExecuteBlockEuphemerally(chainConfig, vmConfig, d.blockchain, engine, block, stateReader, stateWriter)
+		err = core.ExecuteBlockEuphemerally(chainConfig, vmConfig, blockchain, engine, block, plainStateReader, stateWriter)
 		if err != nil {
 			return 0, err
 		}
@@ -122,8 +126,8 @@ func (d *Downloader) spawnExecuteBlocksStage() (uint64, error) {
 			if _, err = mutation.Commit(); err != nil {
 				return 0, err
 			}
-			mutation = d.stateDB.NewBatch()
-			incarnationMap = make(map[common.Address]uint64)
+			mutation = stateDB.NewBatch()
+			uncommitedIncarnations = make(map[common.Address]uint64)
 		}
 
 		/*
@@ -140,25 +144,21 @@ func (d *Downloader) spawnExecuteBlocksStage() (uint64, error) {
 	return atomic.LoadUint64(&nextBlockNumber) - 1 /* the last processed block */, nil
 }
 
-func (d *Downloader) unwindExecutionStage(unwindPoint uint64) error {
-	lastProcessedBlockNumber, err := GetStageProgress(d.stateDB, Execution)
+func unwindExecutionStage(unwindPoint uint64, stateDB ethdb.Database) error {
+	lastProcessedBlockNumber, err := GetStageProgress(stateDB, Execution)
 	if err != nil {
 		return fmt.Errorf("unwind Execution: get stage progress: %v", err)
 	}
-	unwindPoint, err1 := GetStageUnwind(d.stateDB, Execution)
-	if err1 != nil {
-		return err1
-	}
 	if unwindPoint >= lastProcessedBlockNumber {
-		err = SaveStageUnwind(d.stateDB, Execution, 0)
+		err = SaveStageUnwind(stateDB, Execution, 0)
 		if err != nil {
 			return fmt.Errorf("unwind Execution: reset: %v", err)
 		}
 		return nil
 	}
-	log.Info("Unwdind Execution stage", "from", lastProcessedBlockNumber, "to", unwindPoint)
-	mutation := d.stateDB.NewBatch()
-	accountMap, storageMap, err2 := d.stateDB.RewindData(lastProcessedBlockNumber, unwindPoint)
+	log.Info("Unwind Execution stage", "from", lastProcessedBlockNumber, "to", unwindPoint)
+	mutation := stateDB.NewBatch()
+	accountMap, storageMap, err2 := stateDB.RewindData(lastProcessedBlockNumber, unwindPoint)
 	if err2 != nil {
 		return fmt.Errorf("unwind Execution: getting rewind data: %v", err)
 	}
@@ -172,7 +172,7 @@ func (d *Downloader) unwindExecutionStage(unwindPoint uint64) error {
 			}
 			// Fetch the code hash
 			if acc.Incarnation > 0 && acc.IsEmptyCodeHash() {
-				if codeHash, err2 := d.stateDB.Get(dbutils.ContractCodeBucket, dbutils.GenerateStoragePrefix(addrHash[:], acc.Incarnation)); err2 == nil {
+				if codeHash, err2 := stateDB.Get(dbutils.ContractCodeBucket, dbutils.GenerateStoragePrefix(addrHash[:], acc.Incarnation)); err2 == nil {
 					copy(acc.CodeHash[:], codeHash)
 				}
 			}

--- a/ethdb/walk.go
+++ b/ethdb/walk.go
@@ -124,11 +124,21 @@ func GetModifiedAccounts(db Getter, startTimestamp, endTimestamp uint64) ([]comm
 
 // GetCurrentAccountIncarnation reads the latest incarnation of a contract from the database.
 func GetCurrentAccountIncarnation(db Getter, addrHash common.Hash) (incarnation uint64, found bool, err error) {
+	return findIncarnation(db, dbutils.CurrentStateBucket, addrHash[:], common.HashLength)
+}
+
+// PlainGetCurrentAccountIncarnation reads the latest incarnation of a contract from the database (uses plain state).
+func PlainGetCurrentAccountIncarnation(db Getter, address common.Address) (incarnation uint64, found bool, err error) {
+	return findIncarnation(db, dbutils.PlainStateBucket, address[:], common.AddressLength)
+}
+
+// GetCurrentAccountIncarnation reads the latest incarnation of a contract from the database.
+func findIncarnation(db Getter, bucket []byte, criteria []byte, criteriaLength int) (incarnation uint64, found bool, err error) {
 	var incarnationBytes [common.IncarnationLength]byte
-	startkey := make([]byte, common.HashLength+common.IncarnationLength+common.HashLength)
-	var fixedbits int = 8 * common.HashLength
-	copy(startkey, addrHash[:])
-	err = db.Walk(dbutils.CurrentStateBucket, startkey, fixedbits, func(k, v []byte) (bool, error) {
+	startkey := make([]byte, criteriaLength+common.IncarnationLength+common.HashLength)
+	var fixedbits int = 8 * criteriaLength
+	copy(startkey, criteria)
+	err = db.Walk(bucket, startkey, fixedbits, func(k, v []byte) (bool, error) {
 		copy(incarnationBytes[:], k[common.HashLength:])
 		found = true
 		return false, nil


### PR DESCRIPTION
**NB! this PR will break the hash check phase, I disabled it intentionally.**

Basically, staged sync right now writes to a separate set of buckets, that have "plain" state.
Instead of `<address-hash> => <account-data>` they have `<address> => <account-data>`.

The same is true for the composite keys in storage and in changesets.

Next steps: 
- chain rollback
- to generate "hashed" (default) state to be able to check root hashes. 
- to take intermediate hashes into account.