### PR TITLE
KV: Tx objects pool 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -91,7 +91,7 @@ ios:
 	@echo "Import \"$(GOBIN)/Geth.framework\" to use the library."
 
 test: semantics/z3/build/libz3.a all
-	TEST_DB=bolt $(GORUN) build/ci.go test
+	TEST_DB=lmdb $(GORUN) build/ci.go test
 
 test-lmdb: semantics/z3/build/libz3.a all
 	TEST_DB=lmdb $(GORUN) build/ci.go test

--- a/Makefile
+++ b/Makefile
@@ -91,7 +91,7 @@ ios:
 	@echo "Import \"$(GOBIN)/Geth.framework\" to use the library."
 
 test: semantics/z3/build/libz3.a all
-	TEST_DB=lmdb $(GORUN) build/ci.go test
+	TEST_DB=bolt $(GORUN) build/ci.go test
 
 test-lmdb: semantics/z3/build/libz3.a all
 	TEST_DB=lmdb $(GORUN) build/ci.go test

--- a/cmd/hack/hack.go
+++ b/cmd/hack/hack.go
@@ -779,8 +779,9 @@ func execToBlock(chaindata string, block uint64, fromScratch bool) {
 	if fromScratch {
 		os.Remove("statedb")
 	}
-	stateDB, err := ethdb.NewBadgerDatabase("statedb")
-	check(err)
+	stateDB := ethdb.NewObjectDatabase(ethdb.NewLMDB().Path("statedb").MustOpen(context.Background()))
+	//stateDB, err := ethdb.NewBadgerDatabase("statedb")
+	//check(err)
 	defer stateDB.Close()
 
 	//_, _, _, err = core.SetupGenesisBlock(stateDB, core.DefaultGenesisBlock())
@@ -806,7 +807,7 @@ Loop:
 	for i := importedBn; i <= block; i++ {
 		lastBlock = bcb.GetBlockByNumber(i)
 		blocks = append(blocks, lastBlock)
-		if len(blocks) >= 100 || i == block {
+		if len(blocks) >= 20000 || i == block {
 			_, err = bc.InsertChain(context.Background(), blocks)
 			if err != nil {
 				log.Error("Could not insert blocks (group)", "number", len(blocks), "error", err)
@@ -821,7 +822,7 @@ Loop:
 			}
 			blocks = types.Blocks{}
 		}
-		if i%1000 == 0 {
+		if i%20000 == 0 {
 			fmt.Printf("Inserted %dK, %s \n", i/1000, time.Since(now))
 		}
 	}

--- a/common/dbutils/bucket.go
+++ b/common/dbutils/bucket.go
@@ -1,6 +1,11 @@
 package dbutils
 
-import "github.com/ledgerwatch/turbo-geth/metrics"
+import (
+	"bytes"
+	"sort"
+
+	"github.com/ledgerwatch/turbo-geth/metrics"
+)
 
 // The fields below define the low level database schema prefixing.
 var (
@@ -149,6 +154,9 @@ var (
 	CliqueBucket    = []byte("clique-")
 )
 
+// Buckets - list of all buckets. App will panic if some bucket is not in this list.
+// This list will be sorted in `init` method.
+// BucketsIndex - can be used to find index in sorted version of Buckets list by name
 var Buckets = [][]byte{
 	CurrentStateBucket,
 	AccountsHistoryBucket,
@@ -192,4 +200,16 @@ var Buckets = [][]byte{
 	PlainContractCodeBucket,
 	PlainAccountChangeSetBucket,
 	PlainStorageChangeSetBucket,
+}
+
+var BucketsIndex = map[string]int{}
+
+func init() {
+	sort.SliceStable(Buckets, func(i, j int) bool {
+		return bytes.Compare(Buckets[i], Buckets[j]) < 0
+	})
+
+	for i := range Buckets {
+		BucketsIndex[string(Buckets[i])] = i
+	}
 }

--- a/ethdb/badger_db.go
+++ b/ethdb/badger_db.go
@@ -113,7 +113,7 @@ func NewEphemeralBadger() (*BadgerDatabase, error) {
 }
 
 func (db *BadgerDatabase) KV() KV {
-	return &badgerDB{badger: db.db}
+	return &badgerKV{badger: db.db}
 }
 
 // Close closes the database.

--- a/ethdb/badger_db.go
+++ b/ethdb/badger_db.go
@@ -20,7 +20,6 @@ import (
 	"bytes"
 	"context"
 	"os"
-	"runtime"
 	"time"
 
 	"github.com/dgraph-io/badger/v2"
@@ -29,12 +28,8 @@ import (
 	"github.com/ledgerwatch/turbo-geth/log"
 )
 
-// https://github.com/dgraph-io/badger#frequently-asked-questions
-// https://groups.google.com/forum/#!topic/golang-nuts/jPb_h3TvlKE/discussion
-const minGoMaxProcs = 128
-
 // https://github.com/dgraph-io/badger#garbage-collection
-const gcPeriod = 35 * time.Minute
+const gcPeriod = 5 * time.Minute
 
 // BadgerDatabase is a wrapper over BadgerDb,
 // compatible with the Database interface.
@@ -50,11 +45,6 @@ type BadgerDatabase struct {
 func NewBadgerDatabase(dir string) (*BadgerDatabase, error) {
 	logger := log.New("database", dir)
 
-	oldMaxProcs := runtime.GOMAXPROCS(0)
-	if oldMaxProcs < minGoMaxProcs {
-		runtime.GOMAXPROCS(minGoMaxProcs)
-		logger.Info("Bumping GOMAXPROCS", "old", oldMaxProcs, "new", minGoMaxProcs)
-	}
 	options := badger.DefaultOptions(dir).WithMaxTableSize(128 << 20) // 128Mb, default 64Mb
 
 	db, err := badger.Open(options)
@@ -69,7 +59,7 @@ func NewBadgerDatabase(dir string) (*BadgerDatabase, error) {
 		i := 0
 		for range ticker.C {
 		nextFile:
-			err := db.RunValueLogGC(0.5)
+			err := db.RunValueLogGC(0.7)
 			if err == nil {
 				i++
 				goto nextFile
@@ -79,13 +69,6 @@ func NewBadgerDatabase(dir string) (*BadgerDatabase, error) {
 				i = 0
 				continue
 			}
-			logger.Warn("Badger GC error", "err", err)
-		}
-	}()
-
-	go func() {
-		for range time.NewTicker(1 * time.Minute).C {
-			logger.Info("Badger Metrics", "BfCache", db.BfCacheMetrics().String(), "DataCache", db.DataCacheMetrics().String())
 		}
 	}()
 

--- a/ethdb/kv_badger.go
+++ b/ethdb/kv_badger.go
@@ -12,8 +12,8 @@ import (
 )
 
 var (
-	badgerTxPool     = &sync.Pool{New: func() interface{} { return &badgerTx{} }}     // pool of ethdb.badgerTx objects
-	badgerCursorPool = &sync.Pool{New: func() interface{} { return &badgerCursor{} }} // pool of ethdb.badgerCursor objects
+	badgerTxPool     = sync.Pool{New: func() interface{} { return &badgerTx{} }}     // pool of ethdb.badgerTx objects
+	badgerCursorPool = sync.Pool{New: func() interface{} { return &badgerCursor{} }} // pool of ethdb.badgerCursor objects
 )
 
 type badgerOpts struct {
@@ -71,14 +71,12 @@ func (opts badgerOpts) Open(ctx context.Context) (KV, error) {
 		}()
 	}
 
-	db := &badgerKV{
+	return &badgerKV{
 		opts:     opts,
 		badger:   badgerDB,
 		log:      logger,
 		gcTicker: gcTicker,
-	}
-
-	return db, nil
+	}, nil
 }
 
 func (opts badgerOpts) MustOpen(ctx context.Context) KV {

--- a/ethdb/kv_badger.go
+++ b/ethdb/kv_badger.go
@@ -101,7 +101,7 @@ type badgerDB struct {
 	badger   *badger.DB
 	gcTicker *time.Ticker
 	log      log.Logger
-	txPool   sync.Pool
+	txPool   sync.Pool // pool of ethdb.badgerTx objects
 }
 
 func NewBadger() badgerOpts {

--- a/ethdb/kv_badger.go
+++ b/ethdb/kv_badger.go
@@ -297,7 +297,7 @@ func (c *badgerCursor) initCursor() {
 	}
 
 	c.badger = c.bucket.tx.badger.NewIterator(c.badgerOpts)
-	// add to auto-closeCursors on end of transactions
+	// add to auto-close on end of transactions
 	if c.bucket.tx.badgerIterators == nil {
 		c.bucket.tx.badgerIterators = make([]*badger.Iterator, 0, 1)
 	}

--- a/ethdb/kv_bolt.go
+++ b/ethdb/kv_bolt.go
@@ -12,8 +12,8 @@ import (
 )
 
 var (
-	boltTxPool     = &sync.Pool{New: func() interface{} { return &boltTx{} }}
-	boltCursorPool = &sync.Pool{New: func() interface{} { return &boltCursor{} }}
+	boltTxPool     = sync.Pool{New: func() interface{} { return &boltTx{} }}
+	boltCursorPool = sync.Pool{New: func() interface{} { return &boltCursor{} }}
 )
 
 type boltOpts struct {
@@ -87,13 +87,12 @@ func (opts boltOpts) WrapBoltDB(boltDB *bolt.DB) (KV, error) {
 			return nil, err
 		}
 	}
-	db := &BoltKV{
+
+	return &BoltKV{
 		opts: opts,
 		bolt: boltDB,
 		log:  log.New("bolt_db", opts.path),
-	}
-
-	return db, nil
+	}, nil
 }
 
 func (opts boltOpts) Open(ctx context.Context) (db KV, err error) {

--- a/ethdb/kv_bolt.go
+++ b/ethdb/kv_bolt.go
@@ -20,7 +20,7 @@ type BoltKV struct {
 	opts   boltOpts
 	bolt   *bolt.DB
 	log    log.Logger
-	txPool sync.Pool
+	txPool sync.Pool // pool of ethdb.boltTx objects
 }
 type boltTx struct {
 	ctx context.Context
@@ -67,9 +67,9 @@ func (opts boltOpts) Path(path string) boltOpts {
 	return opts
 }
 
-// WrapBoltDb provides a way for the code to gradually migrate
+// WrapBoltDB provides a way for the code to gradually migrate
 // to the abstract interface
-func (opts boltOpts) WrapBoltDb(boltDB *bolt.DB) (KV, error) {
+func (opts boltOpts) WrapBoltDB(boltDB *bolt.DB) (KV, error) {
 	if !opts.Bolt.ReadOnly {
 		if err := boltDB.Update(func(tx *bolt.Tx) error {
 			for _, name := range dbutils.Buckets {
@@ -100,7 +100,7 @@ func (opts boltOpts) Open(ctx context.Context) (db KV, err error) {
 	if err != nil {
 		return nil, err
 	}
-	return opts.WrapBoltDb(boltDB)
+	return opts.WrapBoltDB(boltDB)
 }
 
 func (opts boltOpts) MustOpen(ctx context.Context) KV {

--- a/ethdb/kv_bolt.go
+++ b/ethdb/kv_bolt.go
@@ -17,21 +17,22 @@ type boltOpts struct {
 }
 
 type BoltKV struct {
-	opts   boltOpts
-	bolt   *bolt.DB
-	log    log.Logger
-	txPool *sync.Pool // pool of ethdb.boltTx objects
+	opts       boltOpts
+	bolt       *bolt.DB
+	log        log.Logger
+	txPool     *sync.Pool // pool of ethdb.boltTx objects
+	cursorPool *sync.Pool // pool of ethdb.boltCursor objects
 }
-type boltTx struct {
-	ctx context.Context
-	db  *BoltKV
 
-	bolt *bolt.Tx
+type boltTx struct {
+	ctx     context.Context
+	db      *BoltKV
+	bolt    *bolt.Tx
+	cursors []*boltCursor
 }
 
 type boltBucket struct {
-	tx *boltTx
-
+	tx      *boltTx
 	bolt    *bolt.Bucket
 	nameLen uint
 }
@@ -49,7 +50,7 @@ type boltCursor struct {
 }
 
 type noValuesBoltCursor struct {
-	boltCursor
+	*boltCursor
 }
 
 func (opts boltOpts) InMem() boltOpts {
@@ -90,6 +91,9 @@ func (opts boltOpts) WrapBoltDB(boltDB *bolt.DB) (KV, error) {
 	}
 	db.txPool = &sync.Pool{
 		New: func() interface{} { return &boltTx{db: db} },
+	}
+	db.cursorPool = &sync.Pool{
+		New: func() interface{} { return &boltCursor{} },
 	}
 
 	return db, nil
@@ -161,6 +165,7 @@ func (db *BoltKV) View(ctx context.Context, f func(tx Tx) error) (err error) {
 	t := db.txPool.Get().(*boltTx)
 	defer db.txPool.Put(t)
 	t.ctx = ctx
+	defer t.closeCursors()
 	return db.bolt.View(func(tx *bolt.Tx) error {
 		t.bolt = tx
 		return f(t)
@@ -171,6 +176,7 @@ func (db *BoltKV) Update(ctx context.Context, f func(tx Tx) error) (err error) {
 	t := db.txPool.Get().(*boltTx)
 	defer db.txPool.Put(t)
 	t.ctx = ctx
+	defer t.closeCursors()
 	return db.bolt.Update(func(tx *bolt.Tx) error {
 		t.bolt = tx
 		return f(t)
@@ -178,13 +184,22 @@ func (db *BoltKV) Update(ctx context.Context, f func(tx Tx) error) (err error) {
 }
 
 func (tx *boltTx) Commit(ctx context.Context) error {
+	defer tx.closeCursors()
 	// could not put tx back to pool, because tx can be used by app code after commit
 	return tx.bolt.Commit()
 }
 
 func (tx *boltTx) Rollback() error {
+	defer tx.closeCursors()
 	// could not put tx back to pool, because tx can be used by app code after rollback
 	return tx.bolt.Rollback()
+}
+
+func (tx *boltTx) closeCursors() {
+	for _, c := range tx.cursors {
+		tx.db.cursorPool.Put(c)
+	}
+	tx.cursors = tx.cursors[:0]
 }
 
 func (tx *boltTx) Yield() {
@@ -212,7 +227,7 @@ func (c *boltCursor) Prefetch(v uint) Cursor {
 }
 
 func (c *boltCursor) NoValues() NoValuesCursor {
-	return &noValuesBoltCursor{boltCursor: *c}
+	return &noValuesBoltCursor{boltCursor: c}
 }
 
 func (b boltBucket) Get(key []byte) (val []byte, err error) {
@@ -246,14 +261,20 @@ func (b boltBucket) Delete(key []byte) error {
 }
 
 func (b boltBucket) Cursor() Cursor {
-	return &boltCursor{bucket: b, ctx: b.tx.ctx, bolt: b.bolt.Cursor()}
-}
-
-func (c *boltCursor) initCursor() {
-	if c.bolt != nil {
-		return
+	c := b.tx.db.cursorPool.Get().(*boltCursor)
+	c.ctx = b.tx.ctx
+	c.bucket = b
+	c.prefix = nil
+	c.k = nil
+	c.v = nil
+	c.err = nil
+	c.bolt = b.bolt.Cursor()
+	// add to auto-close on end of transactions
+	if b.tx.cursors == nil {
+		b.tx.cursors = make([]*boltCursor, 0, 1)
 	}
-	c.bolt = c.bucket.bolt.Cursor()
+	b.tx.cursors = append(b.tx.cursors, c)
+	return c
 }
 
 func (c *boltCursor) First() ([]byte, []byte, error) {

--- a/ethdb/kv_bolt.go
+++ b/ethdb/kv_bolt.go
@@ -20,7 +20,7 @@ type BoltKV struct {
 	opts   boltOpts
 	bolt   *bolt.DB
 	log    log.Logger
-	txPool sync.Pool // pool of ethdb.boltTx objects
+	txPool *sync.Pool // pool of ethdb.boltTx objects
 }
 type boltTx struct {
 	ctx context.Context
@@ -88,7 +88,7 @@ func (opts boltOpts) WrapBoltDB(boltDB *bolt.DB) (KV, error) {
 		bolt: boltDB,
 		log:  log.New("bolt_db", opts.path),
 	}
-	db.txPool = sync.Pool{
+	db.txPool = &sync.Pool{
 		New: func() interface{} { return &boltTx{db: db} },
 	}
 

--- a/ethdb/kv_lmdb.go
+++ b/ethdb/kv_lmdb.go
@@ -238,9 +238,9 @@ type lmdbCursor struct {
 func (db *LmdbKV) View(ctx context.Context, f func(tx Tx) error) (err error) {
 	t := db.txPool.Get().(*lmdbTx)
 	defer db.txPool.Put(t)
-	defer t.closeCursors()
 	t.ctx = ctx
 	return db.lmdbTxPool.View(func(tx *lmdb.Txn) error {
+		defer t.closeCursors()
 		t.tx = tx
 		return f(t)
 	})
@@ -249,9 +249,9 @@ func (db *LmdbKV) View(ctx context.Context, f func(tx Tx) error) (err error) {
 func (db *LmdbKV) Update(ctx context.Context, f func(tx Tx) error) (err error) {
 	t := db.txPool.Get().(*lmdbTx)
 	defer db.txPool.Put(t)
-	defer t.closeCursors()
 	t.ctx = ctx
 	return db.env.Update(func(tx *lmdb.Txn) error {
+		defer t.closeCursors()
 		t.tx = tx
 		return f(t)
 	})
@@ -360,7 +360,7 @@ func (c *lmdbCursor) initCursor() error {
 		return err
 	}
 
-	// add to auto-closeCursors on end of transactions
+	// add to auto-close on end of transactions
 	if c.bucket.tx.cursors == nil {
 		c.bucket.tx.cursors = make([]*lmdb.Cursor, 0, 1)
 	}

--- a/ethdb/kv_lmdb.go
+++ b/ethdb/kv_lmdb.go
@@ -126,7 +126,7 @@ func (opts lmdbOpts) Open(ctx context.Context) (KV, error) {
 		buckets:    buckets,
 		lmdbTxPool: lmdbpool.NewTxnPool(env),
 	}
-	db.txPool = sync.Pool{
+	db.txPool = &sync.Pool{
 		New: func() interface{} { return &lmdbTx{db: db} },
 	}
 	return db, nil
@@ -146,7 +146,7 @@ type LmdbKV struct {
 	log        log.Logger
 	buckets    map[string]lmdb.DBI
 	lmdbTxPool *lmdbpool.TxnPool // pool of lmdb.Txn objects
-	txPool     sync.Pool         // pool of ethdb.lmdbTx objects
+	txPool     *sync.Pool        // pool of ethdb.lmdbTx objects
 }
 
 func NewLMDB() lmdbOpts {

--- a/ethdb/kv_lmdb.go
+++ b/ethdb/kv_lmdb.go
@@ -18,8 +18,8 @@ import (
 )
 
 var (
-	lmdbKvTxPool     = &sync.Pool{New: func() interface{} { return &lmdbTx{} }}
-	lmdbKvCursorPool = &sync.Pool{New: func() interface{} { return &lmdbCursor{} }}
+	lmdbKvTxPool     = sync.Pool{New: func() interface{} { return &lmdbTx{} }}
+	lmdbKvCursorPool = sync.Pool{New: func() interface{} { return &lmdbCursor{} }}
 )
 
 type lmdbOpts struct {
@@ -137,16 +137,14 @@ func (opts lmdbOpts) Open(ctx context.Context) (KV, error) {
 		}
 	}()
 
-	db := &LmdbKV{
+	return &LmdbKV{
 		opts:            opts,
 		env:             env,
 		log:             logger,
 		buckets:         buckets,
 		lmdbTxPool:      lmdbpool.NewTxnPool(env),
 		lmdbCursorPools: make([]sync.Pool, len(dbutils.Buckets)),
-	}
-
-	return db, nil
+	}, nil
 }
 
 func (opts lmdbOpts) MustOpen(ctx context.Context) KV {

--- a/ethdb/kv_remote.go
+++ b/ethdb/kv_remote.go
@@ -19,7 +19,7 @@ type RemoteKV struct {
 	opts   remoteOpts
 	remote *remote.DB
 	log    log.Logger
-	txPool sync.Pool // pool of ethdb.remoteTx objects
+	txPool *sync.Pool // pool of ethdb.remoteTx objects
 }
 
 type remoteTx struct {
@@ -92,7 +92,7 @@ func (opts remoteOpts) Open(ctx context.Context) (KV, error) {
 		log:    log.New("remote_db", opts.Remote.DialAddress),
 	}
 
-	db.txPool = sync.Pool{
+	db.txPool = &sync.Pool{
 		New: func() interface{} { return &remoteTx{db: db} },
 	}
 

--- a/ethdb/kv_remote.go
+++ b/ethdb/kv_remote.go
@@ -48,7 +48,7 @@ type remoteCursor struct {
 }
 
 type remoteNoValuesCursor struct {
-	remoteCursor
+	*remoteCursor
 }
 
 func (opts remoteOpts) ReadOnly() remoteOpts {
@@ -179,7 +179,7 @@ func (c *remoteCursor) Prefetch(v uint) Cursor {
 
 func (c *remoteCursor) NoValues() NoValuesCursor {
 	c.remote = c.remote.NoValues()
-	return &remoteNoValuesCursor{remoteCursor: *c}
+	return &remoteNoValuesCursor{remoteCursor: c}
 }
 
 func (b remoteBucket) Get(key []byte) (val []byte, err error) {

--- a/ethdb/kv_remote.go
+++ b/ethdb/kv_remote.go
@@ -19,7 +19,7 @@ type RemoteKV struct {
 	opts   remoteOpts
 	remote *remote.DB
 	log    log.Logger
-	txPool sync.Pool
+	txPool sync.Pool // pool of ethdb.remoteTx objects
 }
 
 type remoteTx struct {

--- a/ethdb/object_db.go
+++ b/ethdb/object_db.go
@@ -20,6 +20,8 @@ package ethdb
 import (
 	"bytes"
 	"context"
+	"fmt"
+	"time"
 
 	"github.com/ledgerwatch/turbo-geth/common"
 	"github.com/ledgerwatch/turbo-geth/common/dbutils"
@@ -50,6 +52,9 @@ func (db *ObjectDatabase) Put(bucket, key []byte, value []byte) error {
 }
 
 func (db *ObjectDatabase) MultiPut(tuples ...[]byte) (uint64, error) {
+	defer func(t time.Time) { fmt.Println("object_db.go:54", time.Since(t)) }(time.Now())
+	defer fmt.Printf("ON: %d\n", len(tuples)/3)
+
 	//var savedTx Tx
 	err := db.kv.Update(context.Background(), func(tx Tx) error {
 		for bucketStart := 0; bucketStart < len(tuples); {
@@ -73,10 +78,6 @@ func (db *ObjectDatabase) MultiPut(tuples ...[]byte) (uint64, error) {
 					}
 				}
 			}
-			// TODO: Add MultiPut to abstraction
-			//if err := b.MultiPut(pairs...); err != nil {
-			//	return err
-			//}
 
 			bucketStart = bucketEnd
 		}

--- a/ethdb/object_db.go
+++ b/ethdb/object_db.go
@@ -303,7 +303,7 @@ func (db *ObjectDatabase) MemCopy() Database {
 		mem = NewObjectDatabase(NewLMDB().InMem().MustOpen(context.Background()))
 	case *BoltKV:
 		mem = NewObjectDatabase(NewBolt().InMem().MustOpen(context.Background()))
-	case *badgerDB:
+	case *badgerKV:
 		mem = NewObjectDatabase(NewBadger().InMem().MustOpen(context.Background()))
 	}
 

--- a/ethdb/object_db.go
+++ b/ethdb/object_db.go
@@ -20,8 +20,6 @@ package ethdb
 import (
 	"bytes"
 	"context"
-	"fmt"
-	"time"
 
 	"github.com/ledgerwatch/turbo-geth/common"
 	"github.com/ledgerwatch/turbo-geth/common/dbutils"
@@ -52,9 +50,6 @@ func (db *ObjectDatabase) Put(bucket, key []byte, value []byte) error {
 }
 
 func (db *ObjectDatabase) MultiPut(tuples ...[]byte) (uint64, error) {
-	defer func(t time.Time) { fmt.Println("object_db.go:54", time.Since(t)) }(time.Now())
-	defer fmt.Printf("ON: %d\n", len(tuples)/3)
-
 	//var savedTx Tx
 	err := db.kv.Update(context.Background(), func(tx Tx) error {
 		for bucketStart := 0; bucketStart < len(tuples); {

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/ledgerwatch/turbo-geth
 go 1.13
 
 require (
-	github.com/AskAlexSharov/lmdb-go v1.8.1-0.20200529061129-bb3efead8192
+	github.com/AskAlexSharov/lmdb-go v1.8.1-0.20200608080821-6fdb53b47e78
 	github.com/Azure/azure-storage-blob-go v0.8.0
 	github.com/Azure/go-autorest/autorest/adal v0.8.3 // indirect
 	github.com/JekaMas/notify v0.9.4

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,6 @@
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
-github.com/AskAlexSharov/lmdb-go v1.8.1-0.20200529061129-bb3efead8192 h1:UqCOs4fjr4Tuaq+yvibtyrkniFDGDtD42Sw6CPXlMaU=
-github.com/AskAlexSharov/lmdb-go v1.8.1-0.20200529061129-bb3efead8192/go.mod h1:k7Jo/kN60Hq1MTBwsVSp2JllEs5Tyhd4MZ7tY9smjeA=
+github.com/AskAlexSharov/lmdb-go v1.8.1-0.20200608080821-6fdb53b47e78 h1:oHoQ7THIToKhelqoWL296YCGV8yogP4KtQQuqfPMKO4=
+github.com/AskAlexSharov/lmdb-go v1.8.1-0.20200608080821-6fdb53b47e78/go.mod h1:k7Jo/kN60Hq1MTBwsVSp2JllEs5Tyhd4MZ7tY9smjeA=
 github.com/Azure/azure-pipeline-go v0.2.1 h1:OLBdZJ3yvOn2MezlWvbrBMTEUQC72zAftRZOMdj5HYo=
 github.com/Azure/azure-pipeline-go v0.2.1/go.mod h1:UGSo8XybXnIGZ3epmeBw7Jdz+HiUVpqIlpz/HKHylF4=
 github.com/Azure/azure-storage-blob-go v0.8.0 h1:53qhf0Oxa0nOjgbDeeYPUeyiNmafAFEY95rZLK0Tj6o=


### PR DESCRIPTION
Lmdb internal objects reuse (built-in feature of lmdb):
- lmdb read transactions pool
- lmdb pool of cursors (of read transactions)

And kv abstraction objects reuse: 
- lmdbKV pools of all tx and cursor objects
- boltKV pools of all tx  and cursor objects
- badgerKV pools of all tx  and cursor objects