### PR TITLE
stagedsync: allow long stages/unwinds to be interrupted

### DIFF
--- a/cmd/hack/hack.go
+++ b/cmd/hack/hack.go
@@ -2048,7 +2048,7 @@ func resetState(chaindata string) {
 	core.UsePlainStateExecution = true
 	_, _, err = core.DefaultGenesisBlock().CommitGenesisState(db, false)
 	check(err)
-	err = stages.SaveStageProgress(db, stages.Execution, 0)
+	err = stages.SaveStageProgress(db, stages.Execution, 0, nil)
 	check(err)
 	fmt.Printf("Reset state done\n")
 }
@@ -2075,7 +2075,7 @@ func resetHashedState(chaindata string) {
 		return nil
 	})
 	check(err)
-	err = stages.SaveStageProgress(db, stages.HashState, 0)
+	err = stages.SaveStageProgress(db, stages.HashState, 0, nil)
 	check(err)
 	fmt.Printf("Reset hashed state done\n")
 }
@@ -2088,11 +2088,11 @@ func resetHistoryIndex(chaindata string) {
 	db.DeleteBucket(dbutils.AccountsHistoryBucket)
 	//nolint:errcheck
 	db.DeleteBucket(dbutils.StorageHistoryBucket)
-	err = stages.SaveStageProgress(db, stages.AccountHistoryIndex, 0)
+	err = stages.SaveStageProgress(db, stages.AccountHistoryIndex, 0, nil)
 	check(err)
-	err = stages.SaveStageProgress(db, stages.StorageHistoryIndex, 0)
+	err = stages.SaveStageProgress(db, stages.StorageHistoryIndex, 0, nil)
 	check(err)
-	err = stages.SaveStageProgress(db, stages.HashState, 0)
+	err = stages.SaveStageProgress(db, stages.HashState, 0, nil)
 	check(err)
 	fmt.Printf("Reset history index done\n")
 }
@@ -2392,11 +2392,11 @@ func testStage5(chaindata string, reset bool) error {
 			return err
 		}
 	}
