### PR TITLE
Fix staged sync issue introduced by LRU caches

### DIFF
--- a/cmd/hack/hack.go
+++ b/cmd/hack/hack.go
@@ -1231,6 +1231,22 @@ func printBranches(block uint64) {
 	}
 }
 
+func readPlainAccount(chaindata string, address common.Address, block uint64, rewind uint64) {
+	ethDb, err := ethdb.NewBoltDatabase(chaindata)
+	check(err)
+	var acc accounts.Account
+	enc, err := ethDb.Get(dbutils.PlainStateBucket, address[:])
+	if err != nil {
+		panic(err)
+	} else if enc == nil {
+		panic("acc not found")
+	}
+	if err = acc.DecodeForStorage(enc); err != nil {
+		panic(err)
+	}
+	fmt.Printf("%x\n%x\n%x\n%d\n", address, acc.Root, acc.CodeHash, acc.Incarnation)
+}
+
 func readAccount(chaindata string, account common.Address, block uint64, rewind uint64) {
 	ethDb, err := ethdb.NewBoltDatabase(chaindata)
 	check(err)

--- a/cmd/hack/hack.go
+++ b/cmd/hack/hack.go
@@ -2316,6 +2316,9 @@ func main() {
 	if *action == "readAccount" {
 		readAccount(*chaindata, common.HexToAddress(*account), uint64(*block), uint64(*rewind))
 	}
+	if *action == "readPlainAccount" {
+		readPlainAccount(*chaindata, common.HexToAddress(*account), uint64(*block), uint64(*rewind))
+	}
 	if *action == "fixAccount" {
 		fixAccount(*chaindata, common.HexToHash(*account), common.HexToHash(*hash))
 	}

--- a/cmd/hack/hack.go
+++ b/cmd/hack/hack.go
@@ -1231,7 +1231,7 @@ func printBranches(block uint64) {
 	}
 }
 
-func readPlainAccount(chaindata string, address common.Address, block uint64, rewind uint64) {
+func readPlainAccount(chaindata string, address common.Address) {
 	ethDb, err := ethdb.NewBoltDatabase(chaindata)
 	check(err)
 	var acc accounts.Account
@@ -2317,7 +2317,7 @@ func main() {
 		readAccount(*chaindata, common.HexToAddress(*account), uint64(*block), uint64(*rewind))
 	}
 	if *action == "readPlainAccount" {
-		readPlainAccount(*chaindata, common.HexToAddress(*account), uint64(*block), uint64(*rewind))
+		readPlainAccount(*chaindata, common.HexToAddress(*account))
 	}
 	if *action == "fixAccount" {
 		fixAccount(*chaindata, common.HexToHash(*account), common.HexToHash(*hash))

--- a/core/state/db_state_reader.go
+++ b/core/state/db_state_reader.go
@@ -100,7 +100,7 @@ func (dbr *DbStateReader) ReadAccountStorage(address common.Address, incarnation
 	return enc, nil
 }
 
-func (dbr *DbStateReader) ReadAccountCode(address common.Address, codeHash common.Hash) (code []byte, err error) {
+func (dbr *DbStateReader) ReadAccountCode(address common.Address, codeHash common.Hash) ([]byte, error) {
 	if bytes.Equal(codeHash[:], emptyCodeHash) {
 		return nil, nil
 	}
@@ -109,7 +109,7 @@ func (dbr *DbStateReader) ReadAccountCode(address common.Address, codeHash commo
 			return code, nil
 		}
 	}
-	code, err = dbr.db.Get(dbutils.CodeBucket, codeHash[:])
+	code, err := dbr.db.Get(dbutils.CodeBucket, codeHash[:])
 	if dbr.codeCache != nil && len(code) <= 1024 {
 		dbr.codeCache.Set(address[:], code)
 	}

--- a/core/state/db_state_reader.go
+++ b/core/state/db_state_reader.go
@@ -2,12 +2,12 @@ package state
 
 import (
 	"bytes"
+	"encoding/binary"
 
-	lru "github.com/hashicorp/golang-lru"
+	"github.com/VictoriaMetrics/fastcache"
 
 	"github.com/ledgerwatch/turbo-geth/common"
 	"github.com/ledgerwatch/turbo-geth/common/dbutils"
-	"github.com/ledgerwatch/turbo-geth/core/rawdb"
 	"github.com/ledgerwatch/turbo-geth/core/types/accounts"
 	"github.com/ledgerwatch/turbo-geth/ethdb"
 )
@@ -16,10 +16,10 @@ import (
 type DbStateReader struct {
 	db             ethdb.Getter
 	incarnationMap map[common.Address]uint64
-	accountCache   *lru.Cache
-	storageCache   *lru.Cache
-	codeCache      *lru.Cache
-	codeSizeCache  *lru.Cache
+	accountCache   *fastcache.Cache
+	storageCache   *fastcache.Cache
+	codeCache      *fastcache.Cache
+	codeSizeCache  *fastcache.Cache
 }
 
 func NewDbStateReader(db ethdb.Getter, incarnationMap map[common.Address]uint64) *DbStateReader {
@@ -29,64 +29,53 @@ func NewDbStateReader(db ethdb.Getter, incarnationMap map[common.Address]uint64)
 	}
 }
 
-func (dbr *DbStateReader) SetAccountCache(accountCache *lru.Cache) {
+func (dbr *DbStateReader) SetAccountCache(accountCache *fastcache.Cache) {
 	dbr.accountCache = accountCache
 }
 
-func (dbr *DbStateReader) SetStorageCache(storageCache *lru.Cache) {
+func (dbr *DbStateReader) SetStorageCache(storageCache *fastcache.Cache) {
 	dbr.storageCache = storageCache
 }
 
-func (dbr *DbStateReader) SetCodeCache(codeCache *lru.Cache) {
+func (dbr *DbStateReader) SetCodeCache(codeCache *fastcache.Cache) {
 	dbr.codeCache = codeCache
 }
 
-func (dbr *DbStateReader) SetCodeSizeCache(codeSizeCache *lru.Cache) {
+func (dbr *DbStateReader) SetCodeSizeCache(codeSizeCache *fastcache.Cache) {
 	dbr.codeSizeCache = codeSizeCache
 }
 
 func (dbr *DbStateReader) ReadAccountData(address common.Address) (*accounts.Account, error) {
+	var enc []byte
+	var ok bool
 	if dbr.accountCache != nil {
-		if cached, ok := dbr.accountCache.Get(address); ok {
-			if cached == nil {
-				return nil, nil
-			}
-			return cached.(*accounts.Account), nil
+		enc, ok = dbr.accountCache.HasGet(nil, address[:])
+	}
+	if !ok {
+		var err error
+		if addrHash, err1 := common.HashData(address[:]); err1 == nil {
+			enc, err = dbr.db.Get(dbutils.CurrentStateBucket, addrHash[:])
+		} else {
+			return nil, err1
+		}
+		if err != nil && !entryNotFound(err) {
+			return nil, err
 		}
 	}
-	addrHash, err := common.HashData(address[:])
-	if err != nil {
-		return nil, err
+	if !ok && dbr.accountCache != nil {
+		dbr.accountCache.Set(address[:], enc)
 	}
-	var a accounts.Account
-	if ok, err := rawdb.ReadAccount(dbr.db, addrHash, &a); err != nil {
-		return nil, err
-	} else if !ok {
-		if dbr.accountCache != nil {
-			dbr.accountCache.Add(address, nil)
-		}
+	if enc == nil {
 		return nil, nil
 	}
-	if dbr.accountCache != nil {
-		dbr.accountCache.Add(address, a.SelfCopy())
+	acc := &accounts.Account{}
+	if err := acc.DecodeForStorage(enc); err != nil {
+		return nil, err
 	}
-	return &a, nil
+	return acc, nil
 }
 
 func (dbr *DbStateReader) ReadAccountStorage(address common.Address, incarnation uint64, key *common.Hash) ([]byte, error) {
-	var storageKeyP *[20 + 32]byte
-	if dbr.storageCache != nil {
-		var storageKey [20 + 32]byte
-		copy(storageKey[:], address[:])
-		copy(storageKey[20:], key[:])
-		if cached, ok := dbr.storageCache.Get(storageKey); ok {
-			if cached == nil {
-				return nil, nil
-			}
-			return cached.([]byte), nil
-		}
-		storageKeyP = &storageKey
-	}
 	addrHash, err := common.HashData(address[:])
 	if err != nil {
 		return nil, err
@@ -95,12 +84,18 @@ func (dbr *DbStateReader) ReadAccountStorage(address common.Address, incarnation
 	if err1 != nil {
 		return nil, err1
 	}
-	enc, err2 := dbr.db.Get(dbutils.CurrentStateBucket, dbutils.GenerateCompositeStorageKey(addrHash, incarnation, seckey))
-	if err2 != nil && err2 != ethdb.ErrKeyNotFound {
+	compositeKey := dbutils.GenerateCompositeStorageKey(addrHash, incarnation, seckey)
+	if dbr.storageCache != nil {
+		if enc, ok := dbr.storageCache.HasGet(nil, compositeKey); ok {
+			return enc, nil
+		}
+	}
+	enc, err2 := dbr.db.Get(dbutils.CurrentStateBucket, compositeKey)
+	if err2 != nil && !entryNotFound(err2) {
 		return nil, err2
 	}
 	if dbr.storageCache != nil {
-		dbr.storageCache.Add(*storageKeyP, enc)
+		dbr.storageCache.Set(compositeKey, enc)
 	}
 	return enc, nil
 }
@@ -110,19 +105,18 @@ func (dbr *DbStateReader) ReadAccountCode(address common.Address, codeHash commo
 		return nil, nil
 	}
 	if dbr.codeCache != nil {
-		if cached, ok := dbr.codeCache.Get(address); ok {
-			if cached == nil {
-				return nil, nil
-			}
-			return cached.([]byte), nil
+		if code, ok := dbr.codeCache.HasGet(nil, address[:]); ok {
+			return code, nil
 		}
 	}
 	code, err = dbr.db.Get(dbutils.CodeBucket, codeHash[:])
 	if dbr.codeCache != nil && len(code) <= 1024 {
-		dbr.codeCache.Add(address, code)
+		dbr.codeCache.Set(address[:], code)
 	}
 	if dbr.codeSizeCache != nil {
-		dbr.codeSizeCache.Add(address, len(code))
+		var b [4]byte
+		binary.BigEndian.PutUint32(b[:], uint32(len(code)))
+		dbr.codeSizeCache.Set(address[:], b[:])
 	}
 	return code, err
 }
@@ -132,8 +126,8 @@ func (dbr *DbStateReader) ReadAccountCodeSize(address common.Address, codeHash c
 		return 0, nil
 	}
 	if dbr.codeSizeCache != nil {
-		if cached, ok := dbr.codeSizeCache.Get(address); ok {
-			return cached.(int), nil
+		if b, ok := dbr.codeSizeCache.HasGet(nil, address[:]); ok {
+			return int(binary.BigEndian.Uint32(b)), nil
 		}
 	}
 	var code []byte
@@ -142,7 +136,9 @@ func (dbr *DbStateReader) ReadAccountCodeSize(address common.Address, codeHash c
 		return 0, err
 	}
 	if dbr.codeSizeCache != nil {
-		dbr.codeSizeCache.Add(address, len(code))
+		var b [4]byte
+		binary.BigEndian.PutUint32(b[:], uint32(len(code)))
+		dbr.codeSizeCache.Set(address[:], b[:])
 	}
 	return len(code), nil
 }

--- a/core/state/db_state_writer.go
+++ b/core/state/db_state_writer.go
@@ -110,6 +110,12 @@ func (dsw *DbStateWriter) DeleteAccount(ctx context.Context, address common.Addr
 	if dsw.accountCache != nil {
 		dsw.accountCache.Add(address, nil)
 	}
+	if dsw.codeCache != nil {
+		dsw.codeCache.Add(address, nil)
+	}
+	if dsw.codeSizeCache != nil {
+		dsw.codeSizeCache.Add(address, 0)
+	}
 	return nil
 }
 

--- a/core/state/db_state_writer.go
+++ b/core/state/db_state_writer.go
@@ -2,8 +2,8 @@ package state
 
 import (
 	"context"
-	"fmt"
 	"encoding/binary"
+	"fmt"
 
 	"github.com/VictoriaMetrics/fastcache"
 

--- a/core/state/db_state_writer.go
+++ b/core/state/db_state_writer.go
@@ -140,8 +140,12 @@ func (dsw *DbStateWriter) UpdateAccountCode(address common.Address, incarnation 
 	if err := dsw.stateDb.Put(dbutils.ContractCodeBucket, dbutils.GenerateStoragePrefix(addrHash[:], incarnation), codeHash[:]); err != nil {
 		return err
 	}
-	if dsw.codeCache != nil && len(code) <= 1024 {
-		dsw.codeCache.Set(address[:], code)
+	if dsw.codeCache != nil {
+		if len(code) <= 1024 {
+			dsw.codeCache.Set(address[:], code)
+		} else {
+			dsw.codeCache.Del(address[:])
+		}
 	}
 	if dsw.codeSizeCache != nil {
 		var b [4]byte

--- a/core/state/plain_state_reader.go
+++ b/core/state/plain_state_reader.go
@@ -2,7 +2,8 @@ package state
 
 import (
 	"bytes"
-	lru "github.com/hashicorp/golang-lru"
+	"encoding/binary"
+	"github.com/VictoriaMetrics/fastcache"
 
 	"github.com/ledgerwatch/turbo-geth/common"
 	"github.com/ledgerwatch/turbo-geth/common/dbutils"
@@ -18,10 +19,10 @@ var _ StateReader = (*PlainStateReader)(nil)
 type PlainStateReader struct {
 	db                     ethdb.Getter
 	uncommitedIncarnations map[common.Address]uint64
-	accountCache           *lru.Cache
-	storageCache           *lru.Cache
-	codeCache              *lru.Cache
-	codeSizeCache          *lru.Cache
+	accountCache           *fastcache.Cache
+	storageCache           *fastcache.Cache
+	codeCache              *fastcache.Cache
+	codeSizeCache          *fastcache.Cache
 }
 
 func NewPlainStateReader(db ethdb.Getter, incarnations map[common.Address]uint64) *PlainStateReader {
@@ -31,91 +32,79 @@ func NewPlainStateReader(db ethdb.Getter, incarnations map[common.Address]uint64
 	}
 }
 
-func (r *PlainStateReader) SetAccountCache(accountCache *lru.Cache) {
+func (r *PlainStateReader) SetAccountCache(accountCache *fastcache.Cache) {
 	r.accountCache = accountCache
 }
 
-func (r *PlainStateReader) SetStorageCache(storageCache *lru.Cache) {
+func (r *PlainStateReader) SetStorageCache(storageCache *fastcache.Cache) {
 	r.storageCache = storageCache
 }
 
-func (r *PlainStateReader) SetCodeCache(codeCache *lru.Cache) {
+func (r *PlainStateReader) SetCodeCache(codeCache *fastcache.Cache) {
 	r.codeCache = codeCache
 }
 
-func (r *PlainStateReader) SetCodeSizeCache(codeSizeCache *lru.Cache) {
+func (r *PlainStateReader) SetCodeSizeCache(codeSizeCache *fastcache.Cache) {
 	r.codeSizeCache = codeSizeCache
 }
 
 func (r *PlainStateReader) ReadAccountData(address common.Address) (*accounts.Account, error) {
+	var enc []byte
+	var ok bool
 	if r.accountCache != nil {
-		if cached, ok := r.accountCache.Get(address); ok {
-			if cached == nil {
-				return nil, nil
-			}
-			return cached.(*accounts.Account), nil
-		}
+		enc, ok = r.accountCache.HasGet(nil, address[:])
 	}
-	enc, err := r.db.Get(dbutils.PlainStateBucket, address[:])
-	if err == nil {
-		acc := &accounts.Account{}
-		if err = acc.DecodeForStorage(enc); err != nil {
+	if !ok {
+		var err error
+		enc, err = r.db.Get(dbutils.PlainStateBucket, address[:])
+		if err != nil && !entryNotFound(err) {
 			return nil, err
 		}
-		if r.accountCache != nil {
-			r.accountCache.Add(address, acc)
-		}
-		return acc, nil
-	} else if !entryNotFound(err) {
+	}
+	if !ok && r.accountCache != nil {
+		r.accountCache.Set(address[:], enc)
+	}
+	if enc == nil {
+		return nil, nil
+	}
+	acc := &accounts.Account{}
+	if err := acc.DecodeForStorage(enc); err != nil {
 		return nil, err
 	}
-	if r.accountCache != nil {
-		r.accountCache.Add(address, nil)
-	}
-	return nil, nil
+	return acc, nil
 }
 
 func (r *PlainStateReader) ReadAccountStorage(address common.Address, incarnation uint64, key *common.Hash) ([]byte, error) {
-	var storageKeyP *[20 + 32]byte
+	compositeKey := dbutils.PlainGenerateCompositeStorageKey(address, incarnation, *key)
 	if r.storageCache != nil {
-		var storageKey [20 + 32]byte
-		copy(storageKey[:], address[:])
-		copy(storageKey[20:], key[:])
-		if cached, ok := r.storageCache.Get(storageKey); ok {
-			if cached == nil {
-				return nil, nil
-			}
-			return cached.([]byte), nil
+		if enc, ok := r.storageCache.HasGet(nil, compositeKey); ok {
+			return enc, nil
 		}
-		storageKeyP = &storageKey
 	}
-	enc, err := r.db.Get(dbutils.PlainStateBucket, dbutils.PlainGenerateCompositeStorageKey(address, incarnation, *key))
-	if err == nil {
-		if r.storageCache != nil {
-			r.storageCache.Add(*storageKeyP, enc)
-		}
-		return enc, nil
-	} else if !entryNotFound(err) {
+	enc, err := r.db.Get(dbutils.PlainStateBucket, compositeKey)
+	if err != nil && !entryNotFound(err) {
 		return nil, err
 	}
 	if r.storageCache != nil {
-		r.storageCache.Add(*storageKeyP, nil)
+		r.storageCache.Set(compositeKey, enc)
 	}
-	return nil, nil
+	return enc, nil
 }
 
 func (r *PlainStateReader) ReadAccountCode(address common.Address, codeHash common.Hash) ([]byte, error) {
-	if bytes.Equal(codeHash[:], emptyCodeHash) {
-		return nil, nil
-	}
 	if r.codeCache != nil {
-		if cached, ok := r.codeCache.Get(address); ok {
-			return cached.([]byte), nil
+		if code, ok := r.codeCache.HasGet(nil, address[:]); ok {
+			return code, nil
 		}
 	}
 	code, err := r.db.Get(dbutils.CodeBucket, codeHash[:])
-	if r.codeCache != nil {
-		r.codeCache.Add(address, code)
+	if r.codeCache != nil && len(code) <= 1024 {
+		 r.codeCache.Set(address[:], code)
+	}
+	if r.codeSizeCache != nil {
+		var b [4]byte
+		binary.BigEndian.PutUint32(b[:], uint32(len(code)))
+		r.codeSizeCache.Set(address[:], b[:])
 	}
 	return code, err
 }
@@ -125,8 +114,8 @@ func (r *PlainStateReader) ReadAccountCodeSize(address common.Address, codeHash 
 		return 0, nil
 	}
 	if r.codeSizeCache != nil {
-		if cached, ok := r.codeSizeCache.Get(address); ok {
-			return cached.(int), nil
+		if b, ok := r.codeSizeCache.HasGet(nil, address[:]); ok {
+			return int(binary.BigEndian.Uint32(b)), nil
 		}
 	}
 	code, err := r.db.Get(dbutils.CodeBucket, codeHash[:])
@@ -134,7 +123,9 @@ func (r *PlainStateReader) ReadAccountCodeSize(address common.Address, codeHash 
 		return 0, err
 	}
 	if r.codeSizeCache != nil {
-		r.codeSizeCache.Add(address, len(code))
+		var b [4]byte
+		binary.BigEndian.PutUint32(b[:], uint32(len(code)))
+		r.codeSizeCache.Set(address[:], b[:])
 	}
 	return len(code), nil
 }

--- a/core/state/plain_state_reader.go
+++ b/core/state/plain_state_reader.go
@@ -99,7 +99,7 @@ func (r *PlainStateReader) ReadAccountCode(address common.Address, codeHash comm
 	}
 	code, err := r.db.Get(dbutils.CodeBucket, codeHash[:])
 	if r.codeCache != nil && len(code) <= 1024 {
-		 r.codeCache.Set(address[:], code)
+		r.codeCache.Set(address[:], code)
 	}
 	if r.codeSizeCache != nil {
 		var b [4]byte

--- a/core/state/plain_state_reader.go
+++ b/core/state/plain_state_reader.go
@@ -24,7 +24,7 @@ type PlainStateReader struct {
 	codeSizeCache          *lru.Cache
 }
 
-func NewPlainStateReaderWithFallback(db ethdb.Getter, incarnations map[common.Address]uint64) *PlainStateReader {
+func NewPlainStateReader(db ethdb.Getter, incarnations map[common.Address]uint64) *PlainStateReader {
 	return &PlainStateReader{
 		db:                     db,
 		uncommitedIncarnations: incarnations,

--- a/core/state/plain_state_writer.go
+++ b/core/state/plain_state_writer.go
@@ -2,8 +2,9 @@ package state
 
 import (
 	"context"
+	"encoding/binary"
 
-	lru "github.com/hashicorp/golang-lru"
+	"github.com/VictoriaMetrics/fastcache"
 
 	"github.com/ledgerwatch/turbo-geth/common"
 	"github.com/ledgerwatch/turbo-geth/common/changeset"
@@ -20,10 +21,10 @@ type PlainStateWriter struct {
 	uncommitedIncarnations map[common.Address]uint64
 	csw                    *ChangeSetWriter
 	blockNumber            uint64
-	accountCache           *lru.Cache
-	storageCache           *lru.Cache
-	codeCache              *lru.Cache
-	codeSizeCache          *lru.Cache
+	accountCache           *fastcache.Cache
+	storageCache           *fastcache.Cache
+	codeCache              *fastcache.Cache
+	codeSizeCache          *fastcache.Cache
 }
 
 func NewPlainStateWriter(stateDb, changeDb ethdb.Database, blockNumber uint64, uncommitedIncarnations map[common.Address]uint64) *PlainStateWriter {
@@ -36,19 +37,19 @@ func NewPlainStateWriter(stateDb, changeDb ethdb.Database, blockNumber uint64, u
 	}
 }
 
-func (w *PlainStateWriter) SetAccountCache(accountCache *lru.Cache) {
+func (w *PlainStateWriter) SetAccountCache(accountCache *fastcache.Cache) {
 	w.accountCache = accountCache
 }
 
-func (w *PlainStateWriter) SetStorageCache(storageCache *lru.Cache) {
+func (w *PlainStateWriter) SetStorageCache(storageCache *fastcache.Cache) {
 	w.storageCache = storageCache
 }
 
-func (w *PlainStateWriter) SetCodeCache(codeCache *lru.Cache) {
+func (w *PlainStateWriter) SetCodeCache(codeCache *fastcache.Cache) {
 	w.codeCache = codeCache
 }
 
-func (w *PlainStateWriter) SetCodeSizeCache(codeSizeCache *lru.Cache) {
+func (w *PlainStateWriter) SetCodeSizeCache(codeSizeCache *fastcache.Cache) {
 	w.codeSizeCache = codeSizeCache
 }
 
@@ -56,11 +57,11 @@ func (w *PlainStateWriter) UpdateAccountData(ctx context.Context, address common
 	if err := w.csw.UpdateAccountData(ctx, address, original, account); err != nil {
 		return err
 	}
-	if w.accountCache != nil {
-		w.accountCache.Add(address, account)
-	}
 	value := make([]byte, account.EncodingLengthForStorage())
 	account.EncodeForStorage(value)
+	if w.accountCache != nil {
+		w.accountCache.Set(address[:], value)
+	}
 	return w.stateDb.Put(dbutils.PlainStateBucket, address[:], value)
 }
 
@@ -68,11 +69,13 @@ func (w *PlainStateWriter) UpdateAccountCode(address common.Address, incarnation
 	if err := w.csw.UpdateAccountCode(address, incarnation, codeHash, code); err != nil {
 		return err
 	}
-	if w.codeCache != nil {
-		w.codeCache.Add(address, code)
+	if w.codeCache != nil && len(code) <= 1024 {
+		w.codeCache.Set(address[:], code)
 	}
 	if w.codeSizeCache != nil {
-		w.codeSizeCache.Add(address, len(code))
+		var b [4]byte
+		binary.BigEndian.PutUint32(b[:], uint32(len(code)))
+		w.codeSizeCache.Set(address[:], b[:])
 	}
 	if err := w.stateDb.Put(dbutils.CodeBucket, codeHash[:], code); err != nil {
 		return err
@@ -88,13 +91,15 @@ func (w *PlainStateWriter) DeleteAccount(ctx context.Context, address common.Add
 		w.uncommitedIncarnations[address] = original.Incarnation
 	}
 	if w.accountCache != nil {
-		w.accountCache.Add(address, nil)
+		w.accountCache.Set(address[:], nil)
 	}
 	if w.codeCache != nil {
-		w.codeCache.Add(address, nil)
+		w.codeCache.Set(address[:], nil)
 	}
 	if w.codeSizeCache != nil {
-		w.codeSizeCache.Add(address, 0)
+		var b [4]byte
+		binary.BigEndian.PutUint32(b[:], 0)
+		w.codeSizeCache.Set(address[:], b[:])
 	}
 	if err := w.stateDb.Delete(dbutils.PlainStateBucket, address[:]); err != nil {
 		if err != ethdb.ErrKeyNotFound {
@@ -111,25 +116,16 @@ func (w *PlainStateWriter) WriteAccountStorage(ctx context.Context, address comm
 	if *original == *value {
 		return nil
 	}
-
 	compositeKey := dbutils.PlainGenerateCompositeStorageKey(address, incarnation, *key)
 
-	v := common.CopyBytes(cleanUpTrailingZeroes(value[:]))
+	v := cleanUpTrailingZeroes(value[:])
 	if w.storageCache != nil {
-		var storageKey [20 + 32]byte
-		copy(storageKey[:], address[:])
-		copy(storageKey[20:], key[:])
-		w.storageCache.Add(storageKey, v)
+		w.storageCache.Set(compositeKey, v)
 	}
 	if len(v) == 0 {
-		if err := w.stateDb.Delete(dbutils.PlainStateBucket, compositeKey); err != nil {
-			if err != ethdb.ErrKeyNotFound {
-				return err
-			}
-		}
-		return nil
+		return w.stateDb.Delete(dbutils.PlainStateBucket, compositeKey)
 	}
-	return w.stateDb.Put(dbutils.PlainStateBucket, compositeKey, v)
+	return w.stateDb.Put(dbutils.PlainStateBucket, compositeKey, common.CopyBytes(v))
 }
 
 func (w *PlainStateWriter) CreateContract(address common.Address) error {

--- a/core/state/plain_state_writer.go
+++ b/core/state/plain_state_writer.go
@@ -101,12 +101,7 @@ func (w *PlainStateWriter) DeleteAccount(ctx context.Context, address common.Add
 		binary.BigEndian.PutUint32(b[:], 0)
 		w.codeSizeCache.Set(address[:], b[:])
 	}
-	if err := w.stateDb.Delete(dbutils.PlainStateBucket, address[:]); err != nil {
-		if err != ethdb.ErrKeyNotFound {
-			return err
-		}
-	}
-	return nil
+	return w.stateDb.Delete(dbutils.PlainStateBucket, address[:])
 }
 
 func (w *PlainStateWriter) WriteAccountStorage(ctx context.Context, address common.Address, incarnation uint64, key, original, value *common.Hash) error {

--- a/core/state/plain_state_writer.go
+++ b/core/state/plain_state_writer.go
@@ -90,6 +90,12 @@ func (w *PlainStateWriter) DeleteAccount(ctx context.Context, address common.Add
 	if w.accountCache != nil {
 		w.accountCache.Add(address, nil)
 	}
+	if w.codeCache != nil {
+		w.codeCache.Add(address, nil)
+	}
+	if w.codeSizeCache != nil {
+		w.codeSizeCache.Add(address, 0)
+	}
 	if err := w.stateDb.Delete(dbutils.PlainStateBucket, address[:]); err != nil {
 		if err != ethdb.ErrKeyNotFound {
 			return err

--- a/core/state/plain_state_writer.go
+++ b/core/state/plain_state_writer.go
@@ -69,8 +69,12 @@ func (w *PlainStateWriter) UpdateAccountCode(address common.Address, incarnation
 	if err := w.csw.UpdateAccountCode(address, incarnation, codeHash, code); err != nil {
 		return err
 	}
-	if w.codeCache != nil && len(code) <= 1024 {
-		w.codeCache.Set(address[:], code)
+	if w.codeCache != nil {
+		if len(code) <= 1024 {
+			w.codeCache.Set(address[:], code)
+		} else {
+			w.codeCache.Del(address[:])
+		}
 	}
 	if w.codeSizeCache != nil {
 		var b [4]byte

--- a/eth/downloader/stagedsync_stage_execute.go
+++ b/eth/downloader/stagedsync_stage_execute.go
@@ -124,13 +124,13 @@ func spawnExecuteBlocksStage(stateDB ethdb.Database, blockchain BlockChain) (uin
 
 		if core.UsePlainStateExecution {
 			plainReader := state.NewPlainStateReader(stateBatch, uncommitedIncarnations)
-			plainReader.SetAccountCache(accountCache)
+			//plainReader.SetAccountCache(accountCache)
 			//plainReader.SetStorageCache(storageCache)
 			plainReader.SetCodeCache(codeCache)
 			plainReader.SetCodeSizeCache(codeSizeCache)
 			stateReader = plainReader
 			plainWriter := state.NewPlainStateWriter(stateBatch, changeBatch, blockNum, uncommitedIncarnations)
-			plainWriter.SetAccountCache(accountCache)
+			//plainWriter.SetAccountCache(accountCache)
 			//plainWriter.SetStorageCache(storageCache)
 			plainWriter.SetCodeCache(codeCache)
 			plainWriter.SetCodeSizeCache(codeSizeCache)

--- a/eth/downloader/stagedsync_stage_execute.go
+++ b/eth/downloader/stagedsync_stage_execute.go
@@ -94,7 +94,7 @@ func spawnExecuteBlocksStage(stateDB ethdb.Database, blockchain BlockChain) (uin
 		}
 	*/
 	stateBatch := stateDB.NewBatch()
-	changeBatch := stateDB.NewBatch()
+	//changeBatch := stateDB.NewBatch()
 
 	progressLogger := NewProgressLogger(logInterval, stateBatch)
 	progressLogger.Start(&nextBlockNumber)
@@ -124,13 +124,13 @@ func spawnExecuteBlocksStage(stateDB ethdb.Database, blockchain BlockChain) (uin
 
 		if core.UsePlainStateExecution {
 			plainReader := state.NewPlainStateReader(stateBatch, uncommitedIncarnations)
-			//plainReader.SetAccountCache(accountCache)
+			plainReader.SetAccountCache(accountCache)
 			plainReader.SetStorageCache(storageCache)
 			plainReader.SetCodeCache(codeCache)
 			plainReader.SetCodeSizeCache(codeSizeCache)
 			stateReader = plainReader
-			plainWriter := state.NewPlainStateWriter(stateBatch, changeBatch, blockNum, uncommitedIncarnations)
-			//plainWriter.SetAccountCache(accountCache)
+			plainWriter := state.NewPlainStateWriter(stateBatch, stateBatch, blockNum, uncommitedIncarnations)
+			plainWriter.SetAccountCache(accountCache)
 			plainWriter.SetStorageCache(storageCache)
 			plainWriter.SetCodeCache(codeCache)
 			plainWriter.SetCodeSizeCache(codeSizeCache)
@@ -142,7 +142,7 @@ func spawnExecuteBlocksStage(stateDB ethdb.Database, blockchain BlockChain) (uin
 			hashStateReader.SetCodeCache(codeCache)
 			hashStateReader.SetCodeSizeCache(codeSizeCache)
 			stateReader = hashStateReader
-			hashedStateWriter := state.NewDbStateWriter(stateBatch, changeBatch, blockNum, uncommitedIncarnations)
+			hashedStateWriter := state.NewDbStateWriter(stateBatch, stateBatch, blockNum, uncommitedIncarnations)
 			hashedStateWriter.SetAccountCache(accountCache)
 			hashedStateWriter.SetStorageCache(storageCache)
 			hashedStateWriter.SetCodeCache(codeCache)
@@ -170,11 +170,13 @@ func spawnExecuteBlocksStage(stateDB ethdb.Database, blockchain BlockChain) (uin
 			uncommitedIncarnations = make(map[common.Address]uint64)
 			log.Info("State batch committed", "in", time.Since(start))
 		}
+		/*
 		if changeBatch.BatchSize() >= ChangeBatchSize {
 			if _, err = changeBatch.Commit(); err != nil {
 				return 0, err
 			}
 		}
+		*/
 		/*
 			if blockNum-profileNumber == 100000 {
 				// Flush the profiler
@@ -186,10 +188,12 @@ func spawnExecuteBlocksStage(stateDB ethdb.Database, blockchain BlockChain) (uin
 	if err != nil {
 		return atomic.LoadUint64(&nextBlockNumber) - 1, fmt.Errorf("sync Execute: failed to write state batch commit: %v", err)
 	}
+	/*
 	_, err = changeBatch.Commit()
 	if err != nil {
 		return atomic.LoadUint64(&nextBlockNumber) - 1, fmt.Errorf("sync Execute: failed to write change batch commit: %v", err)
 	}
+	*/
 	return atomic.LoadUint64(&nextBlockNumber) - 1 /* the last processed block */, nil
 }
 

--- a/eth/downloader/stagedsync_stage_execute.go
+++ b/eth/downloader/stagedsync_stage_execute.go
@@ -124,16 +124,16 @@ func spawnExecuteBlocksStage(stateDB ethdb.Database, blockchain BlockChain) (uin
 
 		if core.UsePlainStateExecution {
 			plainReader := state.NewPlainStateReader(stateBatch, uncommitedIncarnations)
-			//plainReader.SetAccountCache(accountCache)
-			//plainReader.SetStorageCache(storageCache)
+			plainReader.SetAccountCache(accountCache)
+			plainReader.SetStorageCache(storageCache)
 			plainReader.SetCodeCache(codeCache)
-			//plainReader.SetCodeSizeCache(codeSizeCache)
+			plainReader.SetCodeSizeCache(codeSizeCache)
 			stateReader = plainReader
 			plainWriter := state.NewPlainStateWriter(stateBatch, changeBatch, blockNum, uncommitedIncarnations)
-			//plainWriter.SetAccountCache(accountCache)
-			//plainWriter.SetStorageCache(storageCache)
+			plainWriter.SetAccountCache(accountCache)
+			plainWriter.SetStorageCache(storageCache)
 			plainWriter.SetCodeCache(codeCache)
-			//plainWriter.SetCodeSizeCache(codeSizeCache)
+			plainWriter.SetCodeSizeCache(codeSizeCache)
 			stateWriter = plainWriter
 		} else {
 			hashStateReader := state.NewDbStateReader(stateBatch, uncommitedIncarnations)

--- a/eth/downloader/stagedsync_stage_execute.go
+++ b/eth/downloader/stagedsync_stage_execute.go
@@ -8,7 +8,7 @@ import (
 	"sync/atomic"
 	"time"
 
-	lru "github.com/hashicorp/golang-lru"
+	"github.com/VictoriaMetrics/fastcache"
 
 	"github.com/ledgerwatch/turbo-geth/common"
 	"github.com/ledgerwatch/turbo-geth/common/dbutils"
@@ -100,10 +100,10 @@ func spawnExecuteBlocksStage(stateDB ethdb.Database, blockchain BlockChain) (uin
 	progressLogger.Start(&nextBlockNumber)
 	defer progressLogger.Stop()
 
-	accountCache, _ := lru.New(400000)
-	storageCache, _ := lru.New(400000)
-	codeCache, _ := lru.New(1000)
-	codeSizeCache, _ := lru.New(400000)
+	accountCache := fastcache.New(128*1024*1024) // 128 Mb
+	storageCache := fastcache.New(128*1024*1024) // 128 Mb
+	codeCache := fastcache.New(32*1024*1024) // 32 Mb (the minimum)
+	codeSizeCache := fastcache.New(32*1024*1024) // 32 Mb (the minimum)
 	// uncommitedIncarnations map holds incarnations for accounts that were deleted,
 	// but their storage is not yet committed
 	var uncommitedIncarnations = make(map[common.Address]uint64)

--- a/eth/downloader/stagedsync_stage_execute.go
+++ b/eth/downloader/stagedsync_stage_execute.go
@@ -123,14 +123,14 @@ func spawnExecuteBlocksStage(stateDB ethdb.Database, blockchain BlockChain) (uin
 		var stateWriter state.WriterWithChangeSets
 
 		if core.UsePlainStateExecution {
-			plainReader := state.NewPlainStateReaderWithFallback(stateBatch, uncommitedIncarnations)
-			plainReader.SetAccountCache(accountCache)
+			plainReader := state.NewPlainStateReader(stateBatch, uncommitedIncarnations)
+			//plainReader.SetAccountCache(accountCache)
 			plainReader.SetStorageCache(storageCache)
 			plainReader.SetCodeCache(codeCache)
 			plainReader.SetCodeSizeCache(codeSizeCache)
 			stateReader = plainReader
 			plainWriter := state.NewPlainStateWriter(stateBatch, changeBatch, blockNum, uncommitedIncarnations)
-			plainWriter.SetAccountCache(accountCache)
+			//plainWriter.SetAccountCache(accountCache)
 			plainWriter.SetStorageCache(storageCache)
 			plainWriter.SetCodeCache(codeCache)
 			plainWriter.SetCodeSizeCache(codeSizeCache)

--- a/eth/downloader/stagedsync_stage_execute.go
+++ b/eth/downloader/stagedsync_stage_execute.go
@@ -100,10 +100,10 @@ func spawnExecuteBlocksStage(stateDB ethdb.Database, blockchain BlockChain) (uin
 	progressLogger.Start(&nextBlockNumber)
 	defer progressLogger.Stop()
 
-	accountCache := fastcache.New(128*1024*1024) // 128 Mb
-	storageCache := fastcache.New(128*1024*1024) // 128 Mb
-	codeCache := fastcache.New(32*1024*1024) // 32 Mb (the minimum)
-	codeSizeCache := fastcache.New(32*1024*1024) // 32 Mb (the minimum)
+	accountCache := fastcache.New(128 * 1024 * 1024) // 128 Mb
+	storageCache := fastcache.New(128 * 1024 * 1024) // 128 Mb
+	codeCache := fastcache.New(32 * 1024 * 1024)     // 32 Mb (the minimum)
+	codeSizeCache := fastcache.New(32 * 1024 * 1024) // 32 Mb (the minimum)
 	// uncommitedIncarnations map holds incarnations for accounts that were deleted,
 	// but their storage is not yet committed
 	var uncommitedIncarnations = make(map[common.Address]uint64)

--- a/eth/downloader/stagedsync_stage_execute.go
+++ b/eth/downloader/stagedsync_stage_execute.go
@@ -124,16 +124,16 @@ func spawnExecuteBlocksStage(stateDB ethdb.Database, blockchain BlockChain) (uin
 
 		if core.UsePlainStateExecution {
 			plainReader := state.NewPlainStateReader(stateBatch, uncommitedIncarnations)
-			plainReader.SetAccountCache(accountCache)
-			plainReader.SetStorageCache(storageCache)
-			plainReader.SetCodeCache(codeCache)
-			plainReader.SetCodeSizeCache(codeSizeCache)
+			//plainReader.SetAccountCache(accountCache)
+			//plainReader.SetStorageCache(storageCache)
+			//plainReader.SetCodeCache(codeCache)
+			//plainReader.SetCodeSizeCache(codeSizeCache)
 			stateReader = plainReader
 			plainWriter := state.NewPlainStateWriter(stateBatch, changeBatch, blockNum, uncommitedIncarnations)
-			plainWriter.SetAccountCache(accountCache)
-			plainWriter.SetStorageCache(storageCache)
-			plainWriter.SetCodeCache(codeCache)
-			plainWriter.SetCodeSizeCache(codeSizeCache)
+			//plainWriter.SetAccountCache(accountCache)
+			//plainWriter.SetStorageCache(storageCache)
+			//plainWriter.SetCodeCache(codeCache)
+			//plainWriter.SetCodeSizeCache(codeSizeCache)
 			stateWriter = plainWriter
 		} else {
 			hashStateReader := state.NewDbStateReader(stateBatch, uncommitedIncarnations)

--- a/eth/downloader/stagedsync_stage_execute.go
+++ b/eth/downloader/stagedsync_stage_execute.go
@@ -127,13 +127,13 @@ func spawnExecuteBlocksStage(stateDB ethdb.Database, blockchain BlockChain) (uin
 			//plainReader.SetAccountCache(accountCache)
 			//plainReader.SetStorageCache(storageCache)
 			plainReader.SetCodeCache(codeCache)
-			plainReader.SetCodeSizeCache(codeSizeCache)
+			//plainReader.SetCodeSizeCache(codeSizeCache)
 			stateReader = plainReader
 			plainWriter := state.NewPlainStateWriter(stateBatch, changeBatch, blockNum, uncommitedIncarnations)
 			//plainWriter.SetAccountCache(accountCache)
 			//plainWriter.SetStorageCache(storageCache)
 			plainWriter.SetCodeCache(codeCache)
-			plainWriter.SetCodeSizeCache(codeSizeCache)
+			//plainWriter.SetCodeSizeCache(codeSizeCache)
 			stateWriter = plainWriter
 		} else {
 			hashStateReader := state.NewDbStateReader(stateBatch, uncommitedIncarnations)

--- a/eth/downloader/stagedsync_stage_execute.go
+++ b/eth/downloader/stagedsync_stage_execute.go
@@ -94,7 +94,7 @@ func spawnExecuteBlocksStage(stateDB ethdb.Database, blockchain BlockChain) (uin
 		}
 	*/
 	stateBatch := stateDB.NewBatch()
-	//changeBatch := stateDB.NewBatch()
+	changeBatch := stateDB.NewBatch()
 
 	progressLogger := NewProgressLogger(logInterval, stateBatch)
 	progressLogger.Start(&nextBlockNumber)
@@ -129,7 +129,7 @@ func spawnExecuteBlocksStage(stateDB ethdb.Database, blockchain BlockChain) (uin
 			plainReader.SetCodeCache(codeCache)
 			plainReader.SetCodeSizeCache(codeSizeCache)
 			stateReader = plainReader
-			plainWriter := state.NewPlainStateWriter(stateBatch, stateBatch, blockNum, uncommitedIncarnations)
+			plainWriter := state.NewPlainStateWriter(stateBatch, changeBatch, blockNum, uncommitedIncarnations)
 			plainWriter.SetAccountCache(accountCache)
 			plainWriter.SetStorageCache(storageCache)
 			plainWriter.SetCodeCache(codeCache)
@@ -142,7 +142,7 @@ func spawnExecuteBlocksStage(stateDB ethdb.Database, blockchain BlockChain) (uin
 			hashStateReader.SetCodeCache(codeCache)
 			hashStateReader.SetCodeSizeCache(codeSizeCache)
 			stateReader = hashStateReader
-			hashedStateWriter := state.NewDbStateWriter(stateBatch, stateBatch, blockNum, uncommitedIncarnations)
+			hashedStateWriter := state.NewDbStateWriter(stateBatch, changeBatch, blockNum, uncommitedIncarnations)
 			hashedStateWriter.SetAccountCache(accountCache)
 			hashedStateWriter.SetStorageCache(storageCache)
 			hashedStateWriter.SetCodeCache(codeCache)
@@ -170,13 +170,11 @@ func spawnExecuteBlocksStage(stateDB ethdb.Database, blockchain BlockChain) (uin
 			uncommitedIncarnations = make(map[common.Address]uint64)
 			log.Info("State batch committed", "in", time.Since(start))
 		}
-		/*
 		if changeBatch.BatchSize() >= ChangeBatchSize {
 			if _, err = changeBatch.Commit(); err != nil {
 				return 0, err
 			}
 		}
-		*/
 		/*
 			if blockNum-profileNumber == 100000 {
 				// Flush the profiler
@@ -188,12 +186,10 @@ func spawnExecuteBlocksStage(stateDB ethdb.Database, blockchain BlockChain) (uin
 	if err != nil {
 		return atomic.LoadUint64(&nextBlockNumber) - 1, fmt.Errorf("sync Execute: failed to write state batch commit: %v", err)
 	}
-	/*
 	_, err = changeBatch.Commit()
 	if err != nil {
 		return atomic.LoadUint64(&nextBlockNumber) - 1, fmt.Errorf("sync Execute: failed to write change batch commit: %v", err)
 	}
-	*/
 	return atomic.LoadUint64(&nextBlockNumber) - 1 /* the last processed block */, nil
 }
 

--- a/eth/downloader/stagedsync_stage_execute.go
+++ b/eth/downloader/stagedsync_stage_execute.go
@@ -124,16 +124,16 @@ func spawnExecuteBlocksStage(stateDB ethdb.Database, blockchain BlockChain) (uin
 
 		if core.UsePlainStateExecution {
 			plainReader := state.NewPlainStateReader(stateBatch, uncommitedIncarnations)
-			//plainReader.SetAccountCache(accountCache)
+			plainReader.SetAccountCache(accountCache)
 			//plainReader.SetStorageCache(storageCache)
-			//plainReader.SetCodeCache(codeCache)
-			//plainReader.SetCodeSizeCache(codeSizeCache)
+			plainReader.SetCodeCache(codeCache)
+			plainReader.SetCodeSizeCache(codeSizeCache)
 			stateReader = plainReader
 			plainWriter := state.NewPlainStateWriter(stateBatch, changeBatch, blockNum, uncommitedIncarnations)
-			//plainWriter.SetAccountCache(accountCache)
+			plainWriter.SetAccountCache(accountCache)
 			//plainWriter.SetStorageCache(storageCache)
-			//plainWriter.SetCodeCache(codeCache)
-			//plainWriter.SetCodeSizeCache(codeSizeCache)
+			plainWriter.SetCodeCache(codeCache)
+			plainWriter.SetCodeSizeCache(codeSizeCache)
 			stateWriter = plainWriter
 		} else {
 			hashStateReader := state.NewDbStateReader(stateBatch, uncommitedIncarnations)


### PR DESCRIPTION
The problem was that `codeCache` was not cleared when account was deleted. Also, old storage was visible through the `storageCache`.
Also changed LRU cache to fastcache, because it allows keys that are byte slices (instead of arrays), and you can specify maximum size if bytes, not in number of objects.