### PR TITLE
Enforce go mod tidy

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,6 +25,7 @@ jobs:
             - v1-pkg-cache
 
       - run: git submodule update --init --recursive
+      - run: go mod tidy && test -z "$(git status --porcelain)"
 
       - run: go mod download
       - run: go mod verify


### PR DESCRIPTION
CircleCI will fail if `go mod tidy` results differs from what is commited in the branch.