### PR TITLE
Staged sync: Cap number of go routines to 3 for recovery stage

### DIFF
--- a/eth/downloader/stagedsync_stage_senders.go
+++ b/eth/downloader/stagedsync_stage_senders.go
@@ -21,7 +21,10 @@ var cryptoContexts []*secp256k1.Context
 func init() {
 	// To avoid bothering with creating/releasing the resources
 	// but still not leak the contexts
-	numOfGoroutines = runtime.NumCPU()
+	numOfGoroutines = 3 // We never get more than 3x improvement even if we use 8 goroutines
+	if numOfGoroutines > runtime.NumCPU() {
+		numOfGoroutines = runtime.NumCPU()
+	}
 	cryptoContexts = make([]*secp256k1.Context, numOfGoroutines)
 	for i := 0; i < numOfGoroutines; i++ {
 		cryptoContexts[i] = secp256k1.NewContext()


### PR DESCRIPTION
Dankrad is trying to use staged sync to prototype for polynomial commitments, but he gets this all the time:
````
INFO [05-14|18:09:06.461] Recovered for blocks:                    blockNumber=4820001
INFO [05-14|18:10:41.206] Recovered for blocks:                    blockNumber=4830001
INFO [05-14|18:12:05.953] Recovered for blocks:                    blockNumber=4840001
Killed
````
This PR caps number of utilised CPUs to 3, I asked Dankrad to test on this branch.
We do not see more than 3x improvement even if we use 8 CPUs