### PR TITLE
increase golint confidence level to reduce renaming advises

### DIFF
--- a/.golangci/step1.yml
+++ b/.golangci/step1.yml
@@ -13,7 +13,7 @@ linters:
 
 linters-settings:
   golint:
-    min-confidence: 0
+    min-confidence: 1
   goconst:
     min-len: 2
     min-occurrences: 2

--- a/.golangci/step1.yml
+++ b/.golangci/step1.yml
@@ -6,7 +6,7 @@ linters:
     - errcheck
     - goconst
     - gofmt
-    - golint
+#    - golint
     - interfacer
 
   disable-all: true


### PR DESCRIPTION
To silent advises like: `method ChainId should be ChainID (golint)`
because go-ethereum doesn't follow it (will harder to merge)