### PR TITLE
Explicit incarnation map in the database for deleted contracts

### DIFF
--- a/common/dbutils/bucket.go
+++ b/common/dbutils/bucket.go
@@ -65,7 +65,7 @@ var (
 	//key - address
 	//value - incarnation of account when it was last deleted
 	IncarnationMapBucket = []byte("incarnationMap")
-	
+
 	//AccountChangeSetBucket keeps changesets of accounts
 	// key - encoded timestamp(block number)
 	// value - encoded ChangeSet{k - addrHash v - account(encoded).

--- a/common/dbutils/bucket.go
+++ b/common/dbutils/bucket.go
@@ -61,6 +61,11 @@ var (
 	//value - code hash
 	ContractCodeBucket = []byte("contractCode")
 
+	// Incarnations for deleted accounts
+	//key - address
+	//value - incarnation of account when it was last deleted
+	IncarnationMapBucket = []byte("incarnationMap")
+	
 	//AccountChangeSetBucket keeps changesets of accounts
 	// key - encoded timestamp(block number)
 	// value - encoded ChangeSet{k - addrHash v - account(encoded).

--- a/core/genesis.go
+++ b/core/genesis.go
@@ -19,6 +19,7 @@ package core
 import (
 	"bytes"
 	"context"
+	"encoding/binary"
 	"encoding/hex"
 	"encoding/json"
 	"errors"
@@ -29,6 +30,7 @@ import (
 	"github.com/holiman/uint256"
 
 	"github.com/ledgerwatch/turbo-geth/common"
+	"github.com/ledgerwatch/turbo-geth/common/dbutils"
 	"github.com/ledgerwatch/turbo-geth/common/hexutil"
 	"github.com/ledgerwatch/turbo-geth/common/math"
 	"github.com/ledgerwatch/turbo-geth/core/rawdb"
@@ -261,6 +263,14 @@ func (g *Genesis) ToBlock(db ethdb.Database, history bool) (*types.Block, *state
 
 		if len(account.Code) > 0 || len(account.Storage) > 0 {
 			statedb.SetIncarnation(addr, 1)
+		}
+		if len(account.Code) == 0 && len(account.Storage) > 0 {
+			// Special case for weird tests - inaccessible storage
+			var b [8]byte
+			binary.BigEndian.PutUint64(b[:], 1)
+			if err := db.Put(dbutils.IncarnationMapBucket, addr[:], b[:]); err != nil {
+				return nil, nil, nil, err
+			}
 		}
 	}
 	err := statedb.FinalizeTx(context.Background(), tds.TrieStateWriter())

--- a/core/state/readonly.go
+++ b/core/state/readonly.go
@@ -235,17 +235,8 @@ func (dbs *DbState) ReadAccountCodeSize(address common.Address, codeHash common.
 }
 
 func (dbs *DbState) ReadAccountIncarnation(address common.Address) (uint64, error) {
-	addrHash, err := common.HashData(address[:])
-	if err != nil {
-		return 0, err
-	}
-	incarnation, found, err := ethdb.GetHistoricalAccountIncarnation(dbs.db, addrHash, dbs.blockNr+1)
-	if err != nil {
-		return 0, err
-	}
-	if found {
-		return incarnation, nil
-	}
+	// We do not need to know the accurate incarnation value when DbState is used, because correct incarnation
+	// is stored in the account record
 	return 0, nil
 }
 

--- a/core/vm/gas_table_test.go
+++ b/core/vm/gas_table_test.go
@@ -94,7 +94,7 @@ func TestEIP2200(t *testing.T) {
 		s.CommitBlock(context.Background(), tds.DbStateWriter())
 
 		// re-initialize the state
-		state := state.New(state.NewDbStateReader(db, make(map[common.Address]uint64)))
+		state := state.New(state.NewDbStateReader(db))
 
 		vmctx := Context{
 			CanTransfer: func(IntraBlockState, common.Address, *big.Int) bool { return true },

--- a/eth/downloader/stagedsync_stage_execute_test.go
+++ b/eth/downloader/stagedsync_stage_execute_test.go
@@ -228,12 +228,12 @@ type stateWriterGen func(uint64) state.WriterWithChangeSets
 
 func hashedWriterGen(db ethdb.Database) stateWriterGen {
 	return func(blockNum uint64) state.WriterWithChangeSets {
-		return state.NewDbStateWriter(db, db, blockNum, make(map[common.Address]uint64))
+		return state.NewDbStateWriter(db, db, blockNum)
 	}
 }
 
 func plainWriterGen(db ethdb.Database) stateWriterGen {
 	return func(blockNum uint64) state.WriterWithChangeSets {
-		return state.NewPlainStateWriter(db, db, blockNum, make(map[common.Address]uint64))
+		return state.NewPlainStateWriter(db, db, blockNum)
 	}
 }


### PR DESCRIPTION
When pruning stage is implemented, the incarnation map can be pruned after all the storage records with expired incarnations are pruned away

Closes https://github.com/ledgerwatch/turbo-geth/issues/560