### PR TITLE
Mgr schedule iterator

### DIFF
--- a/cmd/hack/hack.go
+++ b/cmd/hack/hack.go
@@ -670,11 +670,11 @@ func mgrSchedule(chaindata string, block uint64) {
 	)
 
 	for block <= toBlock {
-		tick, err2 := schedule.Tick(block)
+		tick, err2 := schedule.Tick2(block)
 		if err2 != nil {
 			panic(err2)
 		}
-		tick2, err2 := schedule2.Tick2(block)
+		tick2, err2 := schedule2.Tick3(block)
 		if err2 != nil {
 			panic(err2)
 		}
@@ -830,21 +830,16 @@ func genIH(chaindata string) {
 
 	accs := map[uint64]int{}
 	err = db.AbstractKV().View(context.Background(), func(tx ethdb.Tx) error {
-		tx.Bucket(dbutils.IntermediateWitnessSizeBucket).Cursor().Walk(func(k, v []byte) (bool, error) {
+		return tx.Bucket(dbutils.IntermediateWitnessSizeBucket).Cursor().Walk(func(k, v []byte) (bool, error) {
 			i := binary.BigEndian.Uint64(v)
-			accs[i]++
+			if i < 5000 {
+				accs[i/10]++
+			}
 			return true, nil
 		})
-		return nil
 	})
 	check(err)
-
-	accs2 := map[uint64]int{}
-	for k, v := range accs {
-		accs2[k/100] += v
-	}
-	fmt.Printf("Agg IWS Stats1: %v\n", accs)
-	fmt.Printf("Agg IWS Stats2: %v\n", accs2)
+	fmt.Printf("Agg IWS Stats: %v\n", accs)
 }
 
 func min(x, y int) int {

--- a/cmd/hack/hack.go
+++ b/cmd/hack/hack.go
@@ -649,10 +649,10 @@ func mgrSchedule(chaindata string, block uint64) {
 	_, err = bc.ChainDb().(ethdb.DbWithPendingMutations).Commit() // apply IH changes
 	check(err)
 
-	//r1, _ := tds.PrefixByCumulativeWitnessSize(5_160_000)
+	//r1, _ := tds.PrefixByCumulativeWitnessSizeDeprecated(5_160_000)
 	//fmt.Println()
 	//fmt.Println()
-	//r2, _ := tds.PrefixByCumulativeWitnessSizeFrom([]byte{}, 5_160_000)
+	//r2, _ := tds.PrefixByCumulativeWitnessSize([]byte{}, 5_160_000)
 	//fmt.Printf("R: %x %x\n", r1, r2)
 
 	t5 := time.Now()
@@ -670,11 +670,11 @@ func mgrSchedule(chaindata string, block uint64) {
 	)
 
 	for block <= toBlock {
-		tick, err2 := schedule.Tick2(block)
+		tick, err2 := schedule.Tick(block)
 		if err2 != nil {
 			panic(err2)
 		}
-		tick2, err2 := schedule2.Tick3(block)
+		tick2, err2 := schedule2.Tick2(block)
 		if err2 != nil {
 			panic(err2)
 		}
@@ -829,17 +829,24 @@ func genIH(chaindata string) {
 	fmt.Printf("IH bucket changed from %d to %d records\n", before, after)
 
 	accs := map[uint64]int{}
+	accs2 := map[uint64]int{}
 	err = db.AbstractKV().View(context.Background(), func(tx ethdb.Tx) error {
 		return tx.Bucket(dbutils.IntermediateWitnessSizeBucket).Cursor().Walk(func(k, v []byte) (bool, error) {
 			i := binary.BigEndian.Uint64(v)
 			if i < 5000 {
 				accs[i/10]++
 			}
+			if len(k) > 32 {
+				if i < 5000 {
+					accs2[i/10]++
+				}
+			}
 			return true, nil
 		})
 	})
 	check(err)
-	fmt.Printf("Agg IWS Stats: %v\n", accs)
+	fmt.Printf("Agg IWS Stats1: %v\n", accs)
+	fmt.Printf("Agg IWS Stats2: %v\n", accs2)
 }
 
 func min(x, y int) int {

--- a/cmd/hack/hack.go
+++ b/cmd/hack/hack.go
@@ -36,6 +36,7 @@ import (
 	"github.com/ledgerwatch/turbo-geth/core/vm"
 	"github.com/ledgerwatch/turbo-geth/crypto"
 	"github.com/ledgerwatch/turbo-geth/eth/downloader"
+	"github.com/ledgerwatch/turbo-geth/eth/mgr"
 	"github.com/ledgerwatch/turbo-geth/ethdb"
 	"github.com/ledgerwatch/turbo-geth/log"
 	"github.com/ledgerwatch/turbo-geth/node"
@@ -633,7 +634,6 @@ func mgrSchedule(chaindata string, block uint64) {
 	tds, err := bc.GetTrieDbState()
 	check(err)
 	fmt.Println("GetTrieDbState: ", time.Since(t2))
-
 	t3 := time.Now()
 	loader := trie.NewSubTrieLoader(0)
 	tr := tds.Trie()
@@ -651,15 +651,14 @@ func mgrSchedule(chaindata string, block uint64) {
 	var witnessSizeAccumulator uint64
 	var witnessCount int64
 	var witnessEstimatedSizeAccumulator uint64
-	//fmt.Printf("%s\n", schedule)
-	//fmt.Printf("stateSize: %d\n", stateSize)
 	t5 := time.Now()
 
-	r1, _ := tds.PrefixByCumulativeWitnessSize(127_099)
+	//Test2(db.KV())
+	r1, _ := tds.PrefixByCumulativeWitnessSize(10_000_000)
 	fmt.Println()
 	fmt.Println()
-	r2, _ := tds.PrefixByCumulativeWitnessSize2(127_099)
-	fmt.Printf("%x %x\n", r1, r2)
+	r2, _ := tds.PrefixByCumulativeWitnessSize2(10_000_000)
+	fmt.Printf("R: %x %x\n", r1, r2)
 
 	//schedule := mgr.NewSchedule(tds)
 	//var toBlock = block + mgr.BlocksPerCycle + 100
@@ -673,19 +672,21 @@ func mgrSchedule(chaindata string, block uint64) {
 	//
 	//	for _, slice := range tick.StateSlices {
 	//		_ = slice
-	//		from2, err := tds.PrefixByCumulativeWitnessSize2(slice.FromSize)
-	//		check(err)
-	//		to2, err := tds.PrefixByCumulativeWitnessSize2(slice.ToSize)
-	//		check(err)
-	//
-	//		if !bytes.Equal(from2, slice.From) {
-	//			fmt.Printf("Alex: %d: %x!=%x\n", slice.FromSize, slice.From, from2)
-	//			return
-	//		}
-	//		if !bytes.Equal(to2, slice.To) {
-	//			fmt.Printf("Alex: %d: %x!=%x\n", slice.FromSize, slice.To, to2)
-	//			return
-	//		}
+	//		//from2, err := tds.PrefixByCumulativeWitnessSize2(slice.FromSize)
+	//		//check(err)
+	//		//to2, err := tds.PrefixByCumulativeWitnessSize2(slice.ToSize)
+	//		//check(err)
+	//		//_ = from2
+	//		//_ = to2
+	//		//
+	//		//if !bytes.Equal(from2, slice.From) {
+	//		//	fmt.Printf("Alex: %d: %x!=%x\n", slice.FromSize, slice.From, from2)
+	//		//	return
+	//		//}
+	//		//if !bytes.Equal(to2, slice.To) {
+	//		//	fmt.Printf("Alex: %d: %x!=%x\n", slice.FromSize, slice.To, to2)
+	//		//	return
+	//		//}
 	//
 	//		//retain := trie.NewRetainRange(common.CopyBytes(slice.From), common.CopyBytes(slice.To))
 	//		//if tick.IsLastInCycle() {
@@ -716,16 +717,16 @@ func mgrSchedule(chaindata string, block uint64) {
 }
 
 func execToBlock(chaindata string, block uint64, fromScratch bool) {
-	state.MaxTrieCacheSize = 32
+	state.MaxTrieCacheSize = 100 * 1024
 	blockDb, err := ethdb.NewBoltDatabase(chaindata)
 	check(err)
 	bcb, err := core.NewBlockChain(blockDb, nil, params.MainnetChainConfig, ethash.NewFaker(), vm.Config{}, nil, nil)
 	check(err)
 	defer blockDb.Close()
 	if fromScratch {
-		os.Remove("statedb")
+		os.Remove("statedb-ih-greater-4k-only")
 	}
-	stateDb, err := ethdb.NewBoltDatabase("statedb")
+	stateDb, err := ethdb.NewBoltDatabase("statedb-ih-greater-4k-only")
 	check(err)
 	defer stateDb.Close()
 

--- a/cmd/hack/hack.go
+++ b/cmd/hack/hack.go
@@ -830,10 +830,10 @@ func genIH(chaindata string) {
 
 	accs := map[uint64]int{}
 	err = db.AbstractKV().View(context.Background(), func(tx ethdb.Tx) error {
-		_, _ = state.CumulativeSearch(db.AbstractKV(), dbutils.IntermediateWitnessSizeBucket, []byte{}, []byte{}, 0, func(k, v []byte) (itsTimeToVisitChild bool, err error) {
+		tx.Bucket(dbutils.IntermediateWitnessSizeBucket).Cursor().Walk(func(k, v []byte) (bool, error) {
 			i := binary.BigEndian.Uint64(v)
 			accs[i]++
-			return false, nil
+			return true, nil
 		})
 		return nil
 	})
@@ -843,7 +843,8 @@ func genIH(chaindata string) {
 	for k, v := range accs {
 		accs2[k/100] += v
 	}
-	fmt.Printf("Agg IWS Stats: %v\n", accs2)
+	fmt.Printf("Agg IWS Stats1: %v\n", accs)
+	fmt.Printf("Agg IWS Stats2: %v\n", accs2)
 }
 
 func min(x, y int) int {

--- a/cmd/hack/hack.go
+++ b/cmd/hack/hack.go
@@ -654,6 +654,7 @@ func mgrSchedule(chaindata string, block uint64) {
 	var witnessEstimatedSizeAccumulator uint64
 	//fmt.Printf("%s\n", schedule)
 	//fmt.Printf("stateSize: %d\n", stateSize)
+	defer func(t time.Time) { fmt.Println("hack.go:657", time.Since(t)) }(time.Now())
 	for i := range schedule.Ticks {
 		tick := schedule.Ticks[i]
 		for j := range tick.StateSizeSlices {
@@ -663,9 +664,9 @@ func mgrSchedule(chaindata string, block uint64) {
 				panic(err2)
 			}
 			retain := trie.NewRetainRange(common.CopyBytes(stateSlice.From), common.CopyBytes(stateSlice.To))
-			//if tick.IsLastInCycle() {
-			//	fmt.Printf("\nretain: %s\n", retain)
-			//}
+			if tick.IsLastInCycle() {
+				fmt.Printf("\nretain: %s\n", retain)
+			}
 			witness, err2 := tds.Trie().ExtractWitness(false, retain)
 			if err2 != nil {
 				panic(err2)
@@ -676,7 +677,7 @@ func mgrSchedule(chaindata string, block uint64) {
 			if err != nil {
 				panic(err)
 			}
-
+			_ = stateSlice
 			witnessCount++
 			witnessSizeAccumulator += uint64(buf.Len())
 		}

--- a/cmd/hack/hack.go
+++ b/cmd/hack/hack.go
@@ -36,7 +36,6 @@ import (
 	"github.com/ledgerwatch/turbo-geth/core/vm"
 	"github.com/ledgerwatch/turbo-geth/crypto"
 	"github.com/ledgerwatch/turbo-geth/eth/downloader"
-	"github.com/ledgerwatch/turbo-geth/eth/mgr"
 	"github.com/ledgerwatch/turbo-geth/ethdb"
 	"github.com/ledgerwatch/turbo-geth/log"
 	"github.com/ledgerwatch/turbo-geth/node"
@@ -634,8 +633,6 @@ func mgrSchedule(chaindata string, block uint64) {
 	tds, err := bc.GetTrieDbState()
 	check(err)
 	fmt.Println("GetTrieDbState: ", time.Since(t2))
-	//currentBlock := bc.CurrentBlock()
-	//currentBlockNr := currentBlock.NumberU64()
 
 	t3 := time.Now()
 	loader := trie.NewSubTrieLoader(0)
@@ -650,8 +647,6 @@ func mgrSchedule(chaindata string, block uint64) {
 	check(err)
 	fmt.Println("HookSubTries: ", time.Since(t4))
 
-	schedule := mgr.NewSchedule(tds)
-	var toBlock = block + mgr.BlocksPerCycle + 100
 	//var buf bytes.Buffer
 	var witnessSizeAccumulator uint64
 	var witnessCount int64
@@ -660,34 +655,58 @@ func mgrSchedule(chaindata string, block uint64) {
 	//fmt.Printf("stateSize: %d\n", stateSize)
 	t5 := time.Now()
 
-	for tick, err := schedule.Tick(block); block <= toBlock; tick, err = schedule.Tick(block) {
-		if err != nil {
-			panic(err)
-		}
-		//fmt.Printf("BlocK: %d\n", block)
-		//fmt.Printf("Tick: %s\n", tick)
+	r1, _ := tds.PrefixByCumulativeWitnessSize(127_099)
+	fmt.Println()
+	fmt.Println()
+	r2, _ := tds.PrefixByCumulativeWitnessSize2(127_099)
+	fmt.Printf("%x %x\n", r1, r2)
 
-		//for _, slice := range tick.StateSlices {
-		//	retain := trie.NewRetainRange(common.CopyBytes(slice.From), common.CopyBytes(slice.To))
-		//	if tick.IsLastInCycle() {
-		//		fmt.Printf("\nretain: %s\n", retain)
-		//	}
-		//	witness, err2 := tds.Trie().ExtractWitness(false, retain)
-		//	if err2 != nil {
-		//		panic(err2)
-		//	}
-		//
-		//	buf.Reset()
-		//	_, err = witness.WriteTo(&buf)
-		//	if err != nil {
-		//		panic(err)
-		//	}
-		//	witnessCount++
-		//	witnessSizeAccumulator += uint64(buf.Len())
-		//}
-		witnessEstimatedSizeAccumulator += tick.ToSize - tick.FromSize
-		block = tick.ToBlock + 1
-	}
+	//schedule := mgr.NewSchedule(tds)
+	//var toBlock = block + mgr.BlocksPerCycle + 100
+	//for tick, err := schedule.Tick(block); block <= toBlock; tick, err = schedule.Tick(block) {
+	//	if err != nil {
+	//		panic(err)
+	//	}
+	//
+	//	//fmt.Printf("BlocK: %d\n", block)
+	//	//fmt.Printf("Tick: %s\n", tick)
+	//
+	//	for _, slice := range tick.StateSlices {
+	//		_ = slice
+	//		from2, err := tds.PrefixByCumulativeWitnessSize2(slice.FromSize)
+	//		check(err)
+	//		to2, err := tds.PrefixByCumulativeWitnessSize2(slice.ToSize)
+	//		check(err)
+	//
+	//		if !bytes.Equal(from2, slice.From) {
+	//			fmt.Printf("Alex: %d: %x!=%x\n", slice.FromSize, slice.From, from2)
+	//			return
+	//		}
+	//		if !bytes.Equal(to2, slice.To) {
+	//			fmt.Printf("Alex: %d: %x!=%x\n", slice.FromSize, slice.To, to2)
+	//			return
+	//		}
+	//
+	//		//retain := trie.NewRetainRange(common.CopyBytes(slice.From), common.CopyBytes(slice.To))
+	//		//if tick.IsLastInCycle() {
+	//		//	fmt.Printf("\nretain: %s\n", retain)
+	//		//}
+	//		//witness, err2 := tds.Trie().ExtractWitness(false, retain)
+	//		//if err2 != nil {
+	//		//	panic(err2)
+	//		//}
+	//		//
+	//		//buf.Reset()
+	//		//_, err = witness.WriteTo(&buf)
+	//		//if err != nil {
+	//		//	panic(err)
+	//		//}
+	//		//witnessCount++
+	//		//witnessSizeAccumulator += uint64(buf.Len())
+	//	}
+	//	witnessEstimatedSizeAccumulator += tick.ToSize - tick.FromSize
+	//	block = tick.ToBlock + 1
+	//}
 
 	fmt.Println("MGR Get All Ticks: ", time.Since(t5))
 

--- a/cmd/hack/hack.go
+++ b/cmd/hack/hack.go
@@ -633,7 +633,7 @@ func mgrSchedule(chaindata string, block uint64) {
 	t2 := time.Now()
 	tds, err := bc.GetTrieDbState()
 	check(err)
-	fmt.Println("2", time.Since(t2))
+	fmt.Println("GetTrieDbState: ", time.Since(t2))
 	//currentBlock := bc.CurrentBlock()
 	//currentBlockNr := currentBlock.NumberU64()
 
@@ -644,11 +644,11 @@ func mgrSchedule(chaindata string, block uint64) {
 	rs.AddHex([]byte{})
 	subTries, err := loader.LoadSubTries(db, 0, rs, [][]byte{nil}, []int{0}, false)
 	check(err)
-	fmt.Println("3", time.Since(t3))
+	fmt.Println("LoadSubTries: ", time.Since(t3))
 	t4 := time.Now()
 	err = tr.HookSubTries(subTries, [][]byte{nil}) // hook up to the root
 	check(err)
-	fmt.Println("4", time.Since(t4))
+	fmt.Println("HookSubTries: ", time.Since(t4))
 
 	schedule := mgr.NewSchedule(tds)
 	var toBlock = block + mgr.BlocksPerCycle + 100
@@ -689,7 +689,7 @@ func mgrSchedule(chaindata string, block uint64) {
 		block = tick.ToBlock + 1
 	}
 
-	fmt.Println("5", time.Since(t5))
+	fmt.Println("MGR Get All Ticks: ", time.Since(t5))
 
 	fmt.Printf("witnessCount: %s\n", humanize.Comma(witnessCount))
 	fmt.Printf("witnessSizeAccumulator: %s\n", humanize.Bytes(witnessSizeAccumulator))
@@ -2003,7 +2003,7 @@ func (r *Receiver) Receive(
 	storageValue []byte,
 	hash []byte,
 	cutoff int,
-	witnessLen uint64,
+	witnessSize uint64,
 ) error {
 	for r.currentIdx < len(r.unfurlList) {
 		ks := r.unfurlList[r.currentIdx]
@@ -2025,7 +2025,7 @@ func (r *Receiver) Receive(
 			c = -1
 		}
 		if c > 0 {
-			return r.defaultReceiver.Receive(itemType, accountKey, storageKeyPart1, storageKeyPart2, accountValue, storageValue, hash, cutoff, witnessLen)
+			return r.defaultReceiver.Receive(itemType, accountKey, storageKeyPart1, storageKeyPart2, accountValue, storageValue, hash, cutoff, witnessSize)
 		}
 		if len(k) > common.HashLength {
 			v := r.storageMap[ks]
@@ -2048,7 +2048,7 @@ func (r *Receiver) Receive(
 		}
 	}
 	// We ran out of modifications, simply pass through
-	return r.defaultReceiver.Receive(itemType, accountKey, storageKeyPart1, storageKeyPart2, accountValue, storageValue, hash, cutoff, witnessLen)
+	return r.defaultReceiver.Receive(itemType, accountKey, storageKeyPart1, storageKeyPart2, accountValue, storageValue, hash, cutoff, witnessSize)
 }
 
 func (r *Receiver) Result() trie.SubTries {

--- a/cmd/restapi/apis/intermediate_data_len_api.go
+++ b/cmd/restapi/apis/intermediate_data_len_api.go
@@ -34,7 +34,7 @@ func findIntermediateDataLenByPrefix(prefixS string, remoteDB ethdb.KV) ([]*Inte
 	var results []*IntermediateDataLenResponse
 	prefix := common.FromHex(prefixS)
 	if err := remoteDB.View(context.TODO(), func(tx ethdb.Tx) error {
-		interBucket := tx.Bucket(dbutils.IntermediateTrieWitnessLenBucket)
+		interBucket := tx.Bucket(dbutils.IntermediateWitnessLenBucket)
 		c := interBucket.Cursor().Prefix(prefix)
 
 		for k, v, err := c.First(); k != nil || err != nil; k, v, err = c.Next() {

--- a/cmd/restapi/apis/intermediate_data_len_api.go
+++ b/cmd/restapi/apis/intermediate_data_len_api.go
@@ -34,7 +34,7 @@ func findIntermediateDataLenByPrefix(prefixS string, remoteDB ethdb.KV) ([]*Inte
 	var results []*IntermediateDataLenResponse
 	prefix := common.FromHex(prefixS)
 	if err := remoteDB.View(context.TODO(), func(tx ethdb.Tx) error {
-		interBucket := tx.Bucket(dbutils.IntermediateWitnessLenBucket)
+		interBucket := tx.Bucket(dbutils.IntermediateWitnessSizeBucket)
 		c := interBucket.Cursor().Prefix(prefix)
 
 		for k, v, err := c.First(); k != nil || err != nil; k, v, err = c.Next() {

--- a/common/dbutils/bucket.go
+++ b/common/dbutils/bucket.go
@@ -80,7 +80,7 @@ var (
 	IntermediateTrieHashBucket = []byte("iTh")
 
 	// some_prefix_of(hash_of_address_of_account) => estimated_number_of_witness_bytes
-	IntermediateWitnessLenBucket = []byte("iwl")
+	IntermediateWitnessSizeBucket = []byte("iws")
 
 	// DatabaseInfoBucket is used to store information about data layout.
 	DatabaseInfoBucket = []byte("DBINFO")
@@ -156,7 +156,7 @@ var Buckets = [][]byte{
 	AccountChangeSetBucket,
 	StorageChangeSetBucket,
 	IntermediateTrieHashBucket,
-	IntermediateWitnessLenBucket,
+	IntermediateWitnessSizeBucket,
 	DatabaseVerisionKey,
 	HeadHeaderKey,
 	HeadBlockKey,

--- a/common/dbutils/bucket.go
+++ b/common/dbutils/bucket.go
@@ -80,7 +80,7 @@ var (
 	IntermediateTrieHashBucket = []byte("iTh")
 
 	// some_prefix_of(hash_of_address_of_account) => estimated_number_of_witness_bytes
-	IntermediateTrieWitnessLenBucket = []byte("iTw")
+	IntermediateWitnessLenBucket = []byte("iwl")
 
 	// DatabaseInfoBucket is used to store information about data layout.
 	DatabaseInfoBucket = []byte("DBINFO")
@@ -156,7 +156,7 @@ var Buckets = [][]byte{
 	AccountChangeSetBucket,
 	StorageChangeSetBucket,
 	IntermediateTrieHashBucket,
-	IntermediateTrieWitnessLenBucket,
+	IntermediateWitnessLenBucket,
 	DatabaseVerisionKey,
 	HeadHeaderKey,
 	HeadBlockKey,

--- a/common/dbutils/composite_keys.go
+++ b/common/dbutils/composite_keys.go
@@ -175,6 +175,10 @@ func DecodeIncarnation(buf []byte) uint64 {
 	return incarnation ^ ^uint64(0)
 }
 
+func EncodeIncarnation(incarnation uint64, buf []byte) {
+	binary.BigEndian.PutUint64(buf, ^incarnation)
+}
+
 func RemoveIncarnationFromKey(key []byte, out *[]byte) {
 	tmp := (*out)[:0]
 	if len(key) <= common.HashLength {

--- a/common/dbutils/composite_keys.go
+++ b/common/dbutils/composite_keys.go
@@ -170,6 +170,21 @@ func ParseStoragePrefix(prefix []byte) (common.Hash, uint64) {
 	return addrHash, inc
 }
 
+func DecodeIncarnation(buf []byte) uint64 {
+	incarnation := binary.BigEndian.Uint64(buf)
+	return incarnation ^ ^uint64(0)
+}
+
+func RemoveIncarnationFromKey(key []byte, out *[]byte) {
+	tmp := (*out)[:0]
+	if len(key) <= common.HashLength {
+		tmp = append(tmp, key...)
+	} else {
+		tmp = append(tmp, key[:common.HashLength]...)
+		tmp = append(tmp, key[common.HashLength+8:]...)
+	}
+	*out = tmp
+}
 
 // Key + blockNum
 func CompositeKeySuffix(key []byte, timestamp uint64) (composite, encodedTS []byte) {
@@ -179,4 +194,3 @@ func CompositeKeySuffix(key []byte, timestamp uint64) (composite, encodedTS []by
 	copy(composite[len(key):], encodedTS)
 	return composite, encodedTS
 }
-

--- a/common/dbutils/helper.go
+++ b/common/dbutils/helper.go
@@ -42,27 +42,17 @@ func ChangeSetByIndexBucket(b []byte) []byte {
 	panic("wrong bucket")
 }
 
-// Cmp - like bytes.Compare, but nil - means "bucket over" and has highest order.
-func Cmp(k1, k2 []byte) int {
-	if k1 == nil && k2 == nil {
-		return 0
-	}
-	if k1 == nil {
-		return 1
-	}
-	if k2 == nil {
-		return -1
-	}
+// NextSubtree does []byte++. Returns false if overflow.
+func NextSubtree(in []byte) ([]byte, bool) {
+	r := make([]byte, len(in))
+	copy(r, in)
+	for i := len(r) - 1; i >= 0; i-- {
+		if r[i] != 255 {
+			r[i]++
+			return r, true
+		}
 
-	return bytes.Compare(k1, k2)
-}
-
-// IsBefore - kind of bytes.Compare, but nil is the last key. And return
-func IsBefore(k1, k2 []byte) (bool, []byte) {
-	switch Cmp(k1, k2) {
-	case -1, 0:
-		return true, k1
-	default:
-		return false, k2
+		r[i] = 0
 	}
+	return nil, false
 }

--- a/common/dbutils/helper.go
+++ b/common/dbutils/helper.go
@@ -1,6 +1,8 @@
 package dbutils
 
-import "bytes"
+import (
+	"bytes"
+)
 
 // EncodeTimestamp has the property: if a < b, then Encoding(a) < Encoding(b) lexicographically
 func EncodeTimestamp(timestamp uint64) []byte {
@@ -55,4 +57,23 @@ func NextSubtree(in []byte) ([]byte, bool) {
 		r[i] = 0
 	}
 	return nil, false
+}
+
+func NextS(in []byte, out *[]byte) bool {
+	tmp := *out
+	if cap(tmp) < len(in) {
+		tmp = make([]byte, len(in))
+	}
+	tmp = tmp[:len(in)]
+	copy(tmp, in)
+	for i := len(tmp) - 1; i >= 0; i-- {
+		if tmp[i] != 255 {
+			tmp[i]++
+			*out = tmp
+			return true
+		}
+		tmp[i] = 0
+	}
+	*out = tmp
+	return false
 }

--- a/core/state/database.go
+++ b/core/state/database.go
@@ -1443,15 +1443,15 @@ func (tds *TrieDbState) PrefixByCumulativeWitnessSize(size uint64) (prefix []byt
 	}
 
 	prefix, incarnation, accumulator, ok := tds.prefixByCumulativeWitnessSizeFromTrie(size)
-	if !ok {
-		return tds.prefixByCumulativeWitnessSizeFromDb(prefix, incarnation, size-accumulator)
-	} else {
+	if ok {
 		if len(prefix)%2 == 1 {
-			prefix = append(prefix, 0)
+			panic("why valueNode has even number of nibbles?")
 		}
 		trie.CompressNibbles(prefix, &prefix)
+		return prefix, nil
 	}
-	return prefix, nil
+
+	return tds.prefixByCumulativeWitnessSizeFromDB(prefix, incarnation, size-accumulator)
 }
 
 func (tds *TrieDbState) prefixByCumulativeWitnessSizeFromTrie(size uint64) (prefix []byte, incarnation uint64, accumulator uint64, ok bool) {
@@ -1460,7 +1460,7 @@ func (tds *TrieDbState) prefixByCumulativeWitnessSizeFromTrie(size uint64) (pref
 	return tds.t.PrefixByCumulativeWitnessSize(size)
 }
 
-func (tds *TrieDbState) prefixByCumulativeWitnessSizeFromDb(prefixInTrie []byte, incarnation uint64, size uint64) (prefix []byte, err error) {
+func (tds *TrieDbState) prefixByCumulativeWitnessSizeFromDB(prefixInTrie []byte, incarnation uint64, size uint64) (prefix []byte, err error) {
 	//fmt.Printf("FromTrie: %x\n", prefixInTrie)
 	seeks := int64(0)
 	defer cumulativeSearchTimer.UpdateSince(time.Now())
@@ -1481,11 +1481,11 @@ func (tds *TrieDbState) prefixByCumulativeWitnessSizeFromDb(prefixInTrie []byte,
 	if hasBolt, ok := tds.db.(ethdb.HasAbstractKV); ok {
 		kv = hasBolt.AbstractKV()
 	} else {
-		return nil, fmt.Errorf("unexpected db type: %T\n", tds.db)
+		return nil, fmt.Errorf("unexpected db type: %T", tds.db)
 	}
 
 	var accumulator uint64
-	prefix, err = CumulativeSearch(kv, dbutils.IntermediateWitnessSizeBucket, prefixInTrie, fixedbits, func(k, v []byte) (itsTimeToVisitChild bool, err error) {
+	prefix, err = CumulativeSearch(kv, dbutils.IntermediateWitnessSizeBucket, append(prefixInTrie, 0), prefixInTrie, fixedbits, func(k, v []byte) (itsTimeToVisitChild bool, err error) {
 		prefixSize := binary.BigEndian.Uint64(v)
 		//fmt.Printf("loop %d+%d=%d <= %d, %x\n", accumulator, prefixSize, accumulator+prefixSize, size, k)
 		overflow := accumulator+prefixSize >= size
@@ -1498,32 +1498,37 @@ func (tds *TrieDbState) prefixByCumulativeWitnessSizeFromDb(prefixInTrie []byte,
 		return nil, err
 	}
 
-	if len(prefix) > common.HashLength {
-		dbutils.RemoveIncarnationFromKey(prefix, &prefix)
-	}
+	//if len(prefix) > common.HashLength {
+	//	dbutils.RemoveIncarnationFromKey(prefix, &prefix)
+	//}
 	//fmt.Printf("Result: %x\n", prefix)
 	return prefix, nil
 }
 
-func (tds *TrieDbState) PrefixByCumulativeWitnessSize2(size uint64) (prefix []byte, err error) {
-	defer func(t time.Time) { fmt.Println("database.go:1543", time.Since(t)) }(time.Now())
-
+func (tds *TrieDbState) PrefixByCumulativeWitnessSizeDBOnly(size uint64) (prefix []byte, err error) {
 	if size == 0 {
 		return []byte{}, nil
 	}
-	return tds.prefixByCumulativeWitnessSizeFromDb2(size)
+	return tds.prefixByCumulativeWitnessSizeFromDB2(size)
 }
 
-func (tds *TrieDbState) prefixByCumulativeWitnessSizeFromDb2(size uint64) (prefix []byte, err error) {
+func (tds *TrieDbState) PrefixByCumulativeWitnessSizeFrom(from []byte, size uint64) (prefix []byte, err error) {
+	if size == 0 {
+		return from, nil
+	}
+	return tds.prefixByCumulativeWitnessSizeFromDBFrom(from, size)
+}
+
+func (tds *TrieDbState) prefixByCumulativeWitnessSizeFromDBFrom(from []byte, size uint64) (prefix []byte, err error) {
 	var kv ethdb.KV
 	if hasBolt, ok := tds.db.(ethdb.HasAbstractKV); ok {
 		kv = hasBolt.AbstractKV()
 	} else {
-		return nil, fmt.Errorf("unexpected db type: %T\n", tds.db)
+		return nil, fmt.Errorf("unexpected db type: %T", tds.db)
 	}
 
 	var accumulator uint64
-	prefix, err = CumulativeSearch(kv, dbutils.IntermediateWitnessSizeBucket, []byte{}, 0, func(k, v []byte) (itsTimeToVisitChild bool, err error) {
+	prefix, err = CumulativeSearch(kv, dbutils.IntermediateWitnessSizeBucket, from, []byte{}, 0, func(k, v []byte) (itsTimeToVisitChild bool, err error) {
 		prefixSize := binary.BigEndian.Uint64(v)
 		//fmt.Printf("loop %d+%d=%d <= %d, %x\n", accumulator, prefixSize, accumulator+prefixSize, size, k)
 		overflow := accumulator+prefixSize >= size
@@ -1535,9 +1540,37 @@ func (tds *TrieDbState) prefixByCumulativeWitnessSizeFromDb2(size uint64) (prefi
 	if err != nil {
 		return nil, err
 	}
-	if len(prefix) > common.HashLength {
-		dbutils.RemoveIncarnationFromKey(prefix, &prefix)
+	//if len(prefix) > common.HashLength {
+	//	dbutils.RemoveIncarnationFromKey(prefix, &prefix)
+	//}
+
+	//fmt.Printf("Result from db2: %x\n", prefix)
+	return prefix, nil
+}
+func (tds *TrieDbState) prefixByCumulativeWitnessSizeFromDB2(size uint64) (prefix []byte, err error) {
+	var kv ethdb.KV
+	if hasBolt, ok := tds.db.(ethdb.HasAbstractKV); ok {
+		kv = hasBolt.AbstractKV()
+	} else {
+		return nil, fmt.Errorf("unexpected db type: %T", tds.db)
 	}
+
+	var accumulator uint64
+	prefix, err = CumulativeSearch(kv, dbutils.IntermediateWitnessSizeBucket, []byte{}, []byte{}, 0, func(k, v []byte) (itsTimeToVisitChild bool, err error) {
+		prefixSize := binary.BigEndian.Uint64(v)
+		//fmt.Printf("loop %d+%d=%d <= %d, %x\n", accumulator, prefixSize, accumulator+prefixSize, size, k)
+		overflow := accumulator+prefixSize >= size
+		if !overflow {
+			accumulator += prefixSize
+		}
+		return overflow, nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	//if len(prefix) > common.HashLength {
+	//	dbutils.RemoveIncarnationFromKey(prefix, &prefix)
+	//}
 
 	//fmt.Printf("Result from db2: %x\n", prefix)
 	return prefix, nil
@@ -1546,7 +1579,9 @@ func (tds *TrieDbState) prefixByCumulativeWitnessSizeFromDb2(size uint64) (prefi
 type CumulativeSearchF func(k, v []byte) (itsTimeToVisitChild bool, err error)
 
 // CumulativeSearch - on each iteration jumps to next subtries (siblings) by default until not get command to go to child
-func CumulativeSearch(kv ethdb.KV, bucket []byte, parent []byte, fixedbits int, f CumulativeSearchF) (lastVisitedParent []byte, err error) {
+func CumulativeSearch(kv ethdb.KV, bucket []byte, startKey []byte, parent []byte, fixedbits int, f CumulativeSearchF) (lastVisitedParent []byte, err error) {
+	//fmt.Printf("Start FRoooom: %x\n", startKey)
+
 	const doCorrectIncarnation = true
 	seeks := int64(0)
 	accountSeek := int64(0)
@@ -1556,9 +1591,10 @@ func CumulativeSearch(kv ethdb.KV, bucket []byte, parent []byte, fixedbits int, 
 	var ok bool
 	a := accounts.NewAccount()
 
-	if err := kv.View(context.TODO(), func(tx ethdb.Tx) error {
+	if err = kv.View(context.Background(), func(tx ethdb.Tx) error {
 		c := tx.Bucket(bucket).Cursor()
 		cs := tx.Bucket(dbutils.CurrentStateBucket).Cursor()
+
 		var k, v, csK, csV []byte
 		// move 2 cursors until find correct incarnation or face shorter prefix
 		var skipIncorrectIncarnation = func() error {
@@ -1629,7 +1665,7 @@ func CumulativeSearch(kv ethdb.KV, bucket []byte, parent []byte, fixedbits int, 
 		}
 
 		fixedbytes, mask := ethdb.Bytesmask(fixedbits)
-		next := append(parent, 0)
+		next := startKey
 		seeks++
 		k, v, err = c.SeekTo(next)
 		if err != nil {
@@ -1667,6 +1703,7 @@ func CumulativeSearch(kv ethdb.KV, bucket []byte, parent []byte, fixedbits int, 
 			}
 
 			parent = common.CopyBytes(k)
+			//fmt.Printf("New parent: %x\n", parent)
 			fixedbits = len(parent) * 8
 			fixedbytes, mask = ethdb.Bytesmask(fixedbits)
 			seeks++
@@ -1691,6 +1728,6 @@ func CumulativeSearch(kv ethdb.KV, bucket []byte, parent []byte, fixedbits int, 
 	}); err != nil {
 		return parent, err
 	}
-	fmt.Printf("Seeks: %d, accountSeek: %d\n", seeks, accountSeek)
+	//fmt.Printf("Seeks: %d, accountSeek: %d\n", seeks, accountSeek)
 	return parent, nil
 }

--- a/core/state/database.go
+++ b/core/state/database.go
@@ -1547,7 +1547,6 @@ func (tds *TrieDbState) PrefixByCumulativeWitnessSize(from []byte, size uint64) 
 	if err != nil {
 		return nil, err
 	}
-
 	return prefix, nil
 }
 
@@ -1555,13 +1554,12 @@ type CumulativeSearchF func(k, v []byte) (itsTimeToVisitChild bool, err error)
 
 // CumulativeSearch - on each iteration jumps to next subtries (siblings) by default until not get command to go to child
 func CumulativeSearch(kv ethdb.KV, bucket []byte, startKey []byte, parent []byte, fixedbits int, f CumulativeSearchF) (lastVisitedParent []byte, seeks, accSeeks int64, err error) {
-	//trace := bytes.HasPrefix(startKey, common.FromHex("9409160bc4922120a08054b27d1ea9f6ef7b0e701dffac7c5186dc40e991232afffffffffffffffef0"))
 	trace := false
 	if trace {
 		fmt.Printf("\n\nStart FRoooom: %x, %x\n", startKey, parent)
 	}
 
-	const doCorrectIncarnation = true
+	const doCorrectIncarnation = false
 	defer cumulativeSearchTimer.UpdateSince(time.Now())
 	defer cumulativeSearchMeter.Mark(seeks)
 
@@ -1677,7 +1675,7 @@ func CumulativeSearch(kv ethdb.KV, bucket []byte, startKey []byte, parent []byte
 				}
 				if !bytes.HasPrefix(k, parent) {
 					if trace {
-						fmt.Printf("No Sibling: %x --> %x, %d\n", parent, k)
+						fmt.Printf("No Sibling: %x --> %x\n", parent, k)
 					}
 					k = nil
 				}

--- a/core/state/database.go
+++ b/core/state/database.go
@@ -1446,11 +1446,7 @@ func (tds *TrieDbState) PrefixByCumulativeWitnessSize(size uint64) ([]byte, erro
 	var accumulator uint64 // increase when go to sibling, don't touch it when go to child
 
 	if err := kv.View(context.TODO(), func(tx ethdb.Tx) error {
-		c := tx.Bucket(dbutils.IntermediateTrieWitnessLenBucket).Cursor()
-		//c.Walk(func(k, v []byte) (bool, error) {
-		//	fmt.Printf("k: %x, v: %x\n", k, v)
-		//	return true, nil
-		//})
+		c := tx.Bucket(dbutils.IntermediateWitnessLenBucket).Cursor()
 		k, v, err := c.Seek(prefix)
 		if err != nil {
 			return err
@@ -1614,14 +1610,7 @@ func (tds *TrieDbState) PrefixByCumulativeWitnessSize2(size1, size2 uint64) (fro
 	}
 
 	if err := kv.View(context.TODO(), func(tx ethdb.Tx) error {
-		c := tx.Bucket(dbutils.IntermediateTrieWitnessLenBucket).Cursor()
-		//fmt.Printf("DUMP!\n")
-		//tx.Bucket(dbutils.IntermediateTrieWitnessLenBucket).Cursor().Walk(func(k, v []byte) (bool, error) {
-		//	if bytes.HasPrefix(k, prefix1) || bytes.HasPrefix(k, prefix2) {
-		//		fmt.Printf("%x, %x\n", k, v)
-		//	}
-		//	return true, nil
-		//})
+		c := tx.Bucket(dbutils.IntermediateWitnessLenBucket).Cursor()
 		var err2 error
 		if !ok1 {
 			from, err2 = f(c, prefix1, size1)

--- a/core/state/database.go
+++ b/core/state/database.go
@@ -1516,10 +1516,10 @@ func (tds *TrieDbState) PrefixByCumulativeWitnessSizeFrom(from []byte, size uint
 	if size == 0 {
 		return from, nil
 	}
-	return tds.prefixByCumulativeWitnessSizeFromDBFrom(from, size)
+	return tds.prefixByCumulativeWitnessSizeFrom(from, size)
 }
 
-func (tds *TrieDbState) prefixByCumulativeWitnessSizeFromDBFrom(from []byte, size uint64) (prefix []byte, err error) {
+func (tds *TrieDbState) prefixByCumulativeWitnessSizeFrom(from []byte, size uint64) (prefix []byte, err error) {
 	var kv ethdb.KV
 	if hasBolt, ok := tds.db.(ethdb.HasAbstractKV); ok {
 		kv = hasBolt.AbstractKV()

--- a/core/state/intermediate_hashes.go
+++ b/core/state/intermediate_hashes.go
@@ -49,18 +49,19 @@ func (ih *IntermediateHashes) WillUnloadBranchNode(prefixAsNibbles []byte, nodeH
 		key = common.CopyBytes(buf.B)
 	}
 
-	lenBytes := make([]byte, 8)
-	binary.BigEndian.PutUint64(lenBytes, witnessLen)
-
 	if !debug.IsTrackWitnessSizeEnabled() {
 		if err := ih.putter.Put(dbutils.IntermediateTrieHashBucket, key, common.CopyBytes(nodeHash[:])); err != nil {
 			log.Warn("could not put intermediate trie hash", "err", err)
 		}
 	} else {
+		lenBytes := make([]byte, 8)
+		binary.BigEndian.PutUint64(lenBytes, witnessLen)
+
 		if err := ih.putter.Put(dbutils.IntermediateTrieHashBucket, key, common.CopyBytes(nodeHash[:])); err != nil {
 			log.Warn("could not put intermediate trie hash", "err", err)
 		}
-		if err := ih.putter.Put(dbutils.IntermediateTrieWitnessLenBucket, key, lenBytes); err != nil {
+		//fmt.Printf("Put:%x\n", key)
+		if err := ih.putter.Put(dbutils.IntermediateWitnessLenBucket, common.CopyBytes(key), lenBytes); err != nil {
 			log.Warn("could not put intermediate trie data len", "err", err)
 		}
 	}
@@ -88,7 +89,8 @@ func (ih *IntermediateHashes) BranchNodeLoaded(prefixAsNibbles []byte, incarnati
 		log.Warn("could not delete intermediate trie hash", "err", err)
 	}
 	if debug.IsTrackWitnessSizeEnabled() {
-		if err := ih.deleter.Delete(dbutils.IntermediateTrieWitnessLenBucket, key); err != nil {
+		//fmt.Printf("Del:%x\n", key)
+		if err := ih.deleter.Delete(dbutils.IntermediateWitnessLenBucket, common.CopyBytes(key)); err != nil {
 			log.Warn("could not delete intermediate trie hash", "err", err)
 		}
 	}

--- a/core/state/intermediate_hashes.go
+++ b/core/state/intermediate_hashes.go
@@ -2,7 +2,6 @@ package state
 
 import (
 	"encoding/binary"
-	"fmt"
 
 	"github.com/ledgerwatch/turbo-geth/common"
 	"github.com/ledgerwatch/turbo-geth/common/dbutils"
@@ -57,7 +56,6 @@ func (ih *IntermediateHashes) WillUnloadBranchNode(prefixAsNibbles []byte, nodeH
 	if debug.IsTrackWitnessSizeEnabled() {
 		lenBytes := make([]byte, 8)
 		binary.BigEndian.PutUint64(lenBytes, witnessSize)
-		fmt.Printf("Put: %dK %x\n", witnessSize/1000, key)
 		if err := ih.putter.Put(dbutils.IntermediateWitnessSizeBucket, common.CopyBytes(key), lenBytes); err != nil {
 			log.Warn("could not put intermediate trie data len", "err", err)
 		}

--- a/core/state/intermediate_hashes.go
+++ b/core/state/intermediate_hashes.go
@@ -52,10 +52,14 @@ func (ih *IntermediateHashes) WillUnloadBranchNode(prefixAsNibbles []byte, nodeH
 	lenBytes := make([]byte, 8)
 	binary.BigEndian.PutUint64(lenBytes, witnessLen)
 
-	if err := ih.putter.Put(dbutils.IntermediateTrieHashBucket, key, common.CopyBytes(nodeHash[:])); err != nil {
-		log.Warn("could not put intermediate trie hash", "err", err)
-	}
-	if debug.IsTrackWitnessSizeEnabled() {
+	if !debug.IsTrackWitnessSizeEnabled() {
+		if err := ih.putter.Put(dbutils.IntermediateTrieHashBucket, key, common.CopyBytes(nodeHash[:])); err != nil {
+			log.Warn("could not put intermediate trie hash", "err", err)
+		}
+	} else {
+		if err := ih.putter.Put(dbutils.IntermediateTrieHashBucket, key, common.CopyBytes(nodeHash[:])); err != nil {
+			log.Warn("could not put intermediate trie hash", "err", err)
+		}
 		if err := ih.putter.Put(dbutils.IntermediateTrieWitnessLenBucket, key, lenBytes); err != nil {
 			log.Warn("could not put intermediate trie data len", "err", err)
 		}
@@ -88,5 +92,4 @@ func (ih *IntermediateHashes) BranchNodeLoaded(prefixAsNibbles []byte, incarnati
 			log.Warn("could not delete intermediate trie hash", "err", err)
 		}
 	}
-
 }

--- a/core/state/intermediate_hashes.go
+++ b/core/state/intermediate_hashes.go
@@ -2,6 +2,7 @@ package state
 
 import (
 	"encoding/binary"
+	"fmt"
 
 	"github.com/ledgerwatch/turbo-geth/common"
 	"github.com/ledgerwatch/turbo-geth/common/dbutils"
@@ -56,6 +57,7 @@ func (ih *IntermediateHashes) WillUnloadBranchNode(prefixAsNibbles []byte, nodeH
 	if debug.IsTrackWitnessSizeEnabled() {
 		lenBytes := make([]byte, 8)
 		binary.BigEndian.PutUint64(lenBytes, witnessSize)
+		fmt.Printf("Put: %dK %x\n", witnessSize/1000, key)
 		if err := ih.putter.Put(dbutils.IntermediateWitnessSizeBucket, common.CopyBytes(key), lenBytes); err != nil {
 			log.Warn("could not put intermediate trie data len", "err", err)
 		}

--- a/core/state_processor.go
+++ b/core/state_processor.go
@@ -190,7 +190,7 @@ func (p *StateProcessor) PreProcess(block *types.Block, ibs *state.IntraBlockSta
 	if err != nil {
 		return
 	}
-	//root, err = tds.CalcTrieRoots(false)
+	root, err = tds.CalcTrieRoots(false)
 	return receipts, allLogs, usedGas, root, err
 }
 

--- a/core/state_processor.go
+++ b/core/state_processor.go
@@ -190,7 +190,7 @@ func (p *StateProcessor) PreProcess(block *types.Block, ibs *state.IntraBlockSta
 	if err != nil {
 		return
 	}
-	root, err = tds.CalcTrieRoots(false)
+	//root, err = tds.CalcTrieRoots(false)
 	return receipts, allLogs, usedGas, root, err
 }
 

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -663,7 +663,6 @@ func setStorageModeIfNotExist(db ethdb.Database, sm StorageMode) error {
 	var (
 		err error
 	)
-
 	err = setModeOnEmpty(db, dbutils.StorageModeHistory, sm.History)
 	if err != nil {
 		return err

--- a/eth/downloader/modes.go
+++ b/eth/downloader/modes.go
@@ -26,6 +26,7 @@ const (
 	FastSync                   // Quickly download the headers, full sync only at the chain head
 	LightSync                  // Download only the headers and terminate afterwards
 	StagedSync                 // Full sync but done in stages
+	MgrSync                    // MarryGoRound sync
 )
 
 const (
@@ -33,6 +34,7 @@ const (
 	FastSyncName   = "fast"
 	LightSyncName  = "light"
 	StagedSyncName = "staged"
+	MgrSyncName    = "mgr"
 )
 
 func (mode SyncMode) IsValid() bool {
@@ -50,6 +52,8 @@ func (mode SyncMode) String() string {
 		return LightSyncName
 	case StagedSync:
 		return StagedSyncName
+	case MgrSync:
+		return MgrSyncName
 	default:
 		return "unknown"
 	}
@@ -65,6 +69,8 @@ func (mode SyncMode) MarshalText() ([]byte, error) {
 		return []byte(LightSyncName), nil
 	case StagedSync:
 		return []byte(StagedSyncName), nil
+	case MgrSync:
+		return []byte(MgrSyncName), nil
 	default:
 		return nil, fmt.Errorf("unknown sync mode %d", mode)
 	}
@@ -80,9 +86,11 @@ func (mode *SyncMode) UnmarshalText(text []byte) error {
 		*mode = LightSync
 	case StagedSyncName:
 		*mode = StagedSync
+	case MgrSyncName:
+		*mode = MgrSync
 	default:
-		return fmt.Errorf(`unknown sync mode %q, want "%s", "%s", "%s" or "%s"`,
-			FullSyncName, FastSyncName, LightSyncName, StagedSyncName, text)
+		return fmt.Errorf(`unknown sync mode %q, want "%s", "%s", "%s" or "%s" or "%s"`,
+			FullSyncName, FastSyncName, LightSyncName, StagedSyncName, MgrSyncName, text)
 	}
 	return nil
 }

--- a/eth/handler.go
+++ b/eth/handler.go
@@ -168,10 +168,10 @@ func NewProtocolManager(config *params.ChainConfig, checkpoint *params.TrustedCh
 	return manager, nil
 }
 
-func (manager *ProtocolManager) SetDataDir(datadir string) {
-	manager.datadir = datadir
-	if manager.downloader != nil {
-		manager.downloader.SetDataDir(datadir)
+func (pm *ProtocolManager) SetDataDir(datadir string) {
+	pm.datadir = datadir
+	if pm.downloader != nil {
+		pm.downloader.SetDataDir(datadir)
 	}
 }
 
@@ -1008,7 +1008,7 @@ func (pm *ProtocolManager) handleDebugMsg(p *debugPeer) error {
 		pm.blockchain.ChainDb().Close()
 		blockchain, err := core.NewBlockChain(ethDb, nil, chainConfig, engine, vm.Config{}, nil, nil)
 		if err != nil {
-			return fmt.Errorf("NewBlockChain: %w", err)
+			return fmt.Errorf("fail in NewBlockChain: %w", err)
 		}
 		pm.blockchain.Stop()
 		pm.blockchain = blockchain

--- a/eth/handler.go
+++ b/eth/handler.go
@@ -1016,7 +1016,7 @@ func (pm *ProtocolManager) handleDebugMsg(p *debugPeer) error {
 
 		tds, err := pm.blockchain.GetTrieDbState()
 		if err != nil {
-			return fmt.Errorf("GetTrieDbState: %w", err)
+			return fmt.Errorf("fail in GetTrieDbState: %w", err)
 		}
 		initPm(pm, pm.txpool, pm.blockchain.Engine(), pm.blockchain, tds, pm.blockchain.ChainDb())
 		pm.quitSync = make(chan struct{})

--- a/eth/handler.go
+++ b/eth/handler.go
@@ -33,11 +33,13 @@ import (
 	"github.com/ledgerwatch/turbo-geth/consensus"
 	"github.com/ledgerwatch/turbo-geth/core"
 	"github.com/ledgerwatch/turbo-geth/core/forkid"
+	"github.com/ledgerwatch/turbo-geth/core/state"
 	"github.com/ledgerwatch/turbo-geth/core/types"
 	"github.com/ledgerwatch/turbo-geth/core/vm"
 	"github.com/ledgerwatch/turbo-geth/crypto"
 	"github.com/ledgerwatch/turbo-geth/eth/downloader"
 	"github.com/ledgerwatch/turbo-geth/eth/fetcher"
+	"github.com/ledgerwatch/turbo-geth/eth/mgr"
 	"github.com/ledgerwatch/turbo-geth/ethdb"
 	"github.com/ledgerwatch/turbo-geth/ethdb/remote/remotedbserver"
 	"github.com/ledgerwatch/turbo-geth/event"
@@ -104,8 +106,9 @@ type ProtocolManager struct {
 	// Test fields or hooks
 	broadcastTxAnnouncesOnly bool // Testing field, disable transaction propagation
 
-	mode downloader.SyncMode // Sync mode passed from the command line
+	mode    downloader.SyncMode // Sync mode passed from the command line
 	datadir string
+	mgr     *mgrBroadcast
 }
 
 // NewProtocolManager returns a new Ethereum sub protocol manager. The Ethereum sub protocol manages peers capable
@@ -156,7 +159,11 @@ func NewProtocolManager(config *params.ChainConfig, checkpoint *params.TrustedCh
 		manager.checkpointHash = checkpoint.SectionHead
 	}
 
-	initPm(manager, txpool, engine, blockchain, chaindb)
+	tds, err := blockchain.GetTrieDbState()
+	if err != nil {
+		return nil, err
+	}
+	initPm(manager, txpool, engine, blockchain, tds, chaindb)
 
 	return manager, nil
 }
@@ -168,7 +175,7 @@ func (manager *ProtocolManager) SetDataDir(datadir string) {
 	}
 }
 
-func initPm(manager *ProtocolManager, txpool txPool, engine consensus.Engine, blockchain *core.BlockChain, chaindb ethdb.Database) {
+func initPm(manager *ProtocolManager, txpool txPool, engine consensus.Engine, blockchain *core.BlockChain, tds *state.TrieDbState, chaindb ethdb.Database) {
 	sm, err := GetStorageModeFromDB(chaindb)
 	if err != nil {
 		log.Error("Get storage mode", "err", err)
@@ -223,6 +230,7 @@ func initPm(manager *ProtocolManager, txpool txPool, engine consensus.Engine, bl
 		manager.txFetcher = fetcher.NewTxFetcher(txpool.Has, txpool.AddRemotes, fetchTx)
 	}
 	manager.chainSync = newChainSyncer(manager)
+	manager.mgr = NewMgr(mgr.NewSchedule(tds), tds)
 }
 
 func (pm *ProtocolManager) makeDebugProtocol() p2p.Protocol {
@@ -1005,8 +1013,14 @@ func (pm *ProtocolManager) handleDebugMsg(p *debugPeer) error {
 		pm.blockchain.Stop()
 		pm.blockchain = blockchain
 		pm.forkFilter = forkid.NewFilter(pm.blockchain)
-		initPm(pm, pm.txpool, pm.blockchain.Engine(), pm.blockchain, pm.blockchain.ChainDb())
+
+		tds, err := pm.blockchain.GetTrieDbState()
+		if err != nil {
+			return fmt.Errorf("GetTrieDbState: %w", err)
+		}
+		initPm(pm, pm.txpool, pm.blockchain.Engine(), pm.blockchain, tds, pm.blockchain.ChainDb())
 		pm.quitSync = make(chan struct{})
+
 		remotedbserver.StartDeprecated(ethDb.AbstractKV(), "") // hack to make UI work. But need to somehow re-create whole Node or Ethereum objects
 
 		// hacks to speedup local sync

--- a/eth/mgr.go
+++ b/eth/mgr.go
@@ -1,6 +1,10 @@
 package eth
 
 import (
+	"io"
+	"sync"
+
+	"github.com/ledgerwatch/turbo-geth/eth/mgr"
 	"github.com/ledgerwatch/turbo-geth/p2p"
 )
 
@@ -33,4 +37,80 @@ type mgrPeer struct {
 func (p *mgrPeer) SendByteCode(id uint64, data [][]byte) error {
 	msg := bytecodeMsg{ID: id, Code: data}
 	return p2p.Send(p.rw, BytecodeCode, msg)
+}
+
+type nodeState interface {
+	GetBlockNr() uint64
+}
+
+type mgrBroadcast struct {
+	lock     sync.RWMutex
+	peers    map[string]*peer
+	schedule *mgr.Schedule
+	state    nodeState
+}
+
+func NewMgr(schedule *mgr.Schedule, nodeState nodeState) *mgrBroadcast {
+	return &mgrBroadcast{schedule: schedule, state: nodeState}
+}
+
+func (m *mgrBroadcast) Start() {
+	for {
+		block := m.state.GetBlockNr()
+		tick, err := m.schedule.Tick(block)
+		if err != nil {
+			panic(err)
+		}
+		//witnessCache := map[string][]byte{}
+		for m.state.GetBlockNr() <= tick.ToBlock {
+			for _, slice := range tick.StateSlices {
+				_ = slice
+
+				// Produce and Broadcast witness of slice
+
+				//retain := trie.NewRetainRange(common.CopyBytes(slice.From), common.CopyBytes(slice.To))
+				//if tick.IsLastInCycle() {
+				//	fmt.Printf("\nretain: %s\n", retain)
+				//}
+				//witness, err2 := tds.Trie().ExtractWitness(false, retain)
+				//if err2 != nil {
+				//	panic(err2)
+				//}
+				//
+				//buf.Reset()
+				//_, err = witness.WriteTo(&buf)
+				//if err != nil {
+				//	panic(err)
+				//}
+			}
+		}
+	}
+}
+
+func (m *mgrBroadcast) AddPeer(p *peer) {
+	m.lock.Lock()
+	defer m.lock.Unlock()
+	m.peers[p.id] = p
+}
+
+func (m *mgrBroadcast) RemovePeer(id string) {
+	m.lock.Lock()
+	defer m.lock.Unlock()
+	delete(m.peers, id)
+}
+
+func (m *mgrBroadcast) Peer(id string) *peer {
+	m.lock.RLock()
+	defer m.lock.RUnlock()
+	return m.peers[id]
+}
+
+func (m *mgrBroadcast) Broadcast(witness io.Reader) {
+	m.lock.RLock()
+	defer m.lock.RUnlock()
+	for _, p := range m.peers {
+		if err := p.rw.WriteMsg(p2p.Msg{Code: MGRWitness, Size: 0, Payload: witness}); err != nil {
+			p.Log().Debug("MGR message sending failed", "err", err)
+		}
+	}
 }

--- a/eth/mgr.go
+++ b/eth/mgr.go
@@ -63,26 +63,22 @@ func (m *mgrBroadcast) Start() {
 		}
 		//witnessCache := map[string][]byte{}
 		for m.state.GetBlockNr() <= tick.ToBlock {
-			for _, slice := range tick.StateSlices {
-				_ = slice
+			// Produce and Broadcast witness of slice
 
-				// Produce and Broadcast witness of slice
-
-				//retain := trie.NewRetainRange(common.CopyBytes(slice.From), common.CopyBytes(slice.To))
-				//if tick.IsLastInCycle() {
-				//	fmt.Printf("\nretain: %s\n", retain)
-				//}
-				//witness, err2 := tds.Trie().ExtractWitness(false, retain)
-				//if err2 != nil {
-				//	panic(err2)
-				//}
-				//
-				//buf.Reset()
-				//_, err = witness.WriteTo(&buf)
-				//if err != nil {
-				//	panic(err)
-				//}
-			}
+			//retain := trie.NewRetainRange(common.CopyBytes(slice.From), common.CopyBytes(slice.To))
+			//if tick.IsLastInCycle() {
+			//	fmt.Printf("\nretain: %s\n", retain)
+			//}
+			//witness, err2 := tds.Trie().ExtractWitness(false, retain)
+			//if err2 != nil {
+			//	panic(err2)
+			//}
+			//
+			//buf.Reset()
+			//_, err = witness.WriteTo(&buf)
+			//if err != nil {
+			//	panic(err)
+			//}
 		}
 	}
 }

--- a/eth/mgr/mgr.go
+++ b/eth/mgr/mgr.go
@@ -80,6 +80,7 @@ type Schedule struct {
 type WitnessEstimator interface {
 	CumulativeWitnessSize(key []byte) uint64
 	PrefixByCumulativeWitnessSize(size uint64) (prefix []byte, err error)
+	PrefixByCumulativeWitnessSize2(size uint64) (prefix []byte, err error)
 }
 
 func NewSchedule(estimator WitnessEstimator) *Schedule {
@@ -91,10 +92,10 @@ func (s *Schedule) Tick(block uint64) (Tick, error) {
 	tick.StateSlices = append(tick.StateSlices)
 	for i := range tick.StateSlices {
 		var err error
-		if tick.StateSlices[i].From, err = s.estimator.PrefixByCumulativeWitnessSize(tick.StateSlices[i].FromSize); err != nil {
+		if tick.StateSlices[i].From, err = s.estimator.PrefixByCumulativeWitnessSize2(tick.StateSlices[i].FromSize); err != nil {
 			return Tick{}, err
 		}
-		if tick.StateSlices[i].To, err = s.estimator.PrefixByCumulativeWitnessSize(tick.StateSlices[i].ToSize); err != nil {
+		if tick.StateSlices[i].To, err = s.estimator.PrefixByCumulativeWitnessSize2(tick.StateSlices[i].ToSize); err != nil {
 			return Tick{}, err
 		}
 	}

--- a/eth/mgr/mgr.go
+++ b/eth/mgr/mgr.go
@@ -62,9 +62,6 @@ type Schedule struct {
 type WitnessEstimator interface {
 	TotalCumulativeWitnessSize() (uint64, error)
 	PrefixByCumulativeWitnessSize(from []byte, size uint64) (prefix []byte, err error)
-
-	TotalCumulativeWitnessSizeDeprecated() uint64
-	PrefixByCumulativeWitnessSizeDeprecated(size uint64) (prefix []byte, err error)
 }
 
 func NewSchedule(estimator WitnessEstimator) *Schedule {
@@ -97,18 +94,5 @@ func (s *Schedule) Tick(block uint64) (*Tick, error) {
 		tick.From = []byte{}
 	}
 	s.prevTick = tick
-	return tick, nil
-}
-
-func (s *Schedule) TickDeprecated(block uint64) (*Tick, error) {
-	tick := NewTick(block, s.estimator.TotalCumulativeWitnessSizeDeprecated(), s.prevTick)
-	var err error
-	if tick.From, err = s.estimator.PrefixByCumulativeWitnessSizeDeprecated(tick.FromSize); err != nil {
-		return tick, err
-	}
-	if tick.To, err = s.estimator.PrefixByCumulativeWitnessSizeDeprecated(tick.ToSize); err != nil {
-		return tick, err
-	}
-
 	return tick, nil
 }

--- a/eth/mgr/mgr.go
+++ b/eth/mgr/mgr.go
@@ -86,6 +86,7 @@ type Schedule struct {
 type WitnessEstimator interface {
 	CumulativeWitnessSize() uint64
 	CumulativeWitnessSizeDBOnly() (uint64, error)
+	CumulativeWitnessSizeDBOnly2() (uint64, error)
 	PrefixByCumulativeWitnessSize(size uint64) (prefix []byte, err error)
 	PrefixByCumulativeWitnessSizeDBOnly(size uint64) (prefix []byte, err error)
 	PrefixByCumulativeWitnessSizeFrom(from []byte, size uint64) (prefix []byte, err error)
@@ -113,6 +114,29 @@ func (s *Schedule) Tick(block uint64) (*Tick, error) {
 
 func (s *Schedule) Tick2(block uint64) (*Tick, error) {
 	total, err := s.estimator.CumulativeWitnessSizeDBOnly()
+	if err != nil {
+		return nil, err
+	}
+
+	tick := newTick(block, total, s.lastTick)
+	for i := range tick.StateSlices {
+		var err error
+		if tick.StateSlices[i].From == nil {
+			if tick.StateSlices[i].From, err = s.estimator.PrefixByCumulativeWitnessSizeFrom([]byte{}, tick.StateSlices[i].FromSize); err != nil {
+				return tick, err
+			}
+		}
+		if tick.StateSlices[i].To, err = s.estimator.PrefixByCumulativeWitnessSizeFrom(tick.StateSlices[i].From, tick.StateSlices[i].ToSize-tick.StateSlices[i].FromSize); err != nil {
+			return tick, err
+		}
+	}
+
+	s.lastTick = tick
+	return tick, nil
+}
+
+func (s *Schedule) Tick3(block uint64) (*Tick, error) {
+	total, err := s.estimator.CumulativeWitnessSizeDBOnly2()
 	if err != nil {
 		return nil, err
 	}

--- a/eth/mgr/mgr.go
+++ b/eth/mgr/mgr.go
@@ -95,6 +95,6 @@ func min(a, b uint64) uint64 {
 
 // Temporary unoptimal implementation. Get existing short prefixes from trie, then resolve range, and give long prefixes from trie.
 func StateSizeSlice2StateSlice(tds *state.TrieDbState, in StateSizeSlice) (out StateSlice, err error) {
-	out.From, out.To, err = tds.PrefixByCumulativeWitnessSize2(in.FromSize, in.ToSize)
+	out.From, out.To, err = tds.PrefixByCumulativeWitnessSize(in.FromSize, in.ToSize)
 	return out, err
 }

--- a/eth/mgr/mgr.go
+++ b/eth/mgr/mgr.go
@@ -4,8 +4,6 @@ import (
 	"fmt"
 
 	"github.com/ledgerwatch/turbo-geth/core/state"
-	"github.com/ledgerwatch/turbo-geth/ethdb"
-	"github.com/ledgerwatch/turbo-geth/trie"
 )
 
 const (
@@ -96,29 +94,7 @@ func min(a, b uint64) uint64 {
 }
 
 // Temporary unoptimal implementation. Get existing short prefixes from trie, then resolve range, and give long prefixes from trie.
-func StateSizeSlice2StateSlice(tds *state.TrieDbState, in StateSizeSlice) (StateSlice, error) {
-	out := StateSlice{}
-
-	var err error
+func StateSizeSlice2StateSlice(tds *state.TrieDbState, in StateSizeSlice) (out StateSlice, err error) {
 	out.From, out.To, err = tds.PrefixByCumulativeWitnessSize2(in.FromSize, in.ToSize)
-	if err != nil {
-		return StateSlice{}, err
-	}
-
-	return out, nil
-}
-
-func _resolve(db ethdb.Database, tr *trie.Trie, decider trie.RetainDecider) error {
-	loader := trie.NewSubTrieLoader(0)
-	dbPrefixes, fixedbits, hooks := tr.FindSubTriesToLoad(decider)
-	subTries, err := loader.LoadSubTries(db, 0, decider, dbPrefixes, fixedbits, false)
-	if err != nil {
-		return err
-	}
-	//fmt.Printf("retain: %s\n", decider)
-	//fmt.Printf("dbPrefixes: %x, %d\n", dbPrefixes, len(subTries.Hashes))
-	if err := tr.HookSubTries(subTries, hooks); err != nil {
-		return err
-	}
-	return nil
+	return out, err
 }

--- a/eth/mgr/mgr.go
+++ b/eth/mgr/mgr.go
@@ -2,8 +2,6 @@ package mgr
 
 import (
 	"fmt"
-
-	"github.com/ledgerwatch/turbo-geth/core/state"
 )
 
 const (
@@ -14,54 +12,37 @@ const (
 	BytesPerWitness uint64 = 1024 * 1024
 )
 
-type Schedule struct {
-	Ticks []Tick
-}
-
 type Tick struct {
-	Number          uint64
-	FromBlock       uint64
-	ToBlock         uint64
-	FromSize        uint64
-	ToSize          uint64
-	StateSizeSlices []StateSizeSlice
-}
-
-type StateSizeSlice struct {
-	FromSize uint64
-	ToSize   uint64
+	Number      uint64
+	FromBlock   uint64
+	ToBlock     uint64
+	FromSize    uint64
+	ToSize      uint64
+	StateSlices []StateSlice
 }
 
 type StateSlice struct {
-	From []byte
-	To   []byte
+	FromSize uint64
+	ToSize   uint64
+	From     []byte
+	To       []byte
 }
 
-func (s Schedule) String() string { return fmt.Sprintf("Schedule{Ticks:%s}", s.Ticks) }
 func (t Tick) String() string {
-	return fmt.Sprintf("Tick{%d,Blocks:%d-%d,Sizes:%d-%d,Slices:%d}", t.Number, t.FromBlock, t.ToBlock, t.FromSize, t.ToSize, t.StateSizeSlices)
+	return fmt.Sprintf("Tick{%d,Blocks:%d-%d,Sizes:%d-%d,Slices:%s}", t.Number, t.FromBlock, t.ToBlock, t.FromSize, t.ToSize, t.StateSlices)
 }
-func (ss StateSlice) String() string { return fmt.Sprintf("{%x-%x}", ss.From, ss.To) }
+func (ss StateSlice) String() string {
+	return fmt.Sprintf("{Sizes:%x-%x,Prefixes:%x-%x}", ss.FromSize, ss.ToSize, ss.From, ss.To)
+}
 
 func (t Tick) IsLastInCycle() bool {
 	return t.Number == TicksPerCycle-1
 }
 
-func NewStateSchedule(stateSize, fromBlock, toBlock uint64) Schedule {
-	schedule := Schedule{}
-
-	for fromBlock <= toBlock {
-		tick := NewTick(fromBlock, stateSize)
-		schedule.Ticks = append(schedule.Ticks, tick)
-		fromBlock = tick.ToBlock + 1
-	}
-
-	return schedule
-}
-
-func NewTick(blockNr, stateSize uint64) Tick {
+func newTick(blockNr, stateSize uint64) Tick {
 	number := blockNr / BlocksPerTick % TicksPerCycle
 	fromSize := number * stateSize / TicksPerCycle
+	fmt.Printf("%d %d,%d\n", blockNr, blockNr-blockNr%BlocksPerTick+BlocksPerTick-1, blockNr%BlocksPerTick)
 
 	tick := Tick{
 		Number:    number,
@@ -72,12 +53,12 @@ func NewTick(blockNr, stateSize uint64) Tick {
 	}
 
 	for i := uint64(0); ; i++ {
-		ss := StateSizeSlice{
+		ss := StateSlice{
 			FromSize: tick.FromSize + i*BytesPerWitness,
 			ToSize:   min(tick.FromSize+(i+1)*BytesPerWitness-1, tick.ToSize),
 		}
 
-		tick.StateSizeSlices = append(tick.StateSizeSlices, ss)
+		tick.StateSlices = append(tick.StateSlices, ss)
 		if ss.ToSize >= tick.ToSize {
 			break
 		}
@@ -93,8 +74,32 @@ func min(a, b uint64) uint64 {
 	return b
 }
 
-// Temporary unoptimal implementation. Get existing short prefixes from trie, then resolve range, and give long prefixes from trie.
-func StateSizeSlice2StateSlice(tds *state.TrieDbState, in StateSizeSlice) (out StateSlice, err error) {
-	out.From, out.To, err = tds.PrefixByCumulativeWitnessSize(in.FromSize, in.ToSize)
-	return out, err
+type Schedule struct {
+	estimator WitnessEstimator
+}
+
+type WitnessEstimator interface {
+	CumulativeWitnessLen(key []byte) uint64
+	PrefixByCumulativeWitnessLen(size uint64) (prefix []byte, err error)
+}
+
+func NewSchedule(estimator WitnessEstimator) *Schedule {
+	return &Schedule{estimator: estimator}
+}
+
+func (s *Schedule) Tick(block uint64) (Tick, error) {
+	tick := newTick(block, s.estimator.CumulativeWitnessLen([]byte{}))
+	tick.StateSlices = append(tick.StateSlices)
+	for i := range tick.StateSlices {
+		var err error
+		if tick.StateSlices[i].From, err = s.estimator.PrefixByCumulativeWitnessLen(tick.StateSlices[i].FromSize); err != nil {
+			return Tick{}, err
+		}
+		if tick.StateSlices[i].To, err = s.estimator.PrefixByCumulativeWitnessLen(tick.StateSlices[i].ToSize); err != nil {
+			return Tick{}, err
+		}
+	}
+
+	return tick, nil
+
 }

--- a/eth/mgr/mgr_test.go
+++ b/eth/mgr/mgr_test.go
@@ -33,5 +33,6 @@ func TestScheduleProperties(t *testing.T) {
 		}
 
 		prevTick = tick
+		block = tick.ToBlock + 1
 	}
 }

--- a/eth/mgr/mgr_test.go
+++ b/eth/mgr/mgr_test.go
@@ -11,16 +11,14 @@ func TestScheduleProperties(t *testing.T) {
 	require := require.New(t)
 	stateSize := uint64(123456)
 	block := uint64(11)
-
+	toBlock := block + mgr.BlocksPerCycle + 100
 	var prevTick *mgr.Tick
 
 	var sizeFromTicksAccumulator uint64
-
-	for block <= block+mgr.BlocksPerCycle+100 {
+	for block <= toBlock {
 		tick := mgr.NewTick(block, stateSize, prevTick)
 
 		sizeFromTicksAccumulator += tick.ToSize - tick.FromSize
-
 		// props
 		if prevTick != nil && prevTick.Number < tick.Number {
 			require.LessOrEqual(block, tick.FromBlock)

--- a/eth/mgr/mgr_test.go
+++ b/eth/mgr/mgr_test.go
@@ -1,51 +1,44 @@
 package mgr_test
 
-import (
-	"testing"
-
-	"github.com/ledgerwatch/turbo-geth/eth/mgr"
-	"github.com/stretchr/testify/require"
-)
-
-func TestScheduleProperties(t *testing.T) {
-	require := require.New(t)
-	stateSize := uint64(123456)
-	block := uint64(11)
-
-	var prevTick mgr.Tick
-	var prevSlice mgr.StateSizeSlice
-
-	var sizeFromSlicesAccumulator uint64
-	var sizeFromTicksAccumulator uint64
-	schedule := mgr.NewStateSchedule(stateSize, block, block+mgr.BlocksPerCycle+100)
-	for i := range schedule.Ticks {
-		tick := schedule.Ticks[i]
-		for j := range tick.StateSizeSlices {
-			ss := tick.StateSizeSlices[j]
-			sizeFromSlicesAccumulator += ss.ToSize - ss.FromSize
-
-			// props
-			if prevTick.Number < tick.Number { // because cycles are... cycled
-				require.Less(ss.FromSize, ss.ToSize)
-				require.LessOrEqual(prevSlice.ToSize, ss.FromSize)
-			}
-
-			prevSlice = ss
-		}
-		sizeFromTicksAccumulator += tick.ToSize - tick.FromSize
-
-		// props
-		if prevTick.Number < tick.Number {
-			require.LessOrEqual(block, tick.FromBlock)
-			require.Less(tick.FromBlock, tick.ToBlock)
-			require.Less(prevTick.ToBlock, tick.FromBlock)
-
-			require.LessOrEqual(tick.ToSize, stateSize)
-			require.Less(tick.FromSize, tick.ToSize)
-			require.Less(prevTick.ToSize, tick.FromSize)
-		}
-
-		prevTick = tick
-	}
-
-}
+//func TestScheduleProperties(t *testing.T) {
+//	require := require.New(t)
+//	stateSize := uint64(123456)
+//	block := uint64(11)
+//
+//	var prevTick mgr.Tick
+//	var prevSlice mgr.StateSizeSlice
+//
+//	var sizeFromSlicesAccumulator uint64
+//	var sizeFromTicksAccumulator uint64
+//	schedule := mgr.NewStateSchedule(stateSize, block, block+mgr.BlocksPerCycle+100)
+//	for i := range schedule.Ticks {
+//		tick := schedule.Ticks[i]
+//		for j := range tick.StateSizeSlices {
+//			ss := tick.StateSizeSlices[j]
+//			sizeFromSlicesAccumulator += ss.ToSize - ss.FromSize
+//
+//			// props
+//			if prevTick.Number < tick.Number { // because cycles are... cycled
+//				require.Less(ss.FromSize, ss.ToSize)
+//				require.LessOrEqual(prevSlice.ToSize, ss.FromSize)
+//			}
+//
+//			prevSlice = ss
+//		}
+//		sizeFromTicksAccumulator += tick.ToSize - tick.FromSize
+//
+//		// props
+//		if prevTick.Number < tick.Number {
+//			require.LessOrEqual(block, tick.FromBlock)
+//			require.Less(tick.FromBlock, tick.ToBlock)
+//			require.Less(prevTick.ToBlock, tick.FromBlock)
+//
+//			require.LessOrEqual(tick.ToSize, stateSize)
+//			require.Less(tick.FromSize, tick.ToSize)
+//			require.Less(prevTick.ToSize, tick.FromSize)
+//		}
+//
+//		prevTick = tick
+//	}
+//
+//}

--- a/eth/mgr/mgr_test.go
+++ b/eth/mgr/mgr_test.go
@@ -1,44 +1,37 @@
 package mgr_test
 
-//func TestScheduleProperties(t *testing.T) {
-//	require := require.New(t)
-//	stateSize := uint64(123456)
-//	block := uint64(11)
-//
-//	var prevTick mgr.Tick
-//	var prevSlice mgr.StateSizeSlice
-//
-//	var sizeFromSlicesAccumulator uint64
-//	var sizeFromTicksAccumulator uint64
-//	schedule := mgr.NewStateSchedule(stateSize, block, block+mgr.BlocksPerCycle+100)
-//	for i := range schedule.Ticks {
-//		tick := schedule.Ticks[i]
-//		for j := range tick.StateSizeSlices {
-//			ss := tick.StateSizeSlices[j]
-//			sizeFromSlicesAccumulator += ss.ToSize - ss.FromSize
-//
-//			// props
-//			if prevTick.Number < tick.Number { // because cycles are... cycled
-//				require.Less(ss.FromSize, ss.ToSize)
-//				require.LessOrEqual(prevSlice.ToSize, ss.FromSize)
-//			}
-//
-//			prevSlice = ss
-//		}
-//		sizeFromTicksAccumulator += tick.ToSize - tick.FromSize
-//
-//		// props
-//		if prevTick.Number < tick.Number {
-//			require.LessOrEqual(block, tick.FromBlock)
-//			require.Less(tick.FromBlock, tick.ToBlock)
-//			require.Less(prevTick.ToBlock, tick.FromBlock)
-//
-//			require.LessOrEqual(tick.ToSize, stateSize)
-//			require.Less(tick.FromSize, tick.ToSize)
-//			require.Less(prevTick.ToSize, tick.FromSize)
-//		}
-//
-//		prevTick = tick
-//	}
-//
-//}
+import (
+	"testing"
+
+	"github.com/ledgerwatch/turbo-geth/eth/mgr"
+	"github.com/stretchr/testify/require"
+)
+
+func TestScheduleProperties(t *testing.T) {
+	require := require.New(t)
+	stateSize := uint64(123456)
+	block := uint64(11)
+
+	var prevTick *mgr.Tick
+
+	var sizeFromTicksAccumulator uint64
+
+	for block <= block+mgr.BlocksPerCycle+100 {
+		tick := mgr.NewTick(block, stateSize, prevTick)
+
+		sizeFromTicksAccumulator += tick.ToSize - tick.FromSize
+
+		// props
+		if prevTick != nil && prevTick.Number < tick.Number {
+			require.LessOrEqual(block, tick.FromBlock)
+			require.Less(tick.FromBlock, tick.ToBlock)
+			require.Less(prevTick.ToBlock, tick.FromBlock)
+
+			require.LessOrEqual(tick.ToSize, stateSize)
+			require.Less(tick.FromSize, tick.ToSize)
+			require.Less(prevTick.ToSize, tick.FromSize)
+		}
+
+		prevTick = tick
+	}
+}

--- a/ethdb/bolt_db.go
+++ b/ethdb/bolt_db.go
@@ -26,6 +26,7 @@ import (
 	"github.com/ledgerwatch/bolt"
 	"github.com/ledgerwatch/turbo-geth/common"
 	"github.com/ledgerwatch/turbo-geth/common/dbutils"
+	"github.com/ledgerwatch/turbo-geth/common/debug"
 	"github.com/ledgerwatch/turbo-geth/core/types/accounts"
 	"github.com/ledgerwatch/turbo-geth/log"
 )
@@ -75,6 +76,9 @@ func NewBoltDatabase(file string) (*BoltDatabase, error) {
 		return nil
 	}); err != nil {
 		return nil, err
+	}
+	if debug.IsTrackWitnessSizeEnabled() {
+		db.NoSync = true
 	}
 
 	return &BoltDatabase{

--- a/ethdb/mutation_puts.go
+++ b/ethdb/mutation_puts.go
@@ -1,9 +1,8 @@
 package ethdb
 
 type puts struct {
-	mp   map[string]putsBucket //map[bucket]putsBucket
-	size int
-	len  int
+	mp  map[string]putsBucket //map[bucket]putsBucketsize int
+	len int
 }
 
 func newPuts() *puts {

--- a/ethdb/mutation_puts.go
+++ b/ethdb/mutation_puts.go
@@ -1,8 +1,8 @@
 package ethdb
 
 type puts struct {
-	mp  map[string]putsBucket //map[bucket]putsBucketsize int
-	len int
+	mp   map[string]putsBucket //map[bucket]putsBucket
+	size intlen int
 }
 
 func newPuts() *puts {

--- a/ethdb/mutation_puts.go
+++ b/ethdb/mutation_puts.go
@@ -2,7 +2,8 @@ package ethdb
 
 type puts struct {
 	mp   map[string]putsBucket //map[bucket]putsBucket
-	size intlen int
+	size int
+	len  int
 }
 
 func newPuts() *puts {

--- a/internal/debug/flags.go
+++ b/internal/debug/flags.go
@@ -290,7 +290,6 @@ func Setup(ctx *cli.Context) error {
 	}
 
 	address := fmt.Sprintf("%s:%d", listenHost, port)
-	fmt.Printf("Enabling metrics!%t\n", metrics.Enabled)
 	StartPProf(ctx.GlobalBool(pprofFlag.Name), metrics.Enabled, address)
 	return nil
 }

--- a/internal/debug/flags.go
+++ b/internal/debug/flags.go
@@ -276,23 +276,22 @@ func Setup(ctx *cli.Context) error {
 	}
 
 	// pprof server
-	if ctx.GlobalBool(pprofFlag.Name) {
-		listenHost := ctx.GlobalString(pprofAddrFlag.Name)
-		if ctx.GlobalIsSet(legacyPprofAddrFlag.Name) && !ctx.GlobalIsSet(pprofAddrFlag.Name) {
-			listenHost = ctx.GlobalString(legacyPprofAddrFlag.Name)
-			log.Warn("The flag --pprofaddr is deprecated and will be removed in the future, please use --pprof.addr")
-		}
-
-		port := ctx.GlobalInt(pprofPortFlag.Name)
-		if ctx.GlobalIsSet(legacyPprofPortFlag.Name) && !ctx.GlobalIsSet(pprofPortFlag.Name) {
-			port = ctx.GlobalInt(legacyPprofPortFlag.Name)
-			log.Warn("The flag --pprofport is deprecated and will be removed in the future, please use --pprof.port")
-			Exit()
-		}
-
-		address := fmt.Sprintf("%s:%d", listenHost, port)
-		StartPProf(ctx.GlobalBool(pprofFlag.Name), metrics.Enabled, address)
+	listenHost := ctx.GlobalString(pprofAddrFlag.Name)
+	if ctx.GlobalIsSet(legacyPprofAddrFlag.Name) && !ctx.GlobalIsSet(pprofAddrFlag.Name) {
+		listenHost = ctx.GlobalString(legacyPprofAddrFlag.Name)
+		log.Warn("The flag --pprofaddr is deprecated and will be removed in the future, please use --pprof.addr")
 	}
+
+	port := ctx.GlobalInt(pprofPortFlag.Name)
+	if ctx.GlobalIsSet(legacyPprofPortFlag.Name) && !ctx.GlobalIsSet(pprofPortFlag.Name) {
+		port = ctx.GlobalInt(legacyPprofPortFlag.Name)
+		log.Warn("The flag --pprofport is deprecated and will be removed in the future, please use --pprof.port")
+		Exit()
+	}
+
+	address := fmt.Sprintf("%s:%d", listenHost, port)
+	fmt.Printf("Enabling metrics!%t\n", metrics.Enabled)
+	StartPProf(ctx.GlobalBool(pprofFlag.Name), metrics.Enabled, address)
 	return nil
 }
 

--- a/internal/ethapi/get_proof.go
+++ b/internal/ethapi/get_proof.go
@@ -129,7 +129,7 @@ func (s *PublicBlockChainAPI) GetProof(ctx context.Context, address common.Addre
 	}
 	sort.Strings(unfurlList)
 	loader := trie.NewFlatDbSubTrieLoader()
-	if err = loader.Reset(db, unfurl, [][]byte{nil}, []int{0}, false); err != nil {
+	if err = loader.Reset(db, unfurl, unfurl, [][]byte{nil}, []int{0}, false); err != nil {
 		return nil, err
 	}
 	r := &Receiver{defaultReceiver: trie.NewDefaultReceiver(), unfurlList: unfurlList, accountMap: accountMap, storageMap: storageMap}

--- a/trie/flatdb_sub_trie_loader.go
+++ b/trie/flatdb_sub_trie_loader.go
@@ -815,6 +815,20 @@ func (dr *DefaultReceiver) saveValueAccount(isIH bool, v *accounts.Account, h []
 	return nil
 }
 
+func (fstl *FlatDbSubTrieLoader) retainAcc(prefix []byte) bool {
+	if !fstl.wasIH {
+		return true
+	}
+	return fstl.rl.Retain(prefix)
+}
+
+func (fstl *FlatDbSubTrieLoader) retainStorage(prefix []byte) bool {
+	if !fstl.wasIHStorage {
+		return true
+	}
+	return fstl.rl.Retain(prefix)
+}
+
 // nextSubtree does []byte++. Returns false if overflow.
 func nextSubtree(in []byte) ([]byte, bool) {
 	r := make([]byte, len(in))

--- a/trie/flatdb_sub_trie_loader.go
+++ b/trie/flatdb_sub_trie_loader.go
@@ -106,7 +106,7 @@ func NewFlatDbSubTrieLoader() *FlatDbSubTrieLoader {
 
 // Reset prepares the loader for reuse
 func (fstl *FlatDbSubTrieLoader) Reset(db ethdb.Getter, rl RetainDecider, dbPrefixes [][]byte, fixedbits []int, trace bool) error {
-	fstl.defaultReceiver.Reset(rl, trace)
+	fstl.defaultReceiver.Reset(NewRetainAll(), trace)
 	fstl.receiver = fstl.defaultReceiver
 	fstl.rangeIdx = 0
 
@@ -813,20 +813,6 @@ func (dr *DefaultReceiver) saveValueAccount(isIH bool, v *accounts.Account, h []
 		}
 	}
 	return nil
-}
-
-func (fstl *FlatDbSubTrieLoader) retainAcc(prefix []byte) bool {
-	if !fstl.wasIH {
-		return true
-	}
-	return fstl.rl.Retain(prefix)
-}
-
-func (fstl *FlatDbSubTrieLoader) retainStorage(prefix []byte) bool {
-	if !fstl.wasIHStorage {
-		return true
-	}
-	return fstl.rl.Retain(prefix)
 }
 
 // nextSubtree does []byte++. Returns false if overflow.

--- a/trie/flatdb_sub_trie_loader.go
+++ b/trie/flatdb_sub_trie_loader.go
@@ -613,7 +613,7 @@ func (fstl *FlatDbSubTrieLoader) LoadSubTries() (SubTries, error) {
 			}
 			k, v := iwl.SeekTo(prefix)
 			if !bytes.Equal(k, prefix) {
-				panic(fmt.Sprintf("IH and DataLen buckets must have same keys set: %x, %x", k, prefix))
+				panic(fmt.Sprintf("IH and WitnessLen buckets must have same keys set: %x, %x", k, prefix))
 			}
 			return binary.BigEndian.Uint64(v)
 		}
@@ -718,7 +718,7 @@ func (dr *DefaultReceiver) genStructStorage() error {
 	var data GenStructStepData
 	if dr.wasIHStorage {
 		dr.hashData.Hash = common.BytesToHash(dr.valueStorage.Bytes())
-		dr.hashData.DataLen = dr.witnessLen
+		dr.hashData.WitnessLen = dr.witnessLen
 		data = &dr.hashData
 	} else {
 		dr.leafData.Value = rlphacks.RlpSerializableBytes(dr.valueStorage.Bytes())
@@ -770,7 +770,7 @@ func (dr *DefaultReceiver) genStructAccount() error {
 	var data GenStructStepData
 	if dr.wasIH {
 		copy(dr.hashData.Hash[:], dr.value.Bytes())
-		dr.hashData.DataLen = dr.witnessLen
+		dr.hashData.WitnessLen = dr.witnessLen
 		data = &dr.hashData
 	} else {
 		dr.accData.Balance.Set(&dr.a.Balance)

--- a/trie/flatdb_sub_trie_loader.go
+++ b/trie/flatdb_sub_trie_loader.go
@@ -606,7 +606,7 @@ func (fstl *FlatDbSubTrieLoader) LoadSubTries() (SubTries, error) {
 	if err := fstl.boltDB.View(func(tx *bolt.Tx) error {
 		c := tx.Bucket(dbutils.CurrentStateBucket).Cursor()
 		ih := tx.Bucket(dbutils.IntermediateTrieHashBucket).Cursor()
-		iwl := tx.Bucket(dbutils.IntermediateTrieWitnessLenBucket).Cursor()
+		iwl := tx.Bucket(dbutils.IntermediateWitnessLenBucket).Cursor()
 		fstl.getWitnessLen = func(prefix []byte) uint64 {
 			if !debug.IsTrackWitnessSizeEnabled() {
 				return 0

--- a/trie/flatdb_sub_trie_loader.go
+++ b/trie/flatdb_sub_trie_loader.go
@@ -105,8 +105,8 @@ func NewFlatDbSubTrieLoader() *FlatDbSubTrieLoader {
 }
 
 // Reset prepares the loader for reuse
-func (fstl *FlatDbSubTrieLoader) Reset(db ethdb.Getter, rl RetainDecider, dbPrefixes [][]byte, fixedbits []int, trace bool) error {
-	fstl.defaultReceiver.Reset(NewRetainAll(rl), trace)
+func (fstl *FlatDbSubTrieLoader) Reset(db ethdb.Getter, rl RetainDecider, receiverDecider RetainDecider, dbPrefixes [][]byte, fixedbits []int, trace bool) error {
+	fstl.defaultReceiver.Reset(receiverDecider, trace)
 	fstl.receiver = fstl.defaultReceiver
 	fstl.rangeIdx = 0
 
@@ -294,7 +294,8 @@ func (fstl *FlatDbSubTrieLoader) iteration(c, ih *bolt.Cursor, first bool) error
 			}
 			copy(fstl.accAddrHashWithInc[:], fstl.k)
 			binary.BigEndian.PutUint64(fstl.accAddrHashWithInc[32:], ^fstl.accountValue.Incarnation)
-			// Now we know the correct incarnation of the account, and we can skip all irrelevant storage records
+			// Now we know the correct incarnation of the account, an
+			//d we can skip all irrelevant storage records
 			// Since 0 incarnation if 0xfff...fff, and we do not expect any records like that, this automatically
 			// skips over all storage items
 			fstl.k, fstl.v = c.SeekTo(fstl.accAddrHashWithInc[:])

--- a/trie/flatdb_sub_trie_loader.go
+++ b/trie/flatdb_sub_trie_loader.go
@@ -31,7 +31,7 @@ type StreamReceiver interface {
 		storageValue []byte,
 		hash []byte,
 		cutoff int,
-		witnessLen uint64,
+		witnessSize uint64,
 	) error
 
 	Result() SubTries
@@ -52,9 +52,9 @@ type FlatDbSubTrieLoader struct {
 	ihK, ihV           []byte
 	minKeyAsNibbles    bytes.Buffer
 
-	itemPresent   bool
-	itemType      StreamItem
-	getWitnessLen func(prefix []byte) uint64
+	itemPresent    bool
+	itemType       StreamItem
+	getWitnessSize func(prefix []byte) uint64
 
 	// Storage item buffer
 	storageKeyPart1 []byte
@@ -66,7 +66,7 @@ type FlatDbSubTrieLoader struct {
 	accountValue accounts.Account
 	hashValue    []byte
 	streamCutoff int
-	witnessLen   uint64
+	witnessSize  uint64
 
 	receiver        StreamReceiver
 	defaultReceiver *DefaultReceiver
@@ -90,7 +90,7 @@ type DefaultReceiver struct {
 	a            accounts.Account
 	leafData     GenStructStepLeafData
 	accData      GenStructStepAccountData
-	witnessLen   uint64
+	witnessSize  uint64
 }
 
 func NewDefaultReceiver() *DefaultReceiver {
@@ -356,18 +356,18 @@ func (fstl *FlatDbSubTrieLoader) iteration(c, ih *bolt.Cursor, first bool) error
 		}
 		fstl.hashValue = fstl.ihV
 		fstl.storageValue = nil
-		fstl.witnessLen = fstl.getWitnessLen(fstl.ihK)
+		fstl.witnessSize = fstl.getWitnessSize(fstl.ihK)
 	} else {
 		fstl.itemType = AHashStreamItem
 		fstl.accountKey = fstl.ihK
 		fstl.storageKeyPart1 = nil
 		fstl.storageKeyPart2 = nil
 		fstl.hashValue = fstl.ihV
-		fstl.witnessLen = fstl.getWitnessLen(fstl.ihK)
+		fstl.witnessSize = fstl.getWitnessSize(fstl.ihK)
 	}
 
 	// skip subtree
-	next, ok := nextSubtree(fstl.ihK)
+	next, ok := dbutils.NextSubtree(fstl.ihK)
 	if !ok { // no siblings left
 		if !retain { // last sub-tree was taken from IH, then nothing to look in the main bucket. Can stop.
 			fstl.k = nil
@@ -438,7 +438,7 @@ func (dr *DefaultReceiver) Receive(itemType StreamItem,
 	storageValue []byte,
 	hash []byte,
 	cutoff int,
-	witnessLen uint64,
+	witnessSize uint64,
 ) error {
 	switch itemType {
 	case StorageStreamItem:
@@ -448,7 +448,7 @@ func (dr *DefaultReceiver) Receive(itemType StreamItem,
 				return err
 			}
 		}
-		dr.saveValueStorage(false, storageValue, hash, witnessLen)
+		dr.saveValueStorage(false, storageValue, hash, witnessSize)
 	case SHashStreamItem:
 		dr.advanceKeysStorage(storageKeyPart1, storageKeyPart2, false /* terminator */)
 		if dr.currStorage.Len() > 0 {
@@ -456,7 +456,7 @@ func (dr *DefaultReceiver) Receive(itemType StreamItem,
 				return err
 			}
 		}
-		dr.saveValueStorage(true, storageValue, hash, witnessLen)
+		dr.saveValueStorage(true, storageValue, hash, witnessSize)
 	case AccountStreamItem:
 		dr.advanceKeysAccount(accountKey, true /* terminator */)
 		if dr.curr.Len() > 0 && !dr.wasIH {
@@ -485,7 +485,7 @@ func (dr *DefaultReceiver) Receive(itemType StreamItem,
 				return err
 			}
 		}
-		if err := dr.saveValueAccount(false, accountValue, hash, witnessLen); err != nil {
+		if err := dr.saveValueAccount(false, accountValue, hash, witnessSize); err != nil {
 			return err
 		}
 	case AHashStreamItem:
@@ -516,7 +516,7 @@ func (dr *DefaultReceiver) Receive(itemType StreamItem,
 				return err
 			}
 		}
-		if err := dr.saveValueAccount(true, accountValue, hash, witnessLen); err != nil {
+		if err := dr.saveValueAccount(true, accountValue, hash, witnessSize); err != nil {
 			return err
 		}
 	case CutoffStreamItem:
@@ -606,14 +606,14 @@ func (fstl *FlatDbSubTrieLoader) LoadSubTries() (SubTries, error) {
 	if err := fstl.boltDB.View(func(tx *bolt.Tx) error {
 		c := tx.Bucket(dbutils.CurrentStateBucket).Cursor()
 		ih := tx.Bucket(dbutils.IntermediateTrieHashBucket).Cursor()
-		iwl := tx.Bucket(dbutils.IntermediateWitnessLenBucket).Cursor()
-		fstl.getWitnessLen = func(prefix []byte) uint64 {
+		iwl := tx.Bucket(dbutils.IntermediateWitnessSizeBucket).Cursor()
+		fstl.getWitnessSize = func(prefix []byte) uint64 {
 			if !debug.IsTrackWitnessSizeEnabled() {
 				return 0
 			}
 			k, v := iwl.SeekTo(prefix)
 			if !bytes.Equal(k, prefix) {
-				panic(fmt.Sprintf("IH and WitnessLen buckets must have same keys set: %x, %x", k, prefix))
+				panic(fmt.Sprintf("IH and WitnessSize buckets must have same keys set: %x, %x", k, prefix))
 			}
 			return binary.BigEndian.Uint64(v)
 		}
@@ -627,7 +627,7 @@ func (fstl *FlatDbSubTrieLoader) LoadSubTries() (SubTries, error) {
 				}
 			}
 			if fstl.itemPresent {
-				if err := fstl.receiver.Receive(fstl.itemType, fstl.accountKey, fstl.storageKeyPart1, fstl.storageKeyPart2, &fstl.accountValue, fstl.storageValue, fstl.hashValue, fstl.streamCutoff, fstl.witnessLen); err != nil {
+				if err := fstl.receiver.Receive(fstl.itemType, fstl.accountKey, fstl.storageKeyPart1, fstl.storageKeyPart2, &fstl.accountValue, fstl.storageValue, fstl.hashValue, fstl.streamCutoff, fstl.witnessSize); err != nil {
 					return err
 				}
 				fstl.itemPresent = false
@@ -718,7 +718,7 @@ func (dr *DefaultReceiver) genStructStorage() error {
 	var data GenStructStepData
 	if dr.wasIHStorage {
 		dr.hashData.Hash = common.BytesToHash(dr.valueStorage.Bytes())
-		dr.hashData.WitnessLen = dr.witnessLen
+		dr.hashData.WitnessSize = dr.witnessSize
 		data = &dr.hashData
 	} else {
 		dr.leafData.Value = rlphacks.RlpSerializableBytes(dr.valueStorage.Bytes())
@@ -731,13 +731,13 @@ func (dr *DefaultReceiver) genStructStorage() error {
 	return nil
 }
 
-func (dr *DefaultReceiver) saveValueStorage(isIH bool, v, h []byte, witnessLen uint64) {
+func (dr *DefaultReceiver) saveValueStorage(isIH bool, v, h []byte, witnessSize uint64) {
 	// Remember the current value
 	dr.wasIHStorage = isIH
 	dr.valueStorage.Reset()
 	if isIH {
 		dr.valueStorage.Write(h)
-		dr.witnessLen = witnessLen
+		dr.witnessSize = witnessSize
 	} else {
 		dr.valueStorage.Write(v)
 	}
@@ -770,7 +770,7 @@ func (dr *DefaultReceiver) genStructAccount() error {
 	var data GenStructStepData
 	if dr.wasIH {
 		copy(dr.hashData.Hash[:], dr.value.Bytes())
-		dr.hashData.WitnessLen = dr.witnessLen
+		dr.hashData.WitnessSize = dr.witnessSize
 		data = &dr.hashData
 	} else {
 		dr.accData.Balance.Set(&dr.a.Balance)
@@ -795,12 +795,12 @@ func (dr *DefaultReceiver) genStructAccount() error {
 	return nil
 }
 
-func (dr *DefaultReceiver) saveValueAccount(isIH bool, v *accounts.Account, h []byte, witnessLen uint64) error {
+func (dr *DefaultReceiver) saveValueAccount(isIH bool, v *accounts.Account, h []byte, witnessSize uint64) error {
 	dr.wasIH = isIH
 	if isIH {
 		dr.value.Reset()
 		dr.value.Write(h)
-		dr.witnessLen = witnessLen
+		dr.witnessSize = witnessSize
 		return nil
 	}
 	dr.a.Copy(v)
@@ -813,21 +813,6 @@ func (dr *DefaultReceiver) saveValueAccount(isIH bool, v *accounts.Account, h []
 		}
 	}
 	return nil
-}
-
-// nextSubtree does []byte++. Returns false if overflow.
-func nextSubtree(in []byte) ([]byte, bool) {
-	r := make([]byte, len(in))
-	copy(r, in)
-	for i := len(r) - 1; i >= 0; i-- {
-		if r[i] != 255 {
-			r[i]++
-			return r, true
-		}
-
-		r[i] = 0
-	}
-	return nil, false
 }
 
 func nextAccount(in, out []byte) bool {

--- a/trie/flatdb_sub_trie_loader.go
+++ b/trie/flatdb_sub_trie_loader.go
@@ -106,7 +106,7 @@ func NewFlatDbSubTrieLoader() *FlatDbSubTrieLoader {
 
 // Reset prepares the loader for reuse
 func (fstl *FlatDbSubTrieLoader) Reset(db ethdb.Getter, rl RetainDecider, dbPrefixes [][]byte, fixedbits []int, trace bool) error {
-	fstl.defaultReceiver.Reset(NewRetainAll(), trace)
+	fstl.defaultReceiver.Reset(NewRetainAll(rl), trace)
 	fstl.receiver = fstl.defaultReceiver
 	fstl.rangeIdx = 0
 

--- a/trie/flatdb_sub_trie_loader_test.go
+++ b/trie/flatdb_sub_trie_loader_test.go
@@ -261,7 +261,7 @@ func TestApiDetails(t *testing.T) {
 	putIDataLen := func(k string, v uint64) {
 		lenBytes := make([]byte, 8)
 		binary.BigEndian.PutUint64(lenBytes, v)
-		require.NoError(db.Put(dbutils.IntermediateTrieWitnessLenBucket, common.Hex2Bytes(k), lenBytes))
+		require.NoError(db.Put(dbutils.IntermediateWitnessLenBucket, common.Hex2Bytes(k), lenBytes))
 	}
 
 	// Test attempt handle cases when: Trie root hash is same for Cached and non-Cached SubTrieLoaders

--- a/trie/flatdb_sub_trie_loader_test.go
+++ b/trie/flatdb_sub_trie_loader_test.go
@@ -261,7 +261,7 @@ func TestApiDetails(t *testing.T) {
 	putIDataLen := func(k string, v uint64) {
 		lenBytes := make([]byte, 8)
 		binary.BigEndian.PutUint64(lenBytes, v)
-		require.NoError(db.Put(dbutils.IntermediateWitnessLenBucket, common.Hex2Bytes(k), lenBytes))
+		require.NoError(db.Put(dbutils.IntermediateWitnessSizeBucket, common.Hex2Bytes(k), lenBytes))
 	}
 
 	// Test attempt handle cases when: Trie root hash is same for Cached and non-Cached SubTrieLoaders
@@ -333,8 +333,8 @@ func TestApiDetails(t *testing.T) {
 
 		//fmt.Printf("%x\n", tr.root.(*fullNode).Children[0].(*fullNode).Children[0].reference())
 		//fmt.Printf("%x\n", tr.root.(*fullNode).Children[15].(*fullNode).Children[15].reference())
-		//fmt.Printf("%d\n", tr.root.(*fullNode).Children[0].(*fullNode).Children[0].witnessLen())
-		//fmt.Printf("%d\n", tr.root.(*fullNode).Children[15].(*fullNode).Children[15].witnessLen())
+		//fmt.Printf("%d\n", tr.root.(*fullNode).Children[0].(*fullNode).Children[0].witnessSize())
+		//fmt.Printf("%d\n", tr.root.(*fullNode).Children[15].(*fullNode).Children[15].witnessSize())
 
 		_, found := tr.GetAccount(hexf("000%061x", 0))
 		assert.False(found) // exists in DB but resolved, there is hashNode
@@ -425,10 +425,10 @@ func TestApiDetails(t *testing.T) {
 		err = tr.HookSubTries(subTries, hooks) // hook up to the root
 		assert.NoError(err)
 
-		assert.Equal(uint64(2050), tr.root.witnessLen())
-		assert.Equal(uint64(1024), tr.root.(*fullNode).Children[0].witnessLen())
-		assert.Equal(uint64(254), tr.root.(*fullNode).Children[0].(*fullNode).Children[0].witnessLen())
-		assert.Equal(uint64(256), tr.root.(*fullNode).Children[15].(*fullNode).Children[15].witnessLen())
+		assert.Equal(uint64(2050), tr.root.witnessSize())
+		assert.Equal(uint64(1024), tr.root.(*fullNode).Children[0].witnessSize())
+		assert.Equal(uint64(254), tr.root.(*fullNode).Children[0].(*fullNode).Children[0].witnessSize())
+		assert.Equal(uint64(256), tr.root.(*fullNode).Children[15].(*fullNode).Children[15].witnessSize())
 
 		witness, err := tr.ExtractWitness(false, rs)
 		if err != nil {
@@ -440,7 +440,7 @@ func TestApiDetails(t *testing.T) {
 		if err != nil {
 			panic(err)
 		}
-		fmt.Printf("WitnessLen. Real: %d, Estimate: %d\n", buf.Len(), tr.root.witnessLen())
+		fmt.Printf("WitnessSize. Real: %d, Estimate: %d\n", buf.Len(), tr.root.witnessSize())
 	}
 }
 

--- a/trie/gen_struct_step.go
+++ b/trie/gen_struct_step.go
@@ -67,8 +67,8 @@ type GenStructStepLeafData struct {
 func (GenStructStepLeafData) GenStructStepData() {}
 
 type GenStructStepHashData struct {
-	Hash    common.Hash
-	DataLen uint64
+	Hash       common.Hash
+	WitnessLen uint64
 }
 
 func (GenStructStepHashData) GenStructStepData() {}
@@ -128,7 +128,7 @@ func GenStructStep(
 			switch v := data.(type) {
 			case *GenStructStepHashData:
 				/* building a hash */
-				if err := e.hash(v.Hash[:], v.DataLen); err != nil {
+				if err := e.hash(v.Hash[:], v.WitnessLen); err != nil {
 					return nil, err
 				}
 				buildExtensions = true

--- a/trie/gen_struct_step.go
+++ b/trie/gen_struct_step.go
@@ -67,8 +67,8 @@ type GenStructStepLeafData struct {
 func (GenStructStepLeafData) GenStructStepData() {}
 
 type GenStructStepHashData struct {
-	Hash       common.Hash
-	WitnessLen uint64
+	Hash        common.Hash
+	WitnessSize uint64
 }
 
 func (GenStructStepHashData) GenStructStepData() {}
@@ -128,7 +128,7 @@ func GenStructStep(
 			switch v := data.(type) {
 			case *GenStructStepHashData:
 				/* building a hash */
-				if err := e.hash(v.Hash[:], v.WitnessLen); err != nil {
+				if err := e.hash(v.Hash[:], v.WitnessSize); err != nil {
 					return nil, err
 				}
 				buildExtensions = true

--- a/trie/hashbuilder.go
+++ b/trie/hashbuilder.go
@@ -17,7 +17,7 @@ import (
 )
 
 const hashStackStride = common.HashLength + 1 // + 1 byte for RLP encoding
-const CountWitnessSizeWithoutStructure = false
+const CountWitnessSizeWithoutStructure = true
 
 var EmptyCodeHash = crypto.Keccak256Hash(nil)
 

--- a/trie/hashbuilder.go
+++ b/trie/hashbuilder.go
@@ -17,7 +17,7 @@ import (
 )
 
 const hashStackStride = common.HashLength + 1 // + 1 byte for RLP encoding
-const CountWitnessSizeWithoutStructure = true
+const CountWitnessSizeWithoutStructure = false
 
 var EmptyCodeHash = crypto.Keccak256Hash(nil)
 
@@ -611,7 +611,7 @@ func (hb *HashBuilder) code(code []byte) error {
 	if CountWitnessSizeWithoutStructure {
 		hb.dataLenStack = append(hb.dataLenStack, 0)
 	} else {
-		hb.dataLenStack = append(hb.dataLenStack, 1+uint64(len(code))) // opcode + len(code)
+		hb.dataLenStack = append(hb.dataLenStack, 0)
 	}
 	hb.sha.Reset()
 	if _, err := hb.sha.Write(codeCopy); err != nil {

--- a/trie/node.go
+++ b/trie/node.go
@@ -246,8 +246,9 @@ func (an *accountNode) reference() []byte { return nil }
 // duoNode: opcode + mask + childrenWitnessSize
 // shortNode: opcode + len(key)/2 + childrenWitnessSize
 // accountNode: opcode + account data len + codeWitnessSize + storageWitnessSize
+/*
 func (n hashNode) witnessSize() uint64   { return n.iws }
-func (n valueNode) witnessSize() uint64  { return uint64(len(n)) + 1 }
+func (n valueNode) witnessSize() uint64  { return uint64(len(n)) + 1}
 func (n codeNode) witnessSize() uint64   { return uint64(len(n)) + 1 }
 func (n *fullNode) witnessSize() uint64  { return n.iws }
 func (n *duoNode) witnessSize() uint64   { return n.iws }
@@ -282,6 +283,45 @@ func (n *duoNode) recalculateWitnessSize() {
 }
 func (n *shortNode) recalculateWitnessSize() {
 	n.iws = 1 + 1 + uint64(len(n.Key))/2 + n.Val.witnessSize() // opcode + len(key)/2 + childrenWitnessSize
+}
+*/
+
+func (n hashNode) witnessSize() uint64   { return n.iws }
+func (n valueNode) witnessSize() uint64  { return uint64(len(n)) }
+func (n codeNode) witnessSize() uint64   { return uint64(len(n)) }
+func (n *fullNode) witnessSize() uint64  { return n.iws }
+func (n *duoNode) witnessSize() uint64   { return n.iws }
+func (n *shortNode) witnessSize() uint64 { return n.iws }
+func (an *accountNode) witnessSize() uint64 {
+	res := uint64(an.EncodingLengthForStorage())
+	if an.storage != nil {
+		res += an.storage.witnessSize()
+	}
+	//if an.code != nil {
+	//	res += an.code.witnessSize()
+	//}
+	return res
+}
+
+func (n *fullNode) recalculateWitnessSize() {
+	n.iws = 0
+	for j := range n.Children {
+		if n.Children[j] != nil {
+			n.iws += n.Children[j].witnessSize()
+		}
+	}
+}
+func (n *duoNode) recalculateWitnessSize() {
+	n.iws = 0
+	if n.child1 != nil {
+		n.iws += n.child1.witnessSize()
+	}
+	if n.child2 != nil {
+		n.iws += n.child2.witnessSize()
+	}
+}
+func (n *shortNode) recalculateWitnessSize() {
+	n.iws = 0 + n.Val.witnessSize()
 }
 
 // Pretty printing.

--- a/trie/node.go
+++ b/trie/node.go
@@ -83,11 +83,16 @@ type (
 var nilValueNode = valueNode(nil)
 
 func NewShortNode(key []byte, value node) *shortNode {
-	return &shortNode{
+	s := &shortNode{
 		Key: key,
 		Val: value,
 		iws: 1 + uint64(1)/2 + value.witnessSize(), //opcode + len(key)/2 + childrenWitnessSize
 	}
+	if CountWitnessSizeWithoutStructure {
+		s.iws = value.witnessSize()
+	}
+
+	return s
 }
 
 func EncodeAsValue(data []byte) ([]byte, error) {
@@ -255,7 +260,7 @@ func (n valueNode) witnessSize() uint64 {
 }
 func (n codeNode) witnessSize() uint64 {
 	if CountWitnessSizeWithoutStructure {
-		return uint64(len(n))
+		return 0
 	}
 	return uint64(len(n)) + 1
 }
@@ -275,9 +280,9 @@ func (an *accountNode) witnessSize() uint64 {
 	if an.storage != nil {
 		res += an.storage.witnessSize()
 	}
-	if an.code != nil {
-		res += an.code.witnessSize()
-	}
+	//if an.code != nil {
+	//	res += an.code.witnessSize()
+	//}
 	return res
 }
 

--- a/trie/node.go
+++ b/trie/node.go
@@ -250,7 +250,7 @@ func (an *accountNode) reference() []byte { return nil }
 // fullNode: opcode + mask + childrenWitnessSize
 // duoNode: opcode + mask + childrenWitnessSize
 // shortNode: opcode + len(key)/2 + childrenWitnessSize
-// accountNode: opcode + account data len + codeWitnessSize + storageWitnessSize
+// accountNode: opcode + account data len + storageWitnessSize - could not include codeSize because it's not available yet
 func (n hashNode) witnessSize() uint64 { return n.iws }
 func (n valueNode) witnessSize() uint64 {
 	if CountWitnessSizeWithoutStructure {
@@ -260,6 +260,7 @@ func (n valueNode) witnessSize() uint64 {
 }
 func (n codeNode) witnessSize() uint64 {
 	if CountWitnessSizeWithoutStructure {
+		//return uint64(len(n))
 		return 0
 	}
 	return uint64(len(n)) + 1

--- a/trie/node.go
+++ b/trie/node.go
@@ -36,34 +36,34 @@ type node interface {
 
 	// if not empty, returns node's RLP or hash thereof
 	reference() []byte
-	witnessLen() uint64
+	witnessSize() uint64
 }
 
 type (
 	// DESCRIBED: docs/programmers_guide/guide.md#hexary-radix-patricia-tree
 	fullNode struct {
-		ref           nodeRef
-		Children      [17]node // Actual trie node data to encode/decode (needs custom encoder)
-		witnessLength uint64   // amount of bytes holded in DB by all storage/code under this prefix. equal to sum of children's witnessLength
+		ref      nodeRef
+		Children [17]node // Actual trie node data to encode/decode (needs custom encoder)
+		iws      uint64   // IntermediateWitnessSize - amount of bytes used in DB by all storage/code under this prefix + few bytes for Trie structure encoding. equal to sum of children's iws
 	}
 	// DESCRIBED: docs/programmers_guide/guide.md#hexary-radix-patricia-tree
 	duoNode struct {
-		ref           nodeRef
-		mask          uint32 // Bitmask. The set bits indicate the child is not nil
-		child1        node
-		child2        node
-		witnessLength uint64
+		ref    nodeRef
+		mask   uint32 // Bitmask. The set bits indicate the child is not nil
+		child1 node
+		child2 node
+		iws    uint64
 	}
 	// DESCRIBED: docs/programmers_guide/guide.md#hexary-radix-patricia-tree
 	shortNode struct {
-		ref           nodeRef
-		Key           []byte // HEX encoding
-		Val           node
-		witnessLength uint64
+		ref nodeRef
+		Key []byte // HEX encoding
+		Val node
+		iws uint64
 	}
 	hashNode struct {
-		hash          []byte
-		witnessLength uint64
+		hash []byte
+		iws  uint64
 	}
 	valueNode []byte
 
@@ -84,9 +84,9 @@ var nilValueNode = valueNode(nil)
 
 func NewShortNode(key []byte, value node) *shortNode {
 	return &shortNode{
-		Key:           key,
-		Val:           value,
-		witnessLength: 1 + uint64(1)/2 + value.witnessLen(), //opcode + len(key)/2 + childrenWitnessLen
+		Key: key,
+		Val: value,
+		iws: 1 + uint64(1)/2 + value.witnessSize(), //opcode + len(key)/2 + childrenWitnessSize
 	}
 }
 
@@ -238,50 +238,50 @@ func (n *duoNode) reference() []byte      { return n.ref.data[0:n.ref.len] }
 func (n *shortNode) reference() []byte    { return n.ref.data[0:n.ref.len] }
 func (an *accountNode) reference() []byte { return nil }
 
-// WitnessLen calculation logic:
+// WitnessSize calculation logic:
 // hashNode: represents full underlying witness
 // valueNode: opcode + len(storage)
 // codeNode: opcode + len(code)
-// fullNode: opcode + mask + childrenWitnessLen
-// duoNode: opcode + mask + childrenWitnessLen
-// shortNode: opcode + len(key)/2 + childrenWitnessLen
-// accountNode: opcode + account data len + codeWitnessLen + storageWitnessLen
-func (n hashNode) witnessLen() uint64   { return n.witnessLength }
-func (n valueNode) witnessLen() uint64  { return uint64(len(n)) + 1 }
-func (n codeNode) witnessLen() uint64   { return uint64(len(n)) + 1 }
-func (n *fullNode) witnessLen() uint64  { return n.witnessLength }
-func (n *duoNode) witnessLen() uint64   { return n.witnessLength }
-func (n *shortNode) witnessLen() uint64 { return n.witnessLength }
-func (an *accountNode) witnessLen() uint64 {
+// fullNode: opcode + mask + childrenWitnessSize
+// duoNode: opcode + mask + childrenWitnessSize
+// shortNode: opcode + len(key)/2 + childrenWitnessSize
+// accountNode: opcode + account data len + codeWitnessSize + storageWitnessSize
+func (n hashNode) witnessSize() uint64   { return n.iws }
+func (n valueNode) witnessSize() uint64  { return uint64(len(n)) + 1 }
+func (n codeNode) witnessSize() uint64   { return uint64(len(n)) + 1 }
+func (n *fullNode) witnessSize() uint64  { return n.iws }
+func (n *duoNode) witnessSize() uint64   { return n.iws }
+func (n *shortNode) witnessSize() uint64 { return n.iws }
+func (an *accountNode) witnessSize() uint64 {
 	res := 1 + uint64(an.EncodingLengthForStorage())
 	if an.storage != nil {
-		res += an.storage.witnessLen()
+		res += an.storage.witnessSize()
 	}
 	if an.code != nil {
-		res += an.code.witnessLen()
+		res += an.code.witnessSize()
 	}
 	return res
 }
 
-func (n *fullNode) recalculateWitnessLen() {
-	n.witnessLength = 1 + 1 // opcode + mask + childrenWitnessLen
+func (n *fullNode) recalculateWitnessSize() {
+	n.iws = 1 + 1 // opcode + mask + childrenWitnessSize
 	for j := range n.Children {
 		if n.Children[j] != nil {
-			n.witnessLength += n.Children[j].witnessLen()
+			n.iws += n.Children[j].witnessSize()
 		}
 	}
 }
-func (n *duoNode) recalculateWitnessLen() {
-	n.witnessLength = 1 + 1 // opcode + mask + childrenWitnessLen
+func (n *duoNode) recalculateWitnessSize() {
+	n.iws = 1 + 1 // opcode + mask + childrenWitnessSize
 	if n.child1 != nil {
-		n.witnessLength += n.child1.witnessLen()
+		n.iws += n.child1.witnessSize()
 	}
 	if n.child2 != nil {
-		n.witnessLength += n.child2.witnessLen()
+		n.iws += n.child2.witnessSize()
 	}
 }
-func (n *shortNode) recalculateWitnessLen() {
-	n.witnessLength = 1 + 1 + uint64(len(n.Key))/2 + n.Val.witnessLen() // opcode + len(key)/2 + childrenWitnessLen
+func (n *shortNode) recalculateWitnessSize() {
+	n.iws = 1 + 1 + uint64(len(n.Key))/2 + n.Val.witnessSize() // opcode + len(key)/2 + childrenWitnessSize
 }
 
 // Pretty printing.

--- a/trie/node.go
+++ b/trie/node.go
@@ -246,14 +246,31 @@ func (an *accountNode) reference() []byte { return nil }
 // duoNode: opcode + mask + childrenWitnessSize
 // shortNode: opcode + len(key)/2 + childrenWitnessSize
 // accountNode: opcode + account data len + codeWitnessSize + storageWitnessSize
-/*
-func (n hashNode) witnessSize() uint64   { return n.iws }
-func (n valueNode) witnessSize() uint64  { return uint64(len(n)) + 1}
-func (n codeNode) witnessSize() uint64   { return uint64(len(n)) + 1 }
+func (n hashNode) witnessSize() uint64 { return n.iws }
+func (n valueNode) witnessSize() uint64 {
+	if CountWitnessSizeWithoutStructure {
+		return uint64(len(n))
+	}
+	return uint64(len(n)) + 1
+}
+func (n codeNode) witnessSize() uint64 {
+	if CountWitnessSizeWithoutStructure {
+		return uint64(len(n))
+	}
+	return uint64(len(n)) + 1
+}
 func (n *fullNode) witnessSize() uint64  { return n.iws }
 func (n *duoNode) witnessSize() uint64   { return n.iws }
 func (n *shortNode) witnessSize() uint64 { return n.iws }
 func (an *accountNode) witnessSize() uint64 {
+	if CountWitnessSizeWithoutStructure {
+		res := uint64(an.EncodingLengthForStorage())
+		if an.storage != nil {
+			res += an.storage.witnessSize()
+		}
+		return res
+	}
+
 	res := 1 + uint64(an.EncodingLengthForStorage())
 	if an.storage != nil {
 		res += an.storage.witnessSize()
@@ -265,6 +282,15 @@ func (an *accountNode) witnessSize() uint64 {
 }
 
 func (n *fullNode) recalculateWitnessSize() {
+	if CountWitnessSizeWithoutStructure {
+		n.iws = 0
+		for j := range n.Children {
+			if n.Children[j] != nil {
+				n.iws += n.Children[j].witnessSize()
+			}
+		}
+		return
+	}
 	n.iws = 1 + 1 // opcode + mask + childrenWitnessSize
 	for j := range n.Children {
 		if n.Children[j] != nil {
@@ -273,6 +299,17 @@ func (n *fullNode) recalculateWitnessSize() {
 	}
 }
 func (n *duoNode) recalculateWitnessSize() {
+	if CountWitnessSizeWithoutStructure {
+		n.iws = 0
+		if n.child1 != nil {
+			n.iws += n.child1.witnessSize()
+		}
+		if n.child2 != nil {
+			n.iws += n.child2.witnessSize()
+		}
+		return
+	}
+
 	n.iws = 1 + 1 // opcode + mask + childrenWitnessSize
 	if n.child1 != nil {
 		n.iws += n.child1.witnessSize()
@@ -282,46 +319,12 @@ func (n *duoNode) recalculateWitnessSize() {
 	}
 }
 func (n *shortNode) recalculateWitnessSize() {
+	if CountWitnessSizeWithoutStructure {
+		n.iws = n.Val.witnessSize()
+		return
+	}
+
 	n.iws = 1 + 1 + uint64(len(n.Key))/2 + n.Val.witnessSize() // opcode + len(key)/2 + childrenWitnessSize
-}
-*/
-
-func (n hashNode) witnessSize() uint64   { return n.iws }
-func (n valueNode) witnessSize() uint64  { return uint64(len(n)) }
-func (n codeNode) witnessSize() uint64   { return uint64(len(n)) }
-func (n *fullNode) witnessSize() uint64  { return n.iws }
-func (n *duoNode) witnessSize() uint64   { return n.iws }
-func (n *shortNode) witnessSize() uint64 { return n.iws }
-func (an *accountNode) witnessSize() uint64 {
-	res := uint64(an.EncodingLengthForStorage())
-	if an.storage != nil {
-		res += an.storage.witnessSize()
-	}
-	//if an.code != nil {
-	//	res += an.code.witnessSize()
-	//}
-	return res
-}
-
-func (n *fullNode) recalculateWitnessSize() {
-	n.iws = 0
-	for j := range n.Children {
-		if n.Children[j] != nil {
-			n.iws += n.Children[j].witnessSize()
-		}
-	}
-}
-func (n *duoNode) recalculateWitnessSize() {
-	n.iws = 0
-	if n.child1 != nil {
-		n.iws += n.child1.witnessSize()
-	}
-	if n.child2 != nil {
-		n.iws += n.child2.witnessSize()
-	}
-}
-func (n *shortNode) recalculateWitnessSize() {
-	n.iws = 0 + n.Val.witnessSize()
 }
 
 // Pretty printing.

--- a/trie/retain_list.go
+++ b/trie/retain_list.go
@@ -191,17 +191,13 @@ type RetainAll struct {
 	decider     RetainDecider
 }
 
-// NewRetainRange creates new NewRetainRange
+// NewRetainAll creates new NewRetainRange
 // to=nil - means no upper bound
 func NewRetainAll(decider RetainDecider) *RetainAll {
 	return &RetainAll{decider: decider, codeTouches: make(map[common.Hash]struct{})}
 }
 
 func (rr *RetainAll) Retain(prefix []byte) (retain bool) {
-	if len(prefix) > 128 {
-		return rr.decider.Retain(prefix)
-	}
-
 	return true
 }
 
@@ -216,5 +212,40 @@ func (rr *RetainAll) IsCodeTouched(codeHash common.Hash) bool {
 }
 
 func (rr *RetainAll) String() string {
+	return ""
+}
+
+// RetainLevels - returns true to any prefix shorter than `levels`
+type RetainLevels struct {
+	codeTouches map[common.Hash]struct{}
+	decider     RetainDecider
+	levels      int
+}
+
+// NewRetainLevels creates new NewRetainRange
+// to=nil - means no upper bound
+func NewRetainLevels(decider RetainDecider, levels int) *RetainLevels {
+	return &RetainLevels{decider: decider, codeTouches: make(map[common.Hash]struct{}), levels: levels}
+}
+
+func (rr *RetainLevels) Retain(prefix []byte) (retain bool) {
+	if len(prefix) > rr.levels {
+		return rr.decider.Retain(prefix)
+	}
+
+	return true
+}
+
+// AddCodeTouch adds a new code touch into the resolve set
+func (rr *RetainLevels) AddCodeTouch(codeHash common.Hash) {
+	rr.codeTouches[codeHash] = struct{}{}
+}
+
+func (rr *RetainLevels) IsCodeTouched(codeHash common.Hash) bool {
+	_, ok := rr.codeTouches[codeHash]
+	return ok
+}
+
+func (rr *RetainLevels) String() string {
 	return ""
 }

--- a/trie/retain_list.go
+++ b/trie/retain_list.go
@@ -188,15 +188,20 @@ func (rr *RetainRange) String() string {
 // RetainAll - returns true to any prefix
 type RetainAll struct {
 	codeTouches map[common.Hash]struct{}
+	decider     RetainDecider
 }
 
 // NewRetainRange creates new NewRetainRange
 // to=nil - means no upper bound
-func NewRetainAll() *RetainAll {
-	return &RetainAll{codeTouches: make(map[common.Hash]struct{})}
+func NewRetainAll(decider RetainDecider) *RetainAll {
+	return &RetainAll{decider: decider, codeTouches: make(map[common.Hash]struct{})}
 }
 
 func (rr *RetainAll) Retain(prefix []byte) (retain bool) {
+	if len(prefix) > 4 {
+		return rr.decider.Retain(prefix)
+	}
+
 	return true
 }
 

--- a/trie/retain_list.go
+++ b/trie/retain_list.go
@@ -185,3 +185,31 @@ func (rr *RetainRange) String() string {
 	return fmt.Sprintf("%x-%x", rr.from, rr.to)
 }
 
+// RetainAll - returns true to any prefix
+type RetainAll struct {
+	codeTouches map[common.Hash]struct{}
+}
+
+// NewRetainRange creates new NewRetainRange
+// to=nil - means no upper bound
+func NewRetainAll() *RetainAll {
+	return &RetainAll{codeTouches: make(map[common.Hash]struct{})}
+}
+
+func (rr *RetainAll) Retain(prefix []byte) (retain bool) {
+	return true
+}
+
+// AddCodeTouch adds a new code touch into the resolve set
+func (rr *RetainAll) AddCodeTouch(codeHash common.Hash) {
+	rr.codeTouches[codeHash] = struct{}{}
+}
+
+func (rr *RetainAll) IsCodeTouched(codeHash common.Hash) bool {
+	_, ok := rr.codeTouches[codeHash]
+	return ok
+}
+
+func (rr *RetainAll) String() string {
+	return ""
+}

--- a/trie/retain_list.go
+++ b/trie/retain_list.go
@@ -198,7 +198,7 @@ func NewRetainAll(decider RetainDecider) *RetainAll {
 }
 
 func (rr *RetainAll) Retain(prefix []byte) (retain bool) {
-	if len(prefix) > 4 {
+	if len(prefix) > 128 {
 		return rr.decider.Retain(prefix)
 	}
 

--- a/trie/stream.go
+++ b/trie/stream.go
@@ -160,7 +160,7 @@ func (it *Iterator) Next() (itemType StreamItem, hex1 []byte, aValue *accounts.A
 				fmt.Printf("valueNode %x\n", hex)
 			}
 			it.top--
-			return StorageStreamItem, hex, nil, nil, n, n.witnessLen()
+			return StorageStreamItem, hex, nil, nil, n, n.witnessSize()
 		case *shortNode:
 			if it.trace {
 				fmt.Printf("shortNode %x\n", hex)
@@ -170,12 +170,12 @@ func (it *Iterator) Next() (itemType StreamItem, hex1 []byte, aValue *accounts.A
 			case hashNode:
 				it.top--
 				if accounts {
-					return AHashStreamItem, hex, nil, v.hash, nil, v.witnessLength
+					return AHashStreamItem, hex, nil, v.hash, nil, v.witnessSize()
 				}
-				return SHashStreamItem, hex, nil, v.hash, nil, v.witnessLength
+				return SHashStreamItem, hex, nil, v.hash, nil, v.witnessSize()
 			case valueNode:
 				it.top--
-				return StorageStreamItem, hex, nil, nil, v, v.witnessLen()
+				return StorageStreamItem, hex, nil, nil, v, v.witnessSize()
 			case *accountNode:
 				if it.trace {
 					fmt.Printf("accountNode %x\n", hex)
@@ -190,7 +190,7 @@ func (it *Iterator) Next() (itemType StreamItem, hex1 []byte, aValue *accounts.A
 				} else {
 					it.top--
 				}
-				return AccountStreamItem, hex, &v.Account, nil, nil, v.witnessLen()
+				return AccountStreamItem, hex, &v.Account, nil, nil, v.witnessSize()
 			}
 			it.hex = hex
 			it.nodeStack[l] = n.Val
@@ -205,9 +205,9 @@ func (it *Iterator) Next() (itemType StreamItem, hex1 []byte, aValue *accounts.A
 			if !goDeep {
 				it.top--
 				if accounts {
-					return AHashStreamItem, hex, nil, n.reference(), nil, n.witnessLen()
+					return AHashStreamItem, hex, nil, n.reference(), nil, n.witnessSize()
 				}
-				return SHashStreamItem, hex, nil, n.reference(), nil, n.witnessLen()
+				return SHashStreamItem, hex, nil, n.reference(), nil, n.witnessSize()
 			}
 			i1, i2 := n.childrenIdx()
 			index := it.iStack[l]
@@ -218,24 +218,24 @@ func (it *Iterator) Next() (itemType StreamItem, hex1 []byte, aValue *accounts.A
 				switch v := n.child1.(type) {
 				case hashNode:
 					if accounts {
-						return AHashStreamItem, hex, nil, v.hash, nil, v.witnessLength
+						return AHashStreamItem, hex, nil, v.hash, nil, v.witnessSize()
 					}
-					return SHashStreamItem, hex, nil, v.hash, nil, v.witnessLength
+					return SHashStreamItem, hex, nil, v.hash, nil, v.witnessSize()
 				case *duoNode:
 					childGoDeep = it.rl.Retain(hex)
 					if !childGoDeep {
 						if accounts {
-							return AHashStreamItem, hex, nil, v.reference(), nil, v.witnessLength
+							return AHashStreamItem, hex, nil, v.reference(), nil, v.witnessSize()
 						}
-						return SHashStreamItem, hex, nil, v.reference(), nil, v.witnessLength
+						return SHashStreamItem, hex, nil, v.reference(), nil, v.witnessSize()
 					}
 				case *fullNode:
 					childGoDeep = it.rl.Retain(hex)
 					if !childGoDeep {
 						if accounts {
-							return AHashStreamItem, hex, nil, v.reference(), nil, v.witnessLength
+							return AHashStreamItem, hex, nil, v.reference(), nil, v.witnessSize()
 						}
-						return SHashStreamItem, hex, nil, v.reference(), nil, v.witnessLength
+						return SHashStreamItem, hex, nil, v.reference(), nil, v.witnessSize()
 					}
 				}
 				it.hex = hex
@@ -261,26 +261,26 @@ func (it *Iterator) Next() (itemType StreamItem, hex1 []byte, aValue *accounts.A
 				case hashNode:
 					it.top--
 					if accounts {
-						return AHashStreamItem, hex, nil, v.hash, nil, v.witnessLength
+						return AHashStreamItem, hex, nil, v.hash, nil, v.witnessSize()
 					}
-					return SHashStreamItem, hex, nil, v.hash, nil, v.witnessLength
+					return SHashStreamItem, hex, nil, v.hash, nil, v.witnessSize()
 				case *duoNode:
 					childGoDeep = it.rl.Retain(hex)
 					if !childGoDeep {
 						it.top--
 						if accounts {
-							return AHashStreamItem, hex, nil, v.reference(), nil, v.witnessLength
+							return AHashStreamItem, hex, nil, v.reference(), nil, v.witnessSize()
 						}
-						return SHashStreamItem, hex, nil, v.reference(), nil, v.witnessLength
+						return SHashStreamItem, hex, nil, v.reference(), nil, v.witnessSize()
 					}
 				case *fullNode:
 					childGoDeep = it.rl.Retain(hex)
 					if !childGoDeep {
 						it.top--
 						if accounts {
-							return AHashStreamItem, hex, nil, v.reference(), nil, v.witnessLength
+							return AHashStreamItem, hex, nil, v.reference(), nil, v.witnessSize()
 						}
-						return SHashStreamItem, hex, nil, v.reference(), nil, v.witnessLength
+						return SHashStreamItem, hex, nil, v.reference(), nil, v.witnessSize()
 					}
 				}
 				it.hex = hex
@@ -297,9 +297,9 @@ func (it *Iterator) Next() (itemType StreamItem, hex1 []byte, aValue *accounts.A
 			if !goDeep {
 				it.top--
 				if accounts {
-					return AHashStreamItem, hex, nil, n.reference(), nil, n.witnessLength
+					return AHashStreamItem, hex, nil, n.reference(), nil, n.witnessSize()
 				}
-				return SHashStreamItem, hex, nil, n.reference(), nil, n.witnessLength
+				return SHashStreamItem, hex, nil, n.reference(), nil, n.witnessSize()
 			}
 			var i1, i2 int
 			i1Found := false
@@ -324,24 +324,24 @@ func (it *Iterator) Next() (itemType StreamItem, hex1 []byte, aValue *accounts.A
 				switch v := n.Children[i1].(type) {
 				case hashNode:
 					if accounts {
-						return AHashStreamItem, hex, nil, v.hash, nil, v.witnessLength
+						return AHashStreamItem, hex, nil, v.hash, nil, v.witnessSize()
 					}
-					return SHashStreamItem, hex, nil, v.hash, nil, v.witnessLength
+					return SHashStreamItem, hex, nil, v.hash, nil, v.witnessSize()
 				case *duoNode:
 					childGoDeep = it.rl.Retain(hex)
 					if !childGoDeep {
 						if accounts {
-							return AHashStreamItem, hex, nil, v.reference(), nil, v.witnessLength
+							return AHashStreamItem, hex, nil, v.reference(), nil, v.witnessSize()
 						}
-						return SHashStreamItem, hex, nil, v.reference(), nil, v.witnessLength
+						return SHashStreamItem, hex, nil, v.reference(), nil, v.witnessSize()
 					}
 				case *fullNode:
 					childGoDeep = it.rl.Retain(hex)
 					if !childGoDeep {
 						if accounts {
-							return AHashStreamItem, hex, nil, v.reference(), nil, v.witnessLength
+							return AHashStreamItem, hex, nil, v.reference(), nil, v.witnessSize()
 						}
-						return SHashStreamItem, hex, nil, v.reference(), nil, v.witnessLength
+						return SHashStreamItem, hex, nil, v.reference(), nil, v.witnessSize()
 					}
 				}
 				it.hex = hex
@@ -367,26 +367,26 @@ func (it *Iterator) Next() (itemType StreamItem, hex1 []byte, aValue *accounts.A
 				case hashNode:
 					it.top--
 					if accounts {
-						return AHashStreamItem, hex, nil, v.hash, nil, v.witnessLength
+						return AHashStreamItem, hex, nil, v.hash, nil, v.witnessSize()
 					}
-					return SHashStreamItem, hex, nil, v.hash, nil, v.witnessLength
+					return SHashStreamItem, hex, nil, v.hash, nil, v.witnessSize()
 				case *duoNode:
 					childGoDeep = it.rl.Retain(hex)
 					if !childGoDeep {
 						it.top--
 						if accounts {
-							return AHashStreamItem, hex, nil, v.reference(), nil, v.witnessLength
+							return AHashStreamItem, hex, nil, v.reference(), nil, v.witnessSize()
 						}
-						return SHashStreamItem, hex, nil, v.reference(), nil, v.witnessLength
+						return SHashStreamItem, hex, nil, v.reference(), nil, v.witnessSize()
 					}
 				case *fullNode:
 					childGoDeep = it.rl.Retain(hex)
 					if !childGoDeep {
 						it.top--
 						if accounts {
-							return AHashStreamItem, hex, nil, v.reference(), nil, v.witnessLength
+							return AHashStreamItem, hex, nil, v.reference(), nil, v.witnessSize()
 						}
-						return SHashStreamItem, hex, nil, v.reference(), nil, v.witnessLength
+						return SHashStreamItem, hex, nil, v.reference(), nil, v.witnessSize()
 					}
 				}
 				it.hex = hex
@@ -410,16 +410,16 @@ func (it *Iterator) Next() (itemType StreamItem, hex1 []byte, aValue *accounts.A
 			} else {
 				it.top--
 			}
-			return AccountStreamItem, hex, &n.Account, nil, nil, n.witnessLen()
+			return AccountStreamItem, hex, &n.Account, nil, nil, n.witnessSize()
 		case hashNode:
 			if it.trace {
 				fmt.Printf("hashNode %x\n", hex)
 			}
 			it.top--
 			if accounts {
-				return AHashStreamItem, hex, nil, n.hash, nil, n.witnessLength
+				return AHashStreamItem, hex, nil, n.hash, nil, n.witnessSize()
 			}
-			return SHashStreamItem, hex, nil, n.hash, nil, n.witnessLength
+			return SHashStreamItem, hex, nil, n.hash, nil, n.witnessSize()
 		default:
 			panic(fmt.Errorf("unexpected node: %T", nd))
 		}
@@ -428,21 +428,21 @@ func (it *Iterator) Next() (itemType StreamItem, hex1 []byte, aValue *accounts.A
 
 // StreamMergeIterator merges an Iterator and a Stream
 type StreamMergeIterator struct {
-	it            *Iterator
-	s             *Stream
-	trace         bool
-	ki, ai, si    int
-	offset        int
-	hex           []byte
-	itemType      StreamItem
-	oldItemType   StreamItem
-	oldHex        []byte
-	oldHexCopy    []byte
-	oldAVal       *accounts.Account
-	oldHash       []byte
-	oldHashCopy   []byte
-	oldVal        []byte
-	oldWitnessLen uint64
+	it             *Iterator
+	s              *Stream
+	trace          bool
+	ki, ai, si     int
+	offset         int
+	hex            []byte
+	itemType       StreamItem
+	oldItemType    StreamItem
+	oldHex         []byte
+	oldHexCopy     []byte
+	oldAVal        *accounts.Account
+	oldHash        []byte
+	oldHashCopy    []byte
+	oldVal         []byte
+	oldWitnessSize uint64
 }
 
 // NewStreamMergeIterator create a brand new StreamMergeIterator
@@ -452,7 +452,7 @@ func NewStreamMergeIterator(it *Iterator, s *Stream, trace bool) *StreamMergeIte
 		s:     s,
 		trace: trace,
 	}
-	smi.oldItemType, smi.oldHex, smi.oldAVal, smi.oldHash, smi.oldVal, smi.oldWitnessLen = it.Next()
+	smi.oldItemType, smi.oldHex, smi.oldAVal, smi.oldHash, smi.oldVal, smi.oldWitnessSize = it.Next()
 	return smi
 }
 
@@ -465,11 +465,11 @@ func (smi *StreamMergeIterator) Reset(it *Iterator, s *Stream, trace bool) {
 	smi.ai = 0
 	smi.si = 0
 	smi.offset = 0
-	smi.oldItemType, smi.oldHex, smi.oldAVal, smi.oldHash, smi.oldVal, smi.oldWitnessLen = it.Next()
+	smi.oldItemType, smi.oldHex, smi.oldAVal, smi.oldHash, smi.oldVal, smi.oldWitnessSize = it.Next()
 }
 
 // Next returns the next item in the merged iterator
-func (smi *StreamMergeIterator) Next() (itemType1 StreamItem, hex1 []byte, aValue *accounts.Account, aCode []byte, hash []byte, value []byte, witnessLen uint64) {
+func (smi *StreamMergeIterator) Next() (itemType1 StreamItem, hex1 []byte, aValue *accounts.Account, aCode []byte, hash []byte, value []byte, witnessSize uint64) {
 	for {
 		if smi.trace {
 			fmt.Printf("smi.hex %x, smi.ki %d, len(smi.s.keySizes) %d, smi.oldItemType %d smi.oldHex %x\n", smi.hex, smi.ki, len(smi.s.keySizes), smi.oldItemType, smi.oldHex)
@@ -515,13 +515,13 @@ func (smi *StreamMergeIterator) Next() (itemType1 StreamItem, hex1 []byte, aValu
 			}
 			smi.oldHashCopy = append(smi.oldHashCopy, smi.oldHash...)
 			oldVal := smi.oldVal
-			oldWitnessLen := smi.oldWitnessLen
-			smi.oldItemType, smi.oldHex, smi.oldAVal, smi.oldHash, smi.oldVal, smi.oldWitnessLen = smi.it.Next()
-			return oldItemType, smi.oldHexCopy, oldAVal, nil, smi.oldHashCopy, oldVal, oldWitnessLen
+			oldWitnessSize := smi.oldWitnessSize
+			smi.oldItemType, smi.oldHex, smi.oldAVal, smi.oldHash, smi.oldVal, smi.oldWitnessSize = smi.it.Next()
+			return oldItemType, smi.oldHexCopy, oldAVal, nil, smi.oldHashCopy, oldVal, oldWitnessSize
 		} else {
 			// Special case - account gets deleted
 			if smi.itemType == AccountStreamItem && smi.s.aValues[smi.ai] == nil && bytes.HasPrefix(smi.oldHex, hex) {
-				smi.oldItemType, smi.oldHex, smi.oldAVal, smi.oldHash, smi.oldVal, smi.oldWitnessLen = smi.it.Next()
+				smi.oldItemType, smi.oldHex, smi.oldAVal, smi.oldHash, smi.oldVal, smi.oldWitnessSize = smi.it.Next()
 			} else {
 				switch bytes.Compare(smi.oldHex, hex) {
 				case -1:
@@ -536,9 +536,9 @@ func (smi *StreamMergeIterator) Next() (itemType1 StreamItem, hex1 []byte, aValu
 					}
 					smi.oldHashCopy = append(smi.oldHashCopy, smi.oldHash...)
 					oldVal := smi.oldVal
-					oldWitnessLen := smi.oldWitnessLen
-					smi.oldItemType, smi.oldHex, smi.oldAVal, smi.oldHash, smi.oldVal, smi.oldWitnessLen = smi.it.Next()
-					return oldItemType, smi.oldHexCopy, oldAVal, nil, smi.oldHashCopy, oldVal, oldWitnessLen
+					oldWitnessSize := smi.oldWitnessSize
+					smi.oldItemType, smi.oldHex, smi.oldAVal, smi.oldHash, smi.oldVal, smi.oldWitnessSize = smi.it.Next()
+					return oldItemType, smi.oldHexCopy, oldAVal, nil, smi.oldHashCopy, oldVal, oldWitnessSize
 				case 1:
 					smi.hex = nil // To be consumed
 					switch smi.itemType {
@@ -559,7 +559,7 @@ func (smi *StreamMergeIterator) Next() (itemType1 StreamItem, hex1 []byte, aValu
 					}
 				case 0:
 					smi.hex = nil // To be consumed
-					smi.oldItemType, smi.oldHex, smi.oldAVal, smi.oldHash, smi.oldVal, smi.oldWitnessLen = smi.it.Next()
+					smi.oldItemType, smi.oldHex, smi.oldAVal, smi.oldHash, smi.oldVal, smi.oldWitnessSize = smi.it.Next()
 					switch smi.itemType {
 					case AccountStreamItem:
 						ai := smi.ai
@@ -594,7 +594,7 @@ func StreamHash(it *StreamMergeIterator, storagePrefixLen int, hb *HashBuilder, 
 	var hashRef []byte
 	var hashRefStorage []byte
 	var groups, sGroups []uint16 // Separate groups slices for storage items and for accounts
-	var witnessLenAcc, witnessLenStorage uint64
+	var witnessSizeAcc, witnessSizeStorage uint64
 	var aRoot common.Hash
 	var aEmptyRoot = true
 	var isAccount bool
@@ -608,10 +608,10 @@ func StreamHash(it *StreamMergeIterator, storagePrefixLen int, hb *HashBuilder, 
 	curr.Reset()
 	currStorage.Reset()
 
-	makeData := func(fieldSet uint32, hashRef []byte, witnessLen uint64) GenStructStepData {
+	makeData := func(fieldSet uint32, hashRef []byte, witnessSize uint64) GenStructStepData {
 		if hashRef != nil {
 			copy(hashData.Hash[:], hashRef)
-			hashData.WitnessLen = witnessLen
+			hashData.WitnessSize = witnessSize
 			return &hashData
 		} else if !isAccount {
 			leafData.Value = rlphacks.RlpSerializableBytes(value.Bytes())
@@ -623,7 +623,7 @@ func StreamHash(it *StreamMergeIterator, storagePrefixLen int, hb *HashBuilder, 
 	}
 
 	retain := func(_ []byte) bool { return trace }
-	for newItemType, hex, aVal, aCode, hash, val, witnessLen := it.Next(); newItemType != NoItem; newItemType, hex, aVal, aCode, hash, val, witnessLen = it.Next() {
+	for newItemType, hex, aVal, aCode, hash, val, witnessSize := it.Next(); newItemType != NoItem; newItemType, hex, aVal, aCode, hash, val, witnessSize = it.Next() {
 		if newItemType == AccountStreamItem || newItemType == AHashStreamItem {
 			// If there was an open storage "sub-stream", close it and set the storage flag on
 			if succStorage.Len() > 0 {
@@ -633,7 +633,7 @@ func StreamHash(it *StreamMergeIterator, storagePrefixLen int, hb *HashBuilder, 
 				if currStorage.Len() > 0 {
 					isAccount = false
 					var err error
-					sGroups, err = GenStructStep(retain, currStorage.Bytes(), succStorage.Bytes(), hb, makeData(0, hashRefStorage, witnessLenStorage), sGroups, trace)
+					sGroups, err = GenStructStep(retain, currStorage.Bytes(), succStorage.Bytes(), hb, makeData(0, hashRefStorage, witnessSizeStorage), sGroups, trace)
 					if err != nil {
 						return common.Hash{}, err
 					}
@@ -641,7 +641,7 @@ func StreamHash(it *StreamMergeIterator, storagePrefixLen int, hb *HashBuilder, 
 					fieldSet += AccountFieldStorageOnly
 				}
 			} else if itemType == AccountStreamItem && !aEmptyRoot {
-				if err := hb.hash(aRoot[:], witnessLen); err != nil {
+				if err := hb.hash(aRoot[:], witnessSize); err != nil {
 					return common.Hash{}, err
 				}
 				fieldSet += AccountFieldStorageOnly
@@ -653,13 +653,13 @@ func StreamHash(it *StreamMergeIterator, storagePrefixLen int, hb *HashBuilder, 
 			if curr.Len() > 0 {
 				isAccount = true
 				var err error
-				groups, err = GenStructStep(retain, curr.Bytes(), succ.Bytes(), hb, makeData(fieldSet, hashRef, witnessLenAcc), groups, trace)
+				groups, err = GenStructStep(retain, curr.Bytes(), succ.Bytes(), hb, makeData(fieldSet, hashRef, witnessSizeAcc), groups, trace)
 				if err != nil {
 					return common.Hash{}, err
 				}
 			}
 			itemType = newItemType
-			witnessLenAcc = witnessLen
+			witnessSizeAcc = witnessSize
 			switch itemType {
 			case AccountStreamItem:
 				var a *accounts.Account = aVal
@@ -699,13 +699,13 @@ func StreamHash(it *StreamMergeIterator, storagePrefixLen int, hb *HashBuilder, 
 			if currStorage.Len() > 0 {
 				isAccount = false
 				var err error
-				sGroups, err = GenStructStep(retain, currStorage.Bytes(), succStorage.Bytes(), hb, makeData(0, hashRefStorage, witnessLenStorage), sGroups, trace)
+				sGroups, err = GenStructStep(retain, currStorage.Bytes(), succStorage.Bytes(), hb, makeData(0, hashRefStorage, witnessSizeStorage), sGroups, trace)
 				if err != nil {
 					return common.Hash{}, err
 				}
 			}
 			sItemType = newItemType
-			witnessLenStorage = witnessLen
+			witnessSizeStorage = witnessSize
 			switch sItemType {
 			case StorageStreamItem:
 				value.Reset()
@@ -725,7 +725,7 @@ func StreamHash(it *StreamMergeIterator, storagePrefixLen int, hb *HashBuilder, 
 		if currStorage.Len() > 0 {
 			isAccount = false
 			var err error
-			_, err = GenStructStep(retain, currStorage.Bytes(), succStorage.Bytes(), hb, makeData(0, hashRefStorage, witnessLenStorage), sGroups, trace)
+			_, err = GenStructStep(retain, currStorage.Bytes(), succStorage.Bytes(), hb, makeData(0, hashRefStorage, witnessSizeStorage), sGroups, trace)
 			if err != nil {
 				return common.Hash{}, err
 			}
@@ -733,7 +733,7 @@ func StreamHash(it *StreamMergeIterator, storagePrefixLen int, hb *HashBuilder, 
 			fieldSet |= AccountFieldStorageOnly
 		}
 	} else if itemType == AccountStreamItem && !aEmptyRoot {
-		if err := hb.hash(aRoot[:], witnessLenAcc); err != nil {
+		if err := hb.hash(aRoot[:], witnessSizeAcc); err != nil {
 			return common.Hash{}, err
 		}
 		fieldSet |= AccountFieldStorageOnly
@@ -744,7 +744,7 @@ func StreamHash(it *StreamMergeIterator, storagePrefixLen int, hb *HashBuilder, 
 	if curr.Len() > 0 {
 		isAccount = true
 		var err error
-		_, err = GenStructStep(retain, curr.Bytes(), succ.Bytes(), hb, makeData(fieldSet, hashRef, witnessLenAcc), groups, trace)
+		_, err = GenStructStep(retain, curr.Bytes(), succ.Bytes(), hb, makeData(fieldSet, hashRef, witnessSizeAcc), groups, trace)
 		if err != nil {
 			return common.Hash{}, err
 		}

--- a/trie/sub_trie_loader.go
+++ b/trie/sub_trie_loader.go
@@ -61,7 +61,7 @@ func (stl *SubTrieLoader) LoadSubTries(db ethdb.Database, blockNr uint64, rl Ret
 
 func (stl *SubTrieLoader) LoadFromFlatDB(db ethdb.Getter, rl RetainDecider, dbPrefixes [][]byte, fixedbits []int, trace bool) (SubTries, error) {
 	loader := NewFlatDbSubTrieLoader()
-	if err1 := loader.Reset(db, rl, dbPrefixes, fixedbits, trace); err1 != nil {
+	if err1 := loader.Reset(db, rl, NewRetainLevels(rl, 5), dbPrefixes, fixedbits, trace); err1 != nil {
 		return SubTries{}, err1
 	}
 	subTries, err := loader.LoadSubTries()

--- a/trie/sub_trie_loader.go
+++ b/trie/sub_trie_loader.go
@@ -61,7 +61,7 @@ func (stl *SubTrieLoader) LoadSubTries(db ethdb.Database, blockNr uint64, rl Ret
 
 func (stl *SubTrieLoader) LoadFromFlatDB(db ethdb.Getter, rl RetainDecider, dbPrefixes [][]byte, fixedbits []int, trace bool) (SubTries, error) {
 	loader := NewFlatDbSubTrieLoader()
-	if err1 := loader.Reset(db, rl, NewRetainLevels(rl, 5), dbPrefixes, fixedbits, trace); err1 != nil {
+	if err1 := loader.Reset(db, rl, rl, dbPrefixes, fixedbits, trace); err1 != nil {
 		return SubTries{}, err1
 	}
 	subTries, err := loader.LoadSubTries()

--- a/trie/trie.go
+++ b/trie/trie.go
@@ -1260,10 +1260,10 @@ func (t *Trie) EvictNode(hex []byte) {
 }
 
 func (t *Trie) notifyUnloadRecursive(hex []byte, incarnation uint64, nd node) {
-	const (
-		dbPageSize          = 4096            // common OS page size is 4KB
-		minNodeSizeToNotify = dbPageSize / 16 // store in DB only IH which allowing do big jumps over state
-	)
+	//const (
+	//	dbPageSize          = 4096             // common OS page size is 4KB
+	//	minNodeSizeToNotify = dbPageSize / 128 // store in DB only IH which allowing do big jumps over state
+	//)
 	// Make a better experiment if make sense to enable it
 	//if nd.witnessSize() < minNodeSizeToNotify {
 	//	return
@@ -1444,17 +1444,22 @@ Loop:
 			break Loop
 		case *fullNode:
 			var acc2 uint64
+			//fmt.Printf("full children %d\n", n.Children)
 			for i := range n.Children {
 				if n.Children[i] == nil {
+					//fmt.Printf("full nill child %d\n", i)
 					continue
 				}
+				//fmt.Printf("full child %d\n", i)
 				if accumulator+acc2+n.Children[i].witnessSize() >= size {
 					prefix = append(prefix, uint8(i))
 					nd = n.Children[i]
 					//fmt.Printf("full overflow(%d): %d+%d+%d=%d <= %d, %x\n", i, accumulator, acc2, n.Children[i].witnessSize(), accumulator+acc2+n.Children[i].witnessSize(), size, prefix)
 					accumulator += acc2
+					//fmt.Printf("full overflow(%d)++\n", accumulator)
 					continue Loop
 				}
+				//fmt.Printf("full no overflow (%d): %d\n", i, n.Children[i].witnessSize())
 				acc2 += n.Children[i].witnessSize()
 			}
 
@@ -1472,12 +1477,8 @@ Loop:
 			//fmt.Printf("valueNode: %d %d %x\n", accumulator, accumulator+n.witnessSize(), prefix)
 			found = true
 			break Loop
-		case codeNode:
-			//fmt.Printf("codeNode: %d %d %x\n", accumulator, accumulator+n.witnessSize(), prefix)
-			found = true
-			break Loop
 		case hashNode:
-			//fmt.Printf("hashNode: %x %d\n", prefix, n.witnessSize())
+			//fmt.Printf("hashNode: %x %d %d\n", prefix, accumulator, n.witnessSize())
 			found = false
 			break Loop
 		default:

--- a/trie/trie.go
+++ b/trie/trie.go
@@ -1260,15 +1260,6 @@ func (t *Trie) EvictNode(hex []byte) {
 }
 
 func (t *Trie) notifyUnloadRecursive(hex []byte, incarnation uint64, nd node) {
-	//const (
-	//	dbPageSize          = 4096             // common OS page size is 4KB
-	//	minNodeSizeToNotify = dbPageSize / 128 // store in DB only IH which allowing do big jumps over state
-	//)
-	// Make a better experiment if make sense to enable it
-	//if nd.witnessSize() < minNodeSizeToNotify {
-	//	return
-	//}
-
 	switch n := nd.(type) {
 	case *shortNode:
 		hex = append(hex, n.Key...)

--- a/trie/trie.go
+++ b/trie/trie.go
@@ -1394,7 +1394,7 @@ func (t *Trie) CumulativeWitnessSize(key []byte) uint64 {
 	return n.witnessSize()
 }
 
-// PrefixByCumulativeWitnessSize returns minimal prefix with accumulated size >= than given one.
+// PrefixByCumulativeWitnessSizeDeprecated returns minimal prefix with accumulated size >= than given one.
 // Returns (nil, true) if size > root.witnessSize()
 // Returns (nil, false) if faced nil node in trie
 func (t *Trie) PrefixByCumulativeWitnessSize(size uint64) (prefix []byte, incarnation uint64, accumulator uint64, found bool) {

--- a/trie/trie_observers.go
+++ b/trie/trie_observers.go
@@ -12,7 +12,7 @@ type Observer interface {
 	CodeNodeTouched(hex []byte)
 	CodeNodeSizeChanged(hex []byte, newSize uint)
 
-	WillUnloadBranchNode(key []byte, nodeHash common.Hash, incarnation uint64, witnessLen uint64)
+	WillUnloadBranchNode(key []byte, nodeHash common.Hash, incarnation uint64, witnessSize uint64)
 	WillUnloadNode(key []byte, nodeHash common.Hash)
 	BranchNodeLoaded(prefixAsNibbles []byte, incarnation uint64)
 }
@@ -99,9 +99,9 @@ func (mux *ObserverMux) WillUnloadNode(key []byte, nodeHash common.Hash) {
 	}
 }
 
-func (mux *ObserverMux) WillUnloadBranchNode(key []byte, nodeHash common.Hash, incarnation uint64, witnessLen uint64) {
+func (mux *ObserverMux) WillUnloadBranchNode(key []byte, nodeHash common.Hash, incarnation uint64, witnessSize uint64) {
 	for _, child := range mux.children {
-		child.WillUnloadBranchNode(key, nodeHash, incarnation, witnessLen)
+		child.WillUnloadBranchNode(key, nodeHash, incarnation, witnessSize)
 	}
 }
 

--- a/trie/trie_observers_test.go
+++ b/trie/trie_observers_test.go
@@ -96,7 +96,7 @@ func (m *mockObserver) CodeNodeSizeChanged(hex []byte, newSize uint) {
 	m.createdNodes[common.Bytes2Hex(hex)] = newSize
 }
 
-func (m *mockObserver) WillUnloadBranchNode(hex []byte, hash common.Hash, incarnation uint64, witnessLen uint64) {
+func (m *mockObserver) WillUnloadBranchNode(hex []byte, hash common.Hash, incarnation uint64, witnessSize uint64) {
 }
 
 func (m *mockObserver) WillUnloadNode(hex []byte, hash common.Hash) {

--- a/trie/trie_transform.go
+++ b/trie/trie_transform.go
@@ -31,7 +31,7 @@ func transformSubTrie(nd node, hex []byte, newTrie *Trie, transformFunc keyTrans
 		}
 		transformSubTrie(n.storage, aHex, newTrie, transformFunc)
 	case hashNode:
-		_, newTrie.root = newTrie.insert(newTrie.root, transformFunc(hex), hashNode{hash: common.CopyBytes(n.hash), witnessLength: n.witnessLength})
+		_, newTrie.root = newTrie.insert(newTrie.root, transformFunc(hex), hashNode{hash: common.CopyBytes(n.hash), iws: n.iws})
 		return
 	case *shortNode:
 		var hexVal []byte

--- a/trie/visual.go
+++ b/trie/visual.go
@@ -285,7 +285,7 @@ func fold(nd node, hexes [][]byte, h *hasher, isRoot bool) (bool, node) {
 			if bytes.Equal(n.Key, hex) {
 				var hn common.Hash
 				h.hash(n, isRoot, hn[:])
-				return true, hashNode{hash: hn[:], witnessLength: n.witnessLength}
+				return true, hashNode{hash: hn[:], iws: n.iws}
 			}
 			pLen := prefixLen(n.Key, hex)
 			if pLen > 0 {
@@ -298,7 +298,7 @@ func fold(nd node, hexes [][]byte, h *hasher, isRoot bool) (bool, node) {
 			if folded {
 				var hn common.Hash
 				h.hash(n, isRoot, hn[:])
-				return true, hashNode{hash: hn[:], witnessLength: n.witnessLength}
+				return true, hashNode{hash: hn[:], iws: n.iws}
 			}
 			return false, n
 		}
@@ -326,7 +326,7 @@ func fold(nd node, hexes [][]byte, h *hasher, isRoot bool) (bool, node) {
 		if folded1 && folded2 {
 			var hn common.Hash
 			h.hash(n, isRoot, hn[:])
-			return true, hashNode{hash: hn[:], witnessLength: n.witnessLength}
+			return true, hashNode{hash: hn[:], iws: n.iws}
 		}
 		return false, n
 	case *fullNode:
@@ -354,7 +354,7 @@ func fold(nd node, hexes [][]byte, h *hasher, isRoot bool) (bool, node) {
 		if !unfolded {
 			var hn common.Hash
 			h.hash(n, isRoot, hn[:])
-			return true, hashNode{hash: hn[:], witnessLength: n.witnessLength}
+			return true, hashNode{hash: hn[:], iws: n.iws}
 		}
 		return false, n
 	}

--- a/trie/witness_builder.go
+++ b/trie/witness_builder.go
@@ -98,7 +98,7 @@ func (b *WitnessBuilder) makeHashNode(n node, force bool, hashNodeFunc HashNodeF
 		if _, err := hashNodeFunc(n, force, hash[:]); err != nil {
 			return hashNode{}, err
 		}
-		return hashNode{hash: hash[:], witnessLength: n.witnessLen()}, nil
+		return hashNode{hash: hash[:], iws: n.witnessSize()}, nil
 	}
 }
 
@@ -154,7 +154,7 @@ func (b *WitnessBuilder) processAccountCode(n *accountNode, retainDec RetainDeci
 	}
 
 	if n.code == nil || (retainDec != nil && !retainDec.IsCodeTouched(n.CodeHash)) {
-		return b.addHashOp(hashNode{hash: n.CodeHash[:], witnessLength: uint64(n.codeSize)})
+		return b.addHashOp(hashNode{hash: n.CodeHash[:], iws: uint64(n.codeSize)})
 	}
 
 	return b.addCodeOp(n.code)


### PR DESCRIPTION
### Store all possible IH (and IWS - intermediate witness size): 
- Right now we store in IH bucket only IH of unloaded nodes (if unload big subtrie, still store 1 record about root of subtrie). To store all possible IH/IWS - `t.notifyUnloadRecursive` introduced
- Introduced functions to generate all IH/IWS: `TRACK_WITNESS_SIZE=1 go run ./cmd/hack/hack.go --action=resetIH --chaindata=./statedb`
- Can unload trie to IH/IWS bucket by next code (but can't use it on node shutdown, because trie can have changes which do not exist in DB state):
```
tr.EvictNode([]byte{})
_, err = bc.ChainDb().(ethdb.DbWithPendingMutations).Commit()
```


### On start - Load to Tire everything what is not in IH bucket:
- Not a good idea because too many things are not in IH (even nibbles, etc...). But `RetainLevels` can restrict memory usage. May work nice in combination with dump level 6 to db on shutdown. 

### MGR Schedule based only on IWS bucket (no trie):
- Combination of trie and db usage works badly - if we take totalWitnessSize from trie root, but will try to make schedule based on it and db, we will face cumulative error (as far by state we go, then bigger this error). This problem is so big that if IWS bucket doesn't have prefixes of len=2 (they are in trie), then mistage ~50% (we will iterate over whole state twice during 1 MGR cycle).  
- But if calculate totalWitnessSize based only on IWS bucket, then error gone (it's still there but it stopping to be cumulative and smashing across whole Tick. And this is fine for us - it's enough determenistic). 

### Store only IH which have witnessSize > X: 
- Looks doable and must not affect Schedule quality if X is small. 
- I need to do a few more experiments to come up with numbers here.  

### Schedule generation logic:
- `tds.TotalCumulativeWitnessSize` - called every tick (means if state size changed, the schedule will be adjusted, but the next tick will start where previous stopped anyway)
- Then called `tds.PrefixByCumulativeWitnessSizeFrom` - it has parameter `from []byte` to avoid scan IWS bucket from the beginning (can take the last key of previous tick and start a scan from there). 
- Speed still testing 

### Logic of calculation witness size:
- Not include code - because most of time it's size not available
- Added temporary constant `CountWitnessSizeWithoutStructure` - to see which logic will give smaller error. In current implementation value `false` win, but I will review one more time maybe some bug is in `true` value. 