-	if err = stages.SaveStageProgress(db, stages.HashState, 0); err != nil {
+	if err = stages.SaveStageProgress(db, stages.HashState, 0, nil); err != nil {
 		return err
 	}
 	var stage4progress uint64
-	if stage4progress, err = stages.GetStageProgress(db, stages.Execution); err != nil {
+	if stage4progress, _, err = stages.GetStageProgress(db, stages.Execution); err != nil {
 		return err
 	}
 	log.Info("Stage4", "progress", stage4progress)
@@ -2418,13 +2418,13 @@ func testStage4(chaindata string, block uint64) error {
 	defer db.Close()
 	var progress uint64
 	for stage := stages.SyncStage(0); stage < stages.Finish; stage++ {
-		if progress, err = stages.GetStageProgress(db, stage); err != nil {
+		if progress, _, err = stages.GetStageProgress(db, stage); err != nil {
 			return err
 		}
 		fmt.Printf("Stage: %d, progress: %d\n", stage, progress)
 	}
 	var stage4progress uint64
-	if stage4progress, err = stages.GetStageProgress(db, stages.Execution); err != nil {
+	if stage4progress, _, err = stages.GetStageProgress(db, stages.Execution); err != nil {
 		return err
 	}
 	core.UsePlainStateExecution = true

--- a/eth/stagedsync/stage.go
+++ b/eth/stagedsync/stage.go
@@ -21,10 +21,15 @@ type StageState struct {
 	state       *State
 	Stage       stages.SyncStage
 	BlockNumber uint64
+	StageData   []byte
 }
 
 func (s *StageState) Update(db ethdb.Putter, newBlockNum uint64) error {
-	return stages.SaveStageProgress(db, s.Stage, newBlockNum)
+	return stages.SaveStageProgress(db, s.Stage, newBlockNum, nil)
+}
+
+func (s *StageState) UpdateWithStageData(db ethdb.Putter, newBlockNum uint64, stageData []byte) error {
+	return stages.SaveStageProgress(db, s.Stage, newBlockNum, stageData)
 }
 
 func (s *StageState) Done() {
@@ -32,11 +37,12 @@ func (s *StageState) Done() {
 }
 
 func (s *StageState) ExecutionAt(db ethdb.Getter) (uint64, error) {
-	return stages.GetStageProgress(db, stages.Execution)
+	execution, _, err := stages.GetStageProgress(db, stages.Execution)
+	return execution, err
 }
 
 func (s *StageState) DoneAndUpdate(db ethdb.Putter, newBlockNum uint64) error {
-	err := stages.SaveStageProgress(db, s.Stage, newBlockNum)
+	err := stages.SaveStageProgress(db, s.Stage, newBlockNum, nil)
 	s.state.NextStage()
 	return err
 }

--- a/eth/stagedsync/stage_bodies.go
+++ b/eth/stagedsync/stage_bodies.go
@@ -18,7 +18,7 @@ func spawnBodyDownloadStage(s *StageState, u Unwinder, d DownloaderGlue, pid str
 
 }
 
-func unwindBodyDownloadStage(db ethdb.Database, u *UnwindState) error {
+func unwindBodyDownloadStage(u *UnwindState, db ethdb.Database) error {
 	mutation := db.NewBatch()
 	if err := u.Done(db); err != nil {
 		return fmt.Errorf("unwind Bodies: reset: %v", err)

--- a/eth/stagedsync/stage_execute.go
+++ b/eth/stagedsync/stage_execute.go
@@ -17,7 +17,6 @@ import (
 	"github.com/ledgerwatch/turbo-geth/core/state"
 	"github.com/ledgerwatch/turbo-geth/core/types/accounts"
 	"github.com/ledgerwatch/turbo-geth/core/vm"
-	"github.com/ledgerwatch/turbo-geth/eth/stagedsync/stages"
 	"github.com/ledgerwatch/turbo-geth/ethdb"
 	"github.com/ledgerwatch/turbo-geth/log"
 )
@@ -207,20 +206,8 @@ func SpawnExecuteBlocksStage(s *StageState, stateDB ethdb.Database, blockchain B
 	return nil
 }
 
-func unwindExecutionStage(unwindPoint uint64, stateDB ethdb.Database) error {
-	lastProcessedBlockNumber, err := stages.GetStageProgress(stateDB, stages.Execution)
-	if err != nil {
-		return fmt.Errorf("unwind Execution: get stage progress: %v", err)
-	}
-
-	if unwindPoint >= lastProcessedBlockNumber {
-		err = stages.SaveStageUnwind(stateDB, stages.Execution, 0)
-		if err != nil {
-			return fmt.Errorf("unwind Execution: reset: %v", err)
-		}
-		return nil
-	}
-	log.Info("Unwind Execution stage", "from", lastProcessedBlockNumber, "to", unwindPoint)
+func unwindExecutionStage(u *UnwindState, s *StageState, stateDB ethdb.Database) error {
+	log.Info("Unwind Execution stage", "from", s.BlockNumber, "to", u.UnwindPoint)
 	mutation := stateDB.NewBatch()
 
 	rewindFunc := ethdb.RewindData
@@ -243,7 +230,7 @@ func unwindExecutionStage(unwindPoint uint64, stateDB ethdb.Database) error {
 		recoverCodeHashFunc = recoverCodeHashPlain
 	}
 
-	accountMap, storageMap, err := rewindFunc(stateDB, lastProcessedBlockNumber, unwindPoint)
+	accountMap, storageMap, err := rewindFunc(stateDB, s.BlockNumber, u.UnwindPoint)
 	if err != nil {
 		return fmt.Errorf("unwind Execution: getting rewind data: %v", err)
 	}
@@ -278,14 +265,13 @@ func unwindExecutionStage(unwindPoint uint64, stateDB ethdb.Database) error {
 		}
 	}
 
-	for i := lastProcessedBlockNumber; i > unwindPoint; i-- {
+	for i := s.BlockNumber; i > u.UnwindPoint; i-- {
 		if err = deleteChangeSets(mutation, i, accountChangeSetBucket, storageChangeSetBucket); err != nil {
 			return err
 		}
 	}
 
-	err = stages.SaveStageUnwind(mutation, stages.Execution, 0)
-	if err != nil {
+	if err = u.Done(mutation); err != nil {
 		return fmt.Errorf("unwind Execution: reset: %v", err)
 	}
 

--- a/eth/stagedsync/stage_execute_test.go
+++ b/eth/stagedsync/stage_execute_test.go
@@ -16,12 +16,14 @@ func TestUnwindExecutionStageHashedStatic(t *testing.T) {
 	mutation := ethdb.NewMemDatabase()
 	generateBlocks(t, 1, 100, hashedWriterGen(mutation), staticCodeStaticIncarnations)
 
-	err := stages.SaveStageProgress(mutation, stages.Execution, 100)
+	err := stages.SaveStageProgress(mutation, stages.Execution, 100, nil)
 	if err != nil {
 		t.Errorf("error while saving progress: %v", err)
 	}
 
-	err = unwindExecutionStage(50, mutation)
+	u := &UnwindState{UnwindPoint: 50}
+	s := &StageState{BlockNumber: 100}
+	err = unwindExecutionStage(u, s, mutation)
 	if err != nil {
 		t.Errorf("error while unwinding state: %v", err)
 	}
@@ -36,11 +38,14 @@ func TestUnwindExecutionStageHashedWithIncarnationChanges(t *testing.T) {
 	mutation := ethdb.NewMemDatabase()
 	generateBlocks(t, 1, 100, hashedWriterGen(mutation), changeCodeWithIncarnations)
 
-	err := stages.SaveStageProgress(mutation, stages.Execution, 100)
+	err := stages.SaveStageProgress(mutation, stages.Execution, 100, nil)
 	if err != nil {
 		t.Errorf("error while saving progress: %v", err)
 	}
-	err = unwindExecutionStage(50, mutation)
+	u := &UnwindState{UnwindPoint: 50}
+	s := &StageState{BlockNumber: 100}
+	err = unwindExecutionStage(u, s, mutation)
+
 	if err != nil {
 		t.Errorf("error while unwinding state: %v", err)
 	}
@@ -56,11 +61,13 @@ func TestUnwindExecutionStageHashedWithCodeChanges(t *testing.T) {
 	mutation := ethdb.NewMemDatabase()
 	generateBlocks(t, 1, 100, hashedWriterGen(mutation), changeCodeIndepenentlyOfIncarnations)
 
-	err := stages.SaveStageProgress(mutation, stages.Execution, 100)
+	err := stages.SaveStageProgress(mutation, stages.Execution, 100, nil)
 	if err != nil {
 		t.Errorf("error while saving progress: %v", err)
 	}
-	err = unwindExecutionStage(50, mutation)
+	u := &UnwindState{UnwindPoint: 50}
+	s := &StageState{BlockNumber: 100}
+	err = unwindExecutionStage(u, s, mutation)
 	if err != nil {
 		t.Errorf("error while unwinding state: %v", err)
 	}
@@ -75,12 +82,14 @@ func TestUnwindExecutionStagePlainStatic(t *testing.T) {
 	mutation := ethdb.NewMemDatabase()
 	generateBlocks(t, 1, 100, plainWriterGen(mutation), staticCodeStaticIncarnations)
 
-	err := stages.SaveStageProgress(mutation, stages.Execution, 100)
+	err := stages.SaveStageProgress(mutation, stages.Execution, 100, nil)
 	if err != nil {
 		t.Errorf("error while saving progress: %v", err)
 	}
 	core.UsePlainStateExecution = true
-	err = unwindExecutionStage(50, mutation)
+	u := &UnwindState{UnwindPoint: 50}
+	s := &StageState{BlockNumber: 100}
+	err = unwindExecutionStage(u, s, mutation)
 	if err != nil {
 		t.Errorf("error while unwinding state: %v", err)
 	}
@@ -95,12 +104,14 @@ func TestUnwindExecutionStagePlainWithIncarnationChanges(t *testing.T) {
 	mutation := ethdb.NewMemDatabase()
 	generateBlocks(t, 1, 100, plainWriterGen(mutation), changeCodeWithIncarnations)
 
-	err := stages.SaveStageProgress(mutation, stages.Execution, 100)
+	err := stages.SaveStageProgress(mutation, stages.Execution, 100, nil)
 	if err != nil {
 		t.Errorf("error while saving progress: %v", err)
 	}
 	core.UsePlainStateExecution = true
-	err = unwindExecutionStage(50, mutation)
+	u := &UnwindState{UnwindPoint: 50}
+	s := &StageState{BlockNumber: 100}
+	err = unwindExecutionStage(u, s, mutation)
 	if err != nil {
 		t.Errorf("error while unwinding state: %v", err)
 	}
@@ -116,12 +127,14 @@ func TestUnwindExecutionStagePlainWithCodeChanges(t *testing.T) {
 	mutation := ethdb.NewMemDatabase()
 	generateBlocks(t, 1, 100, plainWriterGen(mutation), changeCodeIndepenentlyOfIncarnations)
 
-	err := stages.SaveStageProgress(mutation, stages.Execution, 100)
+	err := stages.SaveStageProgress(mutation, stages.Execution, 100, nil)
 	if err != nil {
 		t.Errorf("error while saving progress: %v", err)
 	}
 	core.UsePlainStateExecution = true
-	err = unwindExecutionStage(50, mutation)
+	u := &UnwindState{UnwindPoint: 50}
+	s := &StageState{BlockNumber: 100}
+	err = unwindExecutionStage(u, s, mutation)
 	if err != nil {
 		t.Errorf("error while unwinding state: %v", err)
 	}

--- a/eth/stagedsync/stage_interhashes.go
+++ b/eth/stagedsync/stage_interhashes.go
@@ -3,22 +3,15 @@ package stagedsync
 import (
 	"fmt"
 
-	"github.com/ledgerwatch/turbo-geth/eth/stagedsync/stages"
 	"github.com/ledgerwatch/turbo-geth/ethdb"
 	"github.com/ledgerwatch/turbo-geth/log"
 )
 
 //nolint:interfacer
 func SpawnIntermediateHashesStage(s *StageState, stateDB ethdb.Database, _ string, _ chan struct{}) error {
-	lastProcessedBlockNumber, err := stages.GetStageProgress(stateDB, stages.IntermediateHashes)
-	if err != nil {
-		return fmt.Errorf("IntermediateHashes: get stage progress: %w", err)
-	}
-	var hashedStateBlockNumber uint64
-	hashedStateBlockNumber, err = stages.GetStageProgress(stateDB, stages.IntermediateHashes)
-	if err != nil {
-		return fmt.Errorf("IntermediateHashes: get hashed state progress: %w", err)
-	}
+	lastProcessedBlockNumber := s.BlockNumber
+	hashedStateBlockNumber := s.BlockNumber
+
 	log.Info("Generating intermediate hashes (currently no-op)", "from", lastProcessedBlockNumber, "to", hashedStateBlockNumber)
 	// TODO: Actual work goes here
 	return s.DoneAndUpdate(stateDB, lastProcessedBlockNumber)

--- a/eth/stagedsync/stage_senders.go
+++ b/eth/stagedsync/stage_senders.go
@@ -13,7 +13,6 @@ import (
 	"github.com/ledgerwatch/turbo-geth/core/rawdb"
 	"github.com/ledgerwatch/turbo-geth/core/types"
 	"github.com/ledgerwatch/turbo-geth/crypto/secp256k1"
-	"github.com/ledgerwatch/turbo-geth/eth/stagedsync/stages"
 	"github.com/ledgerwatch/turbo-geth/ethdb"
 	"github.com/ledgerwatch/turbo-geth/log"
 	"github.com/ledgerwatch/turbo-geth/params"
@@ -160,21 +159,10 @@ func recoverSenders(cryptoContext *secp256k1.Context, in chan *senderRecoveryJob
 	}
 }
 
-func unwindSendersStage(stateDB ethdb.Database, unwindPoint uint64) error {
+func unwindSendersStage(u *UnwindState, stateDB ethdb.Database) error {
 	// Does not require any special processing
-	lastProcessedBlockNumber, err := stages.GetStageProgress(stateDB, stages.Senders)
-	if err != nil {
-		return fmt.Errorf("unwind Senders: get stage progress: %v", err)
-	}
-	if unwindPoint >= lastProcessedBlockNumber {
-		err = stages.SaveStageUnwind(stateDB, stages.Senders, 0)
-		if err != nil {
-			return fmt.Errorf("unwind Senders: reset: %v", err)
-		}
-		return nil
-	}
 	mutation := stateDB.NewBatch()
-	err = stages.SaveStageUnwind(mutation, stages.Senders, 0)
+	err := u.Done(mutation)
 	if err != nil {
 		return fmt.Errorf("unwind Senders: reset: %v", err)
 	}

--- a/eth/stagedsync/stagedsync.go
+++ b/eth/stagedsync/stagedsync.go
@@ -39,7 +39,7 @@ func PrepareStagedSync(
 				return spawnBodyDownloadStage(s, u, d, pid)
 			},
 			UnwindFunc: func(u *UnwindState, s *StageState) error {
-				return unwindBodyDownloadStage(stateDB, u)
+				return unwindBodyDownloadStage(u, stateDB)
 			},
 		},
 		{
@@ -49,7 +49,7 @@ func PrepareStagedSync(
 				return spawnRecoverSendersStage(s, stateDB, blockchain.Config(), quitCh)
 			},
 			UnwindFunc: func(u *UnwindState, s *StageState) error {
-				return unwindSendersStage(stateDB, u.UnwindPoint)
+				return unwindSendersStage(u, stateDB)
 			},
 		},
 		{
@@ -59,7 +59,7 @@ func PrepareStagedSync(
 				return SpawnExecuteBlocksStage(s, stateDB, blockchain, 0 /* limit (meaning no limit) */, quitCh, dests)
 			},
 			UnwindFunc: func(u *UnwindState, s *StageState) error {
-				return unwindExecutionStage(u.UnwindPoint, stateDB)
+				return unwindExecutionStage(u, s, stateDB)
 			},
 		},
 		{

--- a/eth/stagedsync/unwind_test.go
+++ b/eth/stagedsync/unwind_test.go
@@ -18,7 +18,7 @@ func TestUnwindStackLoadFromDb(t *testing.T) {
 	points := []uint64{10, 20, 30}
 
 	for i := range stages {
-		err := stack.Add(UnwindState{stages[i], points[i]}, db)
+		err := stack.Add(UnwindState{stages[i], points[i], nil}, db)
 		assert.NoError(t, err)
 	}
 
@@ -42,7 +42,7 @@ func TestUnwindStackLoadFromDbAfterDone(t *testing.T) {
 	points := []uint64{10, 20, 30}
 
 	for i := range stages {
-		err := stack.Add(UnwindState{stages[i], points[i]}, db)
+		err := stack.Add(UnwindState{stages[i], points[i], nil}, db)
 		assert.NoError(t, err)
 	}
 
@@ -71,7 +71,7 @@ func TestUnwindStackLoadFromDbNoDone(t *testing.T) {
 	points := []uint64{10, 20, 30}
 
 	for i := range stages {
-		err := stack.Add(UnwindState{stages[i], points[i]}, db)
+		err := stack.Add(UnwindState{stages[i], points[i], nil}, db)
 		assert.NoError(t, err)
 	}
 
@@ -98,7 +98,7 @@ func TestUnwindStackPopAndEmpty(t *testing.T) {
 	points := []uint64{10, 20, 30}
 
 	for i := range stages {
-		err := stack.Add(UnwindState{stages[i], points[i]}, db)
+		err := stack.Add(UnwindState{stages[i], points[i], nil}, db)
 		assert.NoError(t, err)
 	}
 
@@ -131,13 +131,13 @@ func TestUnwindOverrideWithLower(t *testing.T) {
 	points := []uint64{10, 20, 30}
 
 	for i := range stages {
-		err := stack.Add(UnwindState{stages[i], points[i]}, db)
+		err := stack.Add(UnwindState{stages[i], points[i], nil}, db)
 		assert.NoError(t, err)
 	}
 
 	assert.Equal(t, 3, len(stack.unwindStack))
 
-	err := stack.Add(UnwindState{stages[0], 5}, db)
+	err := stack.Add(UnwindState{stages[0], 5, nil}, db)
 	assert.NoError(t, err)
 
 	// we append if the next unwind is to the lower block
@@ -154,13 +154,13 @@ func TestUnwindOverrideWithHigher(t *testing.T) {
 	points := []uint64{10, 20, 30}
 
 	for i := range stages {
-		err := stack.Add(UnwindState{stages[i], points[i]}, db)
+		err := stack.Add(UnwindState{stages[i], points[i], nil}, db)
 		assert.NoError(t, err)
 	}
 
 	assert.Equal(t, 3, len(stack.unwindStack))
 
-	err := stack.Add(UnwindState{stages[0], 105}, db)
+	err := stack.Add(UnwindState{stages[0], 105, nil}, db)
 	assert.NoError(t, err)
 
 	// we ignore if next unwind is to the higher block
@@ -177,13 +177,13 @@ func TestUnwindOverrideWithTheSame(t *testing.T) {
 	points := []uint64{10, 20, 30}
 
 	for i := range stages {
-		err := stack.Add(UnwindState{stages[i], points[i]}, db)
+		err := stack.Add(UnwindState{stages[i], points[i], nil}, db)
 		assert.NoError(t, err)
 	}
 
 	assert.Equal(t, 3, len(stack.unwindStack))
 
-	err := stack.Add(UnwindState{stages[0], 10}, db)
+	err := stack.Add(UnwindState{stages[0], 10, nil}, db)
 	assert.NoError(t, err)
 
 	// we ignore if next unwind is to the higher block

--- a/eth/stagedsync/unwind_test.go
+++ b/eth/stagedsync/unwind_test.go
@@ -18,7 +18,7 @@ func TestUnwindStackLoadFromDb(t *testing.T) {
 	points := []uint64{10, 20, 30}
 
 	for i := range stages {
-		err := stack.Add(UnwindState{stages[i], points[i], nil}, db)
+		err := stack.Add(UnwindState{stages[i], points[i], []byte{}}, db)
 		assert.NoError(t, err)
 	}
 
@@ -42,7 +42,7 @@ func TestUnwindStackLoadFromDbAfterDone(t *testing.T) {
 	points := []uint64{10, 20, 30}
 
 	for i := range stages {
-		err := stack.Add(UnwindState{stages[i], points[i], nil}, db)
+		err := stack.Add(UnwindState{stages[i], points[i], []byte{}}, db)
 		assert.NoError(t, err)
 	}
 


### PR DESCRIPTION
use `s.UpdateWithStageData(db, <block number>, <key>)` to store the key

use `s.StageData` with `etl.NextKey` to restart ETL from where it was interrupted.