### PR TITLE
Enable golint back but with conditions

### DIFF
--- a/.golangci/step1.yml
+++ b/.golangci/step1.yml
@@ -2,20 +2,25 @@ run:
   deadline: 10m
 
 linters:
+  disable-all: true
   enable:
     - errcheck
     - goconst
     - gofmt
-#    - golint
+    - golint
     - interfacer
-
-  disable-all: true
 
 linters-settings:
   golint:
-    min-confidence: 1
+    min-confidence: 0
   goconst:
     min-len: 2
     min-occurrences: 2
   gofmt:
     auto-fix: false
+
+issues:
+  exclude-rules:
+    - linters:
+        - golint
+      text: "should be"

--- a/.golangci/step2.yml
+++ b/.golangci/step2.yml
@@ -2,12 +2,13 @@ run:
   deadline: 10m
 
 linters:
+  disable-all: true
   enable:
     - govet
     - structcheck
     - stylecheck
-
-  disable-all: true
+    - staticcheck
+    - goerr113
 
 linters-settings:
   govet:
@@ -16,3 +17,10 @@ linters-settings:
 issues:
   exclude:
     - composites
+  exclude-rules:
+    - linters:
+        - goerr113
+      text: "do not define dynamic errors"
+    - linters:
+        - stylecheck
+      text: "(should be|should have name of the form)"

--- a/.golangci/step3.yml
+++ b/.golangci/step3.yml
@@ -2,6 +2,7 @@ run:
   deadline: 10m
 
 linters:
+  disable-all: true
   enable:
     - unconvert
     - unparam
@@ -10,5 +11,4 @@ linters:
     - nakedret
     - prealloc
     - deadcode
-
-  disable-all: true
+    - gosimple

--- a/.golangci/step4.yml
+++ b/.golangci/step4.yml
@@ -2,11 +2,19 @@ run:
   deadline: 10m
 
 linters:
+  disable-all: true
   enable:
     - gosec
     - ineffassign
     - depguard
     - typecheck
-    - megacheck
+    - unused
+    - misspell
 
-  disable-all: true
+issues:
+  exclude-rules:
+    # Exclude some linters from running on tests files.
+    - path: _test\.go
+      linters:
+        - gosec
+        - unused

--- a/cmd/state/stateless/stateless.go
+++ b/cmd/state/stateless/stateless.go
@@ -65,7 +65,7 @@ func runBlock(ibs *state.IntraBlockState, txnWriter state.StateWriter, blockWrit
 
 	ctx := chainConfig.WithEIPsFlags(context.Background(), header.Number)
 	if err := ibs.CommitBlock(ctx, blockWriter); err != nil {
-		return nil, fmt.Errorf("commiting block %d failed: %v", block.NumberU64(), err)
+		return nil, fmt.Errorf("committing block %d failed: %v", block.NumberU64(), err)
 	}
 	return receipts, nil
 }


### PR DESCRIPTION
- Enable golint but hide recommendations of changing `Db` to `DB`
- Add new linter which checks that used `errors.Is` instead of direct `==` of errors
- Remove `megacheck` because enable all sub-linters which it has
- Don't run `gosec` and `unused` linters on test files