### PR TITLE
sort buckets then sort keys inside buckets, then send data to MultiPut

### DIFF
--- a/ethdb/mutation.go
+++ b/ethdb/mutation.go
@@ -160,23 +160,21 @@ func (m *mutation) Commit() (uint64, error) {
 	}
 	m.mu.Lock()
 	defer m.mu.Unlock()
-
-	tuples := common.NewTuples(m.puts.Size(), 3, 1)
+	tuples := make(MultiPutTuples, 0, m.puts.Size()*3)
 	for bucketStr, bt := range m.puts.mp {
 		bucketB := []byte(bucketStr)
 		for key := range bt {
 			value, _ := bt.GetStr(key)
-			if err := tuples.Append(bucketB, []byte(key), value); err != nil {
-				return 0, fmt.Errorf("tuples.Append failed: %w", err)
-			}
+			tuples = append(tuples, bucketB, []byte(key), value)
 		}
 	}
 	sort.Sort(tuples)
 
-	written, err := m.db.MultiPut(tuples.Values...)
+	written, err := m.db.MultiPut(tuples...)
 	if err != nil {
 		return 0, fmt.Errorf("db.MultiPut failed: %w", err)
 	}
+
 	m.puts = newPuts()
 	return written, nil
 }


### PR DESCRIPTION
Proplem statement: current mutation.MultiPut do sort entities by keys - it means entries with different buckets are mixing and underlying BoltDatabase.MultiPut does call bolt.MultiPut on same bucket multiple times with small amoount of keys during 1 transaction.