### PR TITLE
Remove memory leak caused by accountCache, count batch size in bytes

### DIFF
--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -43,6 +43,10 @@ import (
 	"github.com/ledgerwatch/turbo-geth/log"
 	"github.com/ledgerwatch/turbo-geth/metrics"
 	"github.com/ledgerwatch/turbo-geth/node"
+
+	"net/http"
+	//nolint:gosec
+	_ "net/http/pprof"
 )
 
 const (
@@ -260,6 +264,9 @@ func init() {
 }
 
 func main() {
+	go func() {
+		log.Info("HTTP", "error", http.ListenAndServe("localhost:6060", nil))
+	}()
 	if err := app.Run(os.Args); err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -1924,7 +1924,7 @@ func (st *insertStats) report(chain []*types.Block, index int, batch ethdb.DbWit
 		context := []interface{}{
 			"blocks", st.processed, "txs", txs, "mgas", float64(st.usedGas) / 1000000,
 			"elapsed", common.PrettyDuration(elapsed), "mgasps", float64(st.usedGas) * 1000 / float64(elapsed),
-			"number", end.Number(), "hash", end.Hash(), "batch", batch.BatchSize(),
+			"number", end.Number(), "hash", end.Hash(), "batch", common.StorageSize(batch.BatchSize()),
 		}
 		if timestamp := time.Unix(int64(end.Time()), 0); time.Since(timestamp) > time.Minute {
 			context = append(context, []interface{}{"age", common.PrettyAge(timestamp)}...)

--- a/core/state/db_state_reader.go
+++ b/core/state/db_state_reader.go
@@ -121,6 +121,9 @@ func (dbr *DbStateReader) ReadAccountCode(address common.Address, codeHash commo
 	if dbr.codeCache != nil {
 		dbr.codeCache.Add(address, code)
 	}
+	if dbr.codeSizeCache != nil {
+		dbr.codeSizeCache.Add(address, len(code))
+	}
 	return code, err
 }
 

--- a/core/state/db_state_reader.go
+++ b/core/state/db_state_reader.go
@@ -68,7 +68,7 @@ func (dbr *DbStateReader) ReadAccountData(address common.Address) (*accounts.Acc
 		return nil, nil
 	}
 	if dbr.accountCache != nil {
-		dbr.accountCache.Add(address, &a)
+		dbr.accountCache.Add(address, a.SelfCopy())
 	}
 	return &a, nil
 }

--- a/core/state/db_state_reader.go
+++ b/core/state/db_state_reader.go
@@ -118,7 +118,7 @@ func (dbr *DbStateReader) ReadAccountCode(address common.Address, codeHash commo
 		}
 	}
 	code, err = dbr.db.Get(dbutils.CodeBucket, codeHash[:])
-	if dbr.codeCache != nil {
+	if dbr.codeCache != nil && len(code) <= 1024 {
 		dbr.codeCache.Add(address, code)
 	}
 	if dbr.codeSizeCache != nil {

--- a/core/state/db_state_writer.go
+++ b/core/state/db_state_writer.go
@@ -129,7 +129,7 @@ func (dsw *DbStateWriter) UpdateAccountCode(address common.Address, incarnation 
 	if err := dsw.stateDb.Put(dbutils.ContractCodeBucket, dbutils.GenerateStoragePrefix(addrHash[:], incarnation), codeHash[:]); err != nil {
 		return err
 	}
-	if dsw.codeCache != nil {
+	if dsw.codeCache != nil && len(code) <= 1024 {
 		dsw.codeCache.Add(address, code)
 	}
 	if dsw.codeSizeCache != nil {

--- a/core/state/db_state_writer.go
+++ b/core/state/db_state_writer.go
@@ -88,7 +88,7 @@ func (dsw *DbStateWriter) UpdateAccountData(ctx context.Context, address common.
 		return err
 	}
 	if dsw.accountCache != nil {
-		dsw.accountCache.Add(address, account)
+		dsw.accountCache.Add(address, account.SelfCopy())
 	}
 	return nil
 }

--- a/eth/downloader/stagedsync_stage_execute.go
+++ b/eth/downloader/stagedsync_stage_execute.go
@@ -67,8 +67,8 @@ func (l *progressLogger) Stop() {
 	close(l.quit)
 }
 
-const StateBatchSize = 128 * 1024 * 1024 // 128 Mb
-const ChangeBatchSize = 1024 * 1024 // 1 Mb
+const StateBatchSize = 1024 * 1024 // 128 Mb
+const ChangeBatchSize = 1024 * 2014 // 1 Mb
 
 func spawnExecuteBlocksStage(stateDB ethdb.Database, blockchain BlockChain) (uint64, error) {
 	lastProcessedBlockNumber, err := GetStageProgress(stateDB, Execution)

--- a/eth/downloader/stagedsync_stage_execute.go
+++ b/eth/downloader/stagedsync_stage_execute.go
@@ -98,7 +98,7 @@ func spawnExecuteBlocksStage(stateDB ethdb.Database, blockchain BlockChain) (uin
 	progressLogger.Start(&nextBlockNumber)
 	defer progressLogger.Stop()
 
-	//accountCache, _ := lru.New(400000)
+	accountCache, _ := lru.New(400000)
 	storageCache, _ := lru.New(400000)
 	//codeCache, _ := lru.New(1000)
 	codeSizeCache, _ := lru.New(400000)
@@ -122,26 +122,26 @@ func spawnExecuteBlocksStage(stateDB ethdb.Database, blockchain BlockChain) (uin
 
 		if core.UsePlainStateExecution {
 			plainReader := state.NewPlainStateReaderWithFallback(stateBatch, uncommitedIncarnations)
-			//plainReader.SetAccountCache(accountCache)
+			plainReader.SetAccountCache(accountCache)
 			plainReader.SetStorageCache(storageCache)
 			//plainReader.SetCodeCache(codeCache)
 			plainReader.SetCodeSizeCache(codeSizeCache)
 			stateReader = plainReader
 			plainWriter := state.NewPlainStateWriter(stateBatch, changeBatch, blockNum, uncommitedIncarnations)
-			//plainWriter.SetAccountCache(accountCache)
+			plainWriter.SetAccountCache(accountCache)
 			plainWriter.SetStorageCache(storageCache)
 			//plainWriter.SetCodeCache(codeCache)
 			plainWriter.SetCodeSizeCache(codeSizeCache)
 			stateWriter = plainWriter
 		} else {
 			hashStateReader := state.NewDbStateReader(stateBatch, uncommitedIncarnations)
-			//hashStateReader.SetAccountCache(accountCache)
+			hashStateReader.SetAccountCache(accountCache)
 			hashStateReader.SetStorageCache(storageCache)
 			//hashStateReader.SetCodeCache(codeCache)
 			hashStateReader.SetCodeSizeCache(codeSizeCache)
 			stateReader = hashStateReader
 			hashedStateWriter := state.NewDbStateWriter(stateBatch, changeBatch, blockNum, uncommitedIncarnations)
-			//hashedStateWriter.SetAccountCache(accountCache)
+			hashedStateWriter.SetAccountCache(accountCache)
 			hashedStateWriter.SetStorageCache(storageCache)
 			//hashedStateWriter.SetCodeCache(codeCache)
 			hashedStateWriter.SetCodeSizeCache(codeSizeCache)

--- a/eth/downloader/stagedsync_stage_execute.go
+++ b/eth/downloader/stagedsync_stage_execute.go
@@ -67,7 +67,7 @@ func (l *progressLogger) Stop() {
 	close(l.quit)
 }
 
-const StateBatchSize = 1000000
+const StateBatchSize = 100000
 const ChangeBatchSize = 1000
 
 func spawnExecuteBlocksStage(stateDB ethdb.Database, blockchain BlockChain) (uint64, error) {
@@ -98,8 +98,8 @@ func spawnExecuteBlocksStage(stateDB ethdb.Database, blockchain BlockChain) (uin
 	progressLogger.Start(&nextBlockNumber)
 	defer progressLogger.Stop()
 
-	accountCache, _ := lru.New(400000)
-	storageCache, _ := lru.New(400000)
+	accountCache, _ := lru.New(100000)
+	storageCache, _ := lru.New(100000)
 	codeCache, _ := lru.New(1000)
 	codeSizeCache, _ := lru.New(400000)
 	// uncommitedIncarnations map holds incarnations for accounts that were deleted,

--- a/eth/downloader/stagedsync_stage_execute.go
+++ b/eth/downloader/stagedsync_stage_execute.go
@@ -100,7 +100,7 @@ func spawnExecuteBlocksStage(stateDB ethdb.Database, blockchain BlockChain) (uin
 
 	accountCache, _ := lru.New(400000)
 	storageCache, _ := lru.New(400000)
-	//codeCache, _ := lru.New(1000)
+	codeCache, _ := lru.New(1000)
 	codeSizeCache, _ := lru.New(400000)
 	// uncommitedIncarnations map holds incarnations for accounts that were deleted,
 	// but their storage is not yet committed
@@ -124,26 +124,26 @@ func spawnExecuteBlocksStage(stateDB ethdb.Database, blockchain BlockChain) (uin
 			plainReader := state.NewPlainStateReaderWithFallback(stateBatch, uncommitedIncarnations)
 			plainReader.SetAccountCache(accountCache)
 			plainReader.SetStorageCache(storageCache)
-			//plainReader.SetCodeCache(codeCache)
+			plainReader.SetCodeCache(codeCache)
 			plainReader.SetCodeSizeCache(codeSizeCache)
 			stateReader = plainReader
 			plainWriter := state.NewPlainStateWriter(stateBatch, changeBatch, blockNum, uncommitedIncarnations)
 			plainWriter.SetAccountCache(accountCache)
 			plainWriter.SetStorageCache(storageCache)
-			//plainWriter.SetCodeCache(codeCache)
+			plainWriter.SetCodeCache(codeCache)
 			plainWriter.SetCodeSizeCache(codeSizeCache)
 			stateWriter = plainWriter
 		} else {
 			hashStateReader := state.NewDbStateReader(stateBatch, uncommitedIncarnations)
 			hashStateReader.SetAccountCache(accountCache)
 			hashStateReader.SetStorageCache(storageCache)
-			//hashStateReader.SetCodeCache(codeCache)
+			hashStateReader.SetCodeCache(codeCache)
 			hashStateReader.SetCodeSizeCache(codeSizeCache)
 			stateReader = hashStateReader
 			hashedStateWriter := state.NewDbStateWriter(stateBatch, changeBatch, blockNum, uncommitedIncarnations)
 			hashedStateWriter.SetAccountCache(accountCache)
 			hashedStateWriter.SetStorageCache(storageCache)
-			//hashedStateWriter.SetCodeCache(codeCache)
+			hashedStateWriter.SetCodeCache(codeCache)
 			hashedStateWriter.SetCodeSizeCache(codeSizeCache)
 			stateWriter = hashedStateWriter
 		}

--- a/eth/downloader/stagedsync_stage_execute.go
+++ b/eth/downloader/stagedsync_stage_execute.go
@@ -70,7 +70,7 @@ func (l *progressLogger) Stop() {
 }
 
 const StateBatchSize = 50 * 1024 * 1024 // 50 Mb
-const ChangeBatchSize = 1024 * 2014      // 1 Mb
+const ChangeBatchSize = 1024 * 2014     // 1 Mb
 
 func spawnExecuteBlocksStage(stateDB ethdb.Database, blockchain BlockChain) (uint64, error) {
 	lastProcessedBlockNumber, err := GetStageProgress(stateDB, Execution)

--- a/eth/downloader/stagedsync_stage_execute.go
+++ b/eth/downloader/stagedsync_stage_execute.go
@@ -98,7 +98,7 @@ func spawnExecuteBlocksStage(stateDB ethdb.Database, blockchain BlockChain) (uin
 	progressLogger.Start(&nextBlockNumber)
 	defer progressLogger.Stop()
 
-	accountCache, _ := lru.New(400000)
+	//accountCache, _ := lru.New(400000)
 	storageCache, _ := lru.New(400000)
 	//codeCache, _ := lru.New(1000)
 	codeSizeCache, _ := lru.New(400000)
@@ -122,26 +122,26 @@ func spawnExecuteBlocksStage(stateDB ethdb.Database, blockchain BlockChain) (uin
 
 		if core.UsePlainStateExecution {
 			plainReader := state.NewPlainStateReaderWithFallback(stateBatch, uncommitedIncarnations)
-			plainReader.SetAccountCache(accountCache)
+			//plainReader.SetAccountCache(accountCache)
 			plainReader.SetStorageCache(storageCache)
 			//plainReader.SetCodeCache(codeCache)
 			plainReader.SetCodeSizeCache(codeSizeCache)
 			stateReader = plainReader
 			plainWriter := state.NewPlainStateWriter(stateBatch, changeBatch, blockNum, uncommitedIncarnations)
-			plainWriter.SetAccountCache(accountCache)
+			//plainWriter.SetAccountCache(accountCache)
 			plainWriter.SetStorageCache(storageCache)
 			//plainWriter.SetCodeCache(codeCache)
 			plainWriter.SetCodeSizeCache(codeSizeCache)
 			stateWriter = plainWriter
 		} else {
 			hashStateReader := state.NewDbStateReader(stateBatch, uncommitedIncarnations)
-			hashStateReader.SetAccountCache(accountCache)
+			//hashStateReader.SetAccountCache(accountCache)
 			hashStateReader.SetStorageCache(storageCache)
 			//hashStateReader.SetCodeCache(codeCache)
 			hashStateReader.SetCodeSizeCache(codeSizeCache)
 			stateReader = hashStateReader
 			hashedStateWriter := state.NewDbStateWriter(stateBatch, changeBatch, blockNum, uncommitedIncarnations)
-			hashedStateWriter.SetAccountCache(accountCache)
+			//hashedStateWriter.SetAccountCache(accountCache)
 			hashedStateWriter.SetStorageCache(storageCache)
 			//hashedStateWriter.SetCodeCache(codeCache)
 			hashedStateWriter.SetCodeSizeCache(codeSizeCache)

--- a/eth/downloader/stagedsync_stage_execute.go
+++ b/eth/downloader/stagedsync_stage_execute.go
@@ -69,7 +69,7 @@ func (l *progressLogger) Stop() {
 	close(l.quit)
 }
 
-const StateBatchSize = 16 * 1024 * 1024 // 16 Mb
+const StateBatchSize = 50 * 1024 * 1024 // 50 Mb
 const ChangeBatchSize = 1024 * 2014      // 1 Mb
 
 func spawnExecuteBlocksStage(stateDB ethdb.Database, blockchain BlockChain) (uint64, error) {

--- a/eth/downloader/stagedsync_stage_execute.go
+++ b/eth/downloader/stagedsync_stage_execute.go
@@ -68,7 +68,7 @@ func (l *progressLogger) Stop() {
 }
 
 const StateBatchSize = 128 * 1024 * 1024 // 128 Mb
-const ChangeBatchSize = 1024 * 2014 // 1 Mb
+const ChangeBatchSize = 1024 * 2014      // 1 Mb
 
 func spawnExecuteBlocksStage(stateDB ethdb.Database, blockchain BlockChain) (uint64, error) {
 	lastProcessedBlockNumber, err := GetStageProgress(stateDB, Execution)

--- a/eth/downloader/stagedsync_stage_execute.go
+++ b/eth/downloader/stagedsync_stage_execute.go
@@ -69,7 +69,7 @@ func (l *progressLogger) Stop() {
 	close(l.quit)
 }
 
-const StateBatchSize = 128 * 1024 * 1024 // 128 Mb
+const StateBatchSize = 16 * 1024 * 1024 // 16 Mb
 const ChangeBatchSize = 1024 * 2014      // 1 Mb
 
 func spawnExecuteBlocksStage(stateDB ethdb.Database, blockchain BlockChain) (uint64, error) {

--- a/eth/downloader/stagedsync_stage_execute.go
+++ b/eth/downloader/stagedsync_stage_execute.go
@@ -67,7 +67,7 @@ func (l *progressLogger) Stop() {
 	close(l.quit)
 }
 
-const StateBatchSize = 1024 * 1024 // 128 Mb
+const StateBatchSize = 128 * 1024 * 1024 // 128 Mb
 const ChangeBatchSize = 1024 * 2014 // 1 Mb
 
 func spawnExecuteBlocksStage(stateDB ethdb.Database, blockchain BlockChain) (uint64, error) {

--- a/eth/downloader/stagedsync_stage_execute.go
+++ b/eth/downloader/stagedsync_stage_execute.go
@@ -67,7 +67,7 @@ func (l *progressLogger) Stop() {
 	close(l.quit)
 }
 
-const StateBatchSize = 100000
+const StateBatchSize = 1000000
 const ChangeBatchSize = 1000
 
 func spawnExecuteBlocksStage(stateDB ethdb.Database, blockchain BlockChain) (uint64, error) {
@@ -98,9 +98,9 @@ func spawnExecuteBlocksStage(stateDB ethdb.Database, blockchain BlockChain) (uin
 	progressLogger.Start(&nextBlockNumber)
 	defer progressLogger.Stop()
 
-	accountCache, _ := lru.New(100000)
-	storageCache, _ := lru.New(100000)
-	codeCache, _ := lru.New(1000)
+	accountCache, _ := lru.New(400000)
+	storageCache, _ := lru.New(400000)
+	//codeCache, _ := lru.New(1000)
 	codeSizeCache, _ := lru.New(400000)
 	// uncommitedIncarnations map holds incarnations for accounts that were deleted,
 	// but their storage is not yet committed
@@ -124,26 +124,26 @@ func spawnExecuteBlocksStage(stateDB ethdb.Database, blockchain BlockChain) (uin
 			plainReader := state.NewPlainStateReaderWithFallback(stateBatch, uncommitedIncarnations)
 			plainReader.SetAccountCache(accountCache)
 			plainReader.SetStorageCache(storageCache)
-			plainReader.SetCodeCache(codeCache)
+			//plainReader.SetCodeCache(codeCache)
 			plainReader.SetCodeSizeCache(codeSizeCache)
 			stateReader = plainReader
 			plainWriter := state.NewPlainStateWriter(stateBatch, changeBatch, blockNum, uncommitedIncarnations)
 			plainWriter.SetAccountCache(accountCache)
 			plainWriter.SetStorageCache(storageCache)
-			plainWriter.SetCodeCache(codeCache)
+			//plainWriter.SetCodeCache(codeCache)
 			plainWriter.SetCodeSizeCache(codeSizeCache)
 			stateWriter = plainWriter
 		} else {
 			hashStateReader := state.NewDbStateReader(stateBatch, uncommitedIncarnations)
 			hashStateReader.SetAccountCache(accountCache)
 			hashStateReader.SetStorageCache(storageCache)
-			hashStateReader.SetCodeCache(codeCache)
+			//hashStateReader.SetCodeCache(codeCache)
 			hashStateReader.SetCodeSizeCache(codeSizeCache)
 			stateReader = hashStateReader
 			hashedStateWriter := state.NewDbStateWriter(stateBatch, changeBatch, blockNum, uncommitedIncarnations)
 			hashedStateWriter.SetAccountCache(accountCache)
 			hashedStateWriter.SetStorageCache(storageCache)
-			hashedStateWriter.SetCodeCache(codeCache)
+			//hashedStateWriter.SetCodeCache(codeCache)
 			hashedStateWriter.SetCodeSizeCache(codeSizeCache)
 			stateWriter = hashedStateWriter
 		}

--- a/eth/downloader/stagedsync_stage_execute.go
+++ b/eth/downloader/stagedsync_stage_execute.go
@@ -67,8 +67,8 @@ func (l *progressLogger) Stop() {
 	close(l.quit)
 }
 
-const StateBatchSize = 1000000
-const ChangeBatchSize = 1000
+const StateBatchSize = 128 * 1024 * 1024 // 128 Mb
+const ChangeBatchSize = 1024 * 1024 // 1 Mb
 
 func spawnExecuteBlocksStage(stateDB ethdb.Database, blockchain BlockChain) (uint64, error) {
 	lastProcessedBlockNumber, err := GetStageProgress(stateDB, Execution)

--- a/eth/downloader/stagedsync_stage_execute.go
+++ b/eth/downloader/stagedsync_stage_execute.go
@@ -28,13 +28,15 @@ type progressLogger struct {
 	timer    *time.Ticker
 	quit     chan struct{}
 	interval int
+	batch    ethdb.DbWithPendingMutations
 }
 
-func NewProgressLogger(intervalInSeconds int) *progressLogger {
+func NewProgressLogger(intervalInSeconds int, batch ethdb.DbWithPendingMutations) *progressLogger {
 	return &progressLogger{
 		timer:    time.NewTicker(time.Duration(intervalInSeconds) * time.Second),
 		quit:     make(chan struct{}),
 		interval: intervalInSeconds,
+		batch:    batch,
 	}
 }
 
@@ -46,7 +48,7 @@ func (l *progressLogger) Start(numberRef *uint64) {
 			speed := float64(now-prev) / float64(l.interval)
 			var m runtime.MemStats
 			runtime.ReadMemStats(&m)
-			log.Info("Executed blocks:", "currentBlock", now, "speed (blk/second)", speed,
+			log.Info("Executed blocks:", "currentBlock", now, "speed (blk/second)", speed, "state batch", common.StorageSize(l.batch.BatchSize()),
 				"alloc", int(m.Alloc/1024), "sys", int(m.Sys/1024), "numGC", int(m.NumGC))
 			prev = now
 		}
@@ -94,7 +96,7 @@ func spawnExecuteBlocksStage(stateDB ethdb.Database, blockchain BlockChain) (uin
 	stateBatch := stateDB.NewBatch()
 	changeBatch := stateDB.NewBatch()
 
-	progressLogger := NewProgressLogger(logInterval)
+	progressLogger := NewProgressLogger(logInterval, stateBatch)
 	progressLogger.Start(&nextBlockNumber)
 	defer progressLogger.Stop()
 

--- a/ethdb/bolt_db.go
+++ b/ethdb/bolt_db.go
@@ -725,7 +725,7 @@ func (db *BoltDatabase) NewBatch() DbWithPendingMutations {
 
 // IdealBatchSize defines the size of the data batches should ideally add in one write.
 func (db *BoltDatabase) IdealBatchSize() int {
-	return 16 * 1024 * 1024 // 16 Mb
+	return 50 * 1024 * 1024 // 50 Mb
 }
 
 // [TURBO-GETH] Freezer support (not implemented yet)

--- a/ethdb/bolt_db.go
+++ b/ethdb/bolt_db.go
@@ -725,7 +725,7 @@ func (db *BoltDatabase) NewBatch() DbWithPendingMutations {
 
 // IdealBatchSize defines the size of the data batches should ideally add in one write.
 func (db *BoltDatabase) IdealBatchSize() int {
-	return 100 * 1024
+	return 16 * 1024 * 1024 // 16 Mb
 }
 
 // [TURBO-GETH] Freezer support (not implemented yet)

--- a/ethdb/bolt_db.go
+++ b/ethdb/bolt_db.go
@@ -725,7 +725,7 @@ func (db *BoltDatabase) NewBatch() DbWithPendingMutations {
 
 // IdealBatchSize defines the size of the data batches should ideally add in one write.
 func (db *BoltDatabase) IdealBatchSize() int {
-	return 128 * 1024 * 1024 // 16 Mb
+	return 16 * 1024 * 1024 // 16 Mb
 }
 
 // [TURBO-GETH] Freezer support (not implemented yet)

--- a/ethdb/bolt_db.go
+++ b/ethdb/bolt_db.go
@@ -725,7 +725,7 @@ func (db *BoltDatabase) NewBatch() DbWithPendingMutations {
 
 // IdealBatchSize defines the size of the data batches should ideally add in one write.
 func (db *BoltDatabase) IdealBatchSize() int {
-	return 16 * 1024 * 1024 // 16 Mb
+	return 128 * 1024 * 1024 // 16 Mb
 }
 
 // [TURBO-GETH] Freezer support (not implemented yet)

--- a/ethdb/mutation.go
+++ b/ethdb/mutation.go
@@ -11,7 +11,7 @@ import (
 )
 
 type mutation struct {
-	puts puts // Map buckets to map[key]value
+	puts *puts // Map buckets to map[key]value
 	mu   sync.RWMutex
 	db   Database
 }

--- a/ethdb/mutation_puts.go
+++ b/ethdb/mutation_puts.go
@@ -1,20 +1,18 @@
 package ethdb
 
-import (
-)
-
 type puts struct {
-	mp       map[string]putsBucket //map[bucket]putsBucket
-	size 	int
+	mp   map[string]putsBucket //map[bucket]putsBucket
+	size int
 }
 
-func newPuts() puts {
-	return puts{
-		mp:       make(map[string]putsBucket),
+func newPuts() *puts {
+	return &puts{
+		mp:   make(map[string]putsBucket),
+		size: 0,
 	}
 }
 
-func (p puts) set(bucket, key, value []byte) {
+func (p *puts) set(bucket, key, value []byte) {
 	var bucketPuts putsBucket
 	var ok bool
 	if bucketPuts, ok = p.mp[string(bucket)]; !ok {
@@ -31,7 +29,7 @@ func (p puts) set(bucket, key, value []byte) {
 	p.size += len(value)
 }
 
-func (p puts) get(bucket, key []byte) ([]byte, bool) {
+func (p *puts) get(bucket, key []byte) ([]byte, bool) {
 	var bucketPuts putsBucket
 	var ok bool
 	if bucketPuts, ok = p.mp[string(bucket)]; !ok {
@@ -40,11 +38,11 @@ func (p puts) get(bucket, key []byte) ([]byte, bool) {
 	return bucketPuts.Get(key)
 }
 
-func (p puts) Delete(bucket, key []byte) {
+func (p *puts) Delete(bucket, key []byte) {
 	p.set(bucket, key, nil)
 }
 
-func (p puts) Size() int {
+func (p *puts) Size() int {
 	return p.size
 }
 

--- a/ethdb/mutation_puts.go
+++ b/ethdb/mutation_puts.go
@@ -5,6 +5,7 @@ import (
 
 type puts struct {
 	mp       map[string]putsBucket //map[bucket]putsBucket
+	size 	int
 }
 
 func newPuts() puts {
@@ -20,7 +21,14 @@ func (p puts) set(bucket, key, value []byte) {
 		bucketPuts = make(putsBucket)
 		p.mp[string(bucket)] = bucketPuts
 	}
+	skey := string(key)
+	if oldVal, ok := bucketPuts[skey]; ok {
+		p.size -= len(oldVal)
+	} else {
+		p.size += len(skey)
+	}
 	bucketPuts[string(key)] = value
+	p.size += len(value)
 }
 
 func (p puts) get(bucket, key []byte) ([]byte, bool) {
@@ -37,11 +45,7 @@ func (p puts) Delete(bucket, key []byte) {
 }
 
 func (p puts) Size() int {
-	var size int
-	for _, put := range p.mp {
-		size += len(put)
-	}
-	return size
+	return p.size
 }
 
 type putsBucket map[string][]byte //map[key]value
@@ -71,4 +75,3 @@ func (pb putsBucket) GetStr(key string) ([]byte, bool) {
 
 	return value, true
 }
-

--- a/ethdb/mutation_puts.go
+++ b/ethdb/mutation_puts.go
@@ -25,7 +25,7 @@ func (p puts) set(bucket, key, value []byte) {
 	if oldVal, ok := bucketPuts[skey]; ok {
 		p.size -= len(oldVal)
 	} else {
-		p.size += len(skey)
+		p.size += len(skey) + 32 // Add fixed overhead per key
 	}
 	bucketPuts[string(key)] = value
 	p.size += len(value)


### PR DESCRIPTION
Entries in the `accountCache` were preventing GC from freeing state objects and it caused memory leak. Also, large bytecodes are now not placed into the codeCache