### PR TITLE
Use same lmdb version as in python bindings: version of 2019 year

### DIFF
--- a/ethdb/kv_lmdb.go
+++ b/ethdb/kv_lmdb.go
@@ -44,6 +44,7 @@ func (opts lmdbOpts) ReadOnly() lmdbOpts {
 }
 
 func (opts lmdbOpts) Open() (KV, error) {
+	ctx, ctxCancel := context.WithCancel(ctx)
 	env, err := lmdb.NewEnv()
 	if err != nil {
 		return nil, err
@@ -117,6 +118,7 @@ func (opts lmdbOpts) Open() (KV, error) {
 	db := &LmdbKV{
 		opts:            opts,
 		env:             env,
+		ctxCancel:       ctxCancel,
 		log:             logger,
 		buckets:         buckets,
 		lmdbTxPool:      lmdbpool.NewTxnPool(env),
@@ -145,6 +147,7 @@ func (opts lmdbOpts) MustOpen() KV {
 type LmdbKV struct {
 	opts                lmdbOpts
 	env                 *lmdb.Env
+	ctxCancel           context.CancelFunc
 	log                 log.Logger
 	buckets             []lmdb.DBI
 	lmdbTxPool          *lmdbpool.TxnPool // pool of lmdb.Txn objects

--- a/ethdb/kv_lmdb.go
+++ b/ethdb/kv_lmdb.go
@@ -44,7 +44,6 @@ func (opts lmdbOpts) ReadOnly() lmdbOpts {
 }
 
 func (opts lmdbOpts) Open() (KV, error) {
-	ctx, ctxCancel := context.WithCancel(ctx)
 	env, err := lmdb.NewEnv()
 	if err != nil {
 		return nil, err

--- a/ethdb/kv_lmdb.go
+++ b/ethdb/kv_lmdb.go
@@ -117,7 +117,6 @@ func (opts lmdbOpts) Open() (KV, error) {
 	db := &LmdbKV{
 		opts:            opts,
 		env:             env,
-		ctxCancel:       ctxCancel,
 		log:             logger,
 		buckets:         buckets,
 		lmdbTxPool:      lmdbpool.NewTxnPool(env),
@@ -146,7 +145,6 @@ func (opts lmdbOpts) MustOpen() KV {
 type LmdbKV struct {
 	opts                lmdbOpts
 	env                 *lmdb.Env
-	ctxCancel           context.CancelFunc
 	log                 log.Logger
 	buckets             []lmdb.DBI
 	lmdbTxPool          *lmdbpool.TxnPool // pool of lmdb.Txn objects

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/ledgerwatch/turbo-geth
 go 1.13
 
 require (
-	github.com/AskAlexSharov/lmdb-go v1.8.1-0.20200609024141-123c53568c38
+	github.com/AskAlexSharov/lmdb-go v1.9.0
 	github.com/Azure/azure-storage-blob-go v0.8.0
 	github.com/Azure/go-autorest/autorest/adal v0.8.3 // indirect
 	github.com/JekaMas/notify v0.9.4

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,6 @@
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
-github.com/AskAlexSharov/lmdb-go v1.8.1-0.20200609024141-123c53568c38 h1:0lvFLmXBPIKQSwbMBc6CC+v93gqWn/wiwmlEs1/EURE=
-github.com/AskAlexSharov/lmdb-go v1.8.1-0.20200609024141-123c53568c38/go.mod h1:k7Jo/kN60Hq1MTBwsVSp2JllEs5Tyhd4MZ7tY9smjeA=
+github.com/AskAlexSharov/lmdb-go v1.9.0 h1:lXbgv+ERzRsLOiZi53tu2MOLuOZy6vSLFL8qlfSbLWU=
+github.com/AskAlexSharov/lmdb-go v1.9.0/go.mod h1:k7Jo/kN60Hq1MTBwsVSp2JllEs5Tyhd4MZ7tY9smjeA=
 github.com/Azure/azure-pipeline-go v0.2.1 h1:OLBdZJ3yvOn2MezlWvbrBMTEUQC72zAftRZOMdj5HYo=
 github.com/Azure/azure-pipeline-go v0.2.1/go.mod h1:UGSo8XybXnIGZ3epmeBw7Jdz+HiUVpqIlpz/HKHylF4=
 github.com/Azure/azure-storage-blob-go v0.8.0 h1:53qhf0Oxa0nOjgbDeeYPUeyiNmafAFEY95rZLK0Tj6o=


### PR DESCRIPTION
Downgrade lmdb to version of 2019, which is compatible with https://github.com/jnwatson/py-lmdb (lmdb of 2020 year version - upgaded lock file version from 1 to 2 - and python binding can't open database if lockfile exists - if main app is running).