### PR TITLE
Stop blockchain when terminating downloader

### DIFF
--- a/eth/downloader/downloader.go
+++ b/eth/downloader/downloader.go
@@ -231,6 +231,9 @@ type BlockChain interface {
 
 	// GetVMConfig is necessary for staged sync
 	GetVMConfig() *vm.Config
+
+	// Stop the import that is going on
+	Stop()
 }
 
 // New creates a new downloader to fetch hashes and blocks from remote peers.
@@ -615,6 +618,7 @@ func (d *Downloader) Terminate() {
 	fmt.Printf("=======================================\n")
 	fmt.Printf("d.Terminate() is called\n")
 	fmt.Printf("---------------------------------------\n")
+	d.blockchain.Stop()
 	// Close the termination channel (make sure double close is allowed)
 	d.quitLock.Lock()
 	select {

--- a/eth/downloader/downloader.go
+++ b/eth/downloader/downloader.go
@@ -602,9 +602,6 @@ func (d *Downloader) cancel() {
 // Cancel aborts all of the operations and waits for all download goroutines to
 // finish before returning.
 func (d *Downloader) Cancel() {
-	fmt.Printf("=======================================\n")
-	fmt.Printf("d.Cancel() is called\n")
-	fmt.Printf("---------------------------------------\n")
 	d.cancel()
 	d.cancelWg.Wait()
 
@@ -615,9 +612,6 @@ func (d *Downloader) Cancel() {
 // Terminate interrupts the downloader, canceling all pending operations.
 // The downloader cannot be reused after calling Terminate.
 func (d *Downloader) Terminate() {
-	fmt.Printf("=======================================\n")
-	fmt.Printf("d.Terminate() is called\n")
-	fmt.Printf("---------------------------------------\n")
 	d.blockchain.Stop()
 	// Close the termination channel (make sure double close is allowed)
 	d.quitLock.Lock()

--- a/eth/downloader/downloader.go
+++ b/eth/downloader/downloader.go
@@ -599,6 +599,9 @@ func (d *Downloader) cancel() {
 // Cancel aborts all of the operations and waits for all download goroutines to
 // finish before returning.
 func (d *Downloader) Cancel() {
+	fmt.Printf("=======================================\n")
+	fmt.Printf("d.Cancel() is called\n")
+	fmt.Printf("---------------------------------------\n")
 	d.cancel()
 	d.cancelWg.Wait()
 
@@ -609,6 +612,9 @@ func (d *Downloader) Cancel() {
 // Terminate interrupts the downloader, canceling all pending operations.
 // The downloader cannot be reused after calling Terminate.
 func (d *Downloader) Terminate() {
+	fmt.Printf("=======================================\n")
+	fmt.Printf("d.Terminate() is called\n")
+	fmt.Printf("---------------------------------------\n")
 	// Close the termination channel (make sure double close is allowed)
 	d.quitLock.Lock()
 	select {

--- a/eth/downloader/downloader_test.go
+++ b/eth/downloader/downloader_test.go
@@ -390,6 +390,9 @@ func (dl *downloadTester) GetHeader(common.Hash, uint64) *types.Header {
 	panic("not implemented and should not be called")
 }
 
+func (dl *downloadTester) Stop() {
+}
+
 type downloadTesterPeer struct {
 	dl            *downloadTester
 	id            string

--- a/eth/downloader/stagedsync_test.go
+++ b/eth/downloader/stagedsync_test.go
@@ -275,6 +275,9 @@ func (st *stagedSyncTester) sync(id string, td *big.Int) error {
 	return err
 }
 
+func (st *stagedSyncTester) Stop() {
+}
+
 type stagedSyncTesterPeer struct {
 	st    *stagedSyncTester
 	id    string


### PR DESCRIPTION
This brings the granularity of possible termination from between chain segments (which could take a long time to get imported) to individual blocks