### PR TITLE
badger-compatible trie loader

### DIFF
--- a/trie/flatdb_sub_trie_loader.go
+++ b/trie/flatdb_sub_trie_loader.go
@@ -279,9 +279,9 @@ func (fstl *FlatDbSubTrieLoader) iteration(c, ih ethdb.Cursor, first bool) error
 		fstl.itemPresent = true
 		if len(fstl.k) > common.HashLength {
 			fstl.itemType = StorageStreamItem
-			fstl.storageKey = fstl.k
+			fstl.storageKey = append(fstl.storageKey[:0], fstl.k...)
 			fstl.hashValue = nil
-			fstl.storageValue = fstl.v
+			fstl.storageValue = append(fstl.storageValue[:0], fstl.v...)
 			if fstl.k, fstl.v, err = c.Next(); err != nil {
 				return err
 			}
@@ -290,7 +290,7 @@ func (fstl *FlatDbSubTrieLoader) iteration(c, ih ethdb.Cursor, first bool) error
 			}
 		} else {
 			fstl.itemType = AccountStreamItem
-			fstl.accountKey = fstl.k
+			fstl.accountKey = append(fstl.accountKey[:0], fstl.k...)
 			fstl.storageKey = nil
 			fstl.hashValue = nil
 			if err := fstl.accountValue.DecodeForStorage(fstl.v); err != nil {
@@ -363,15 +363,15 @@ func (fstl *FlatDbSubTrieLoader) iteration(c, ih ethdb.Cursor, first bool) error
 	fstl.itemPresent = true
 	if len(fstl.ihK) > common.HashLength {
 		fstl.itemType = SHashStreamItem
-		fstl.storageKey = fstl.ihK
-		fstl.hashValue = fstl.ihV
+		fstl.storageKey = append(fstl.storageKey[:0], fstl.ihK...)
+		fstl.hashValue = append(fstl.hashValue[:0], fstl.ihV...)
 		fstl.storageValue = nil
 		fstl.witnessSize = fstl.getWitnessSize(fstl.ihK)
 	} else {
 		fstl.itemType = AHashStreamItem
-		fstl.accountKey = fstl.ihK
+		fstl.accountKey = append(fstl.accountKey[:0], fstl.ihK...)
 		fstl.storageKey = nil
-		fstl.hashValue = fstl.ihV
+		fstl.hashValue = append(fstl.hashValue[:0], fstl.ihV...)
 		fstl.witnessSize = fstl.getWitnessSize(fstl.ihK)
 	}
 


### PR DESCRIPTION
- badger-compatible trie loader (key and value in badger iterator valid only until .Next/.Seek call)
- disable badger compaction for in-mem mode
- fixed bug in kv_badger:Put method: did pass buffer `c.prefix` to `badger.Set` method

- kv_badger to return key=[]byte instead of nil when err!=nil. It's about following next api definition in AbstractKV.md: 
Methods .First, .Next, .Seek - can return error. If err!=nil then key SHOULD be !=nil (can be []byte{} for example). Then looping code will look as: 
```go
for k, v, err := c.First(); k != nil; k, v, err = c.Next() {
    if err != nil {
        return err
    }
    // logic
}
``` 