### PR TITLE
Prepare codebase for future default DB change

### DIFF
--- a/cmd/geth/chaincmd.go
+++ b/cmd/geth/chaincmd.go
@@ -418,10 +418,7 @@ func copyDb(ctx *cli.Context) error {
 	dl := downloader.New(0, chainDb, syncBloom, new(event.TypeMux), chain, nil, nil, ethdb.DefaultStorageMode)
 
 	// Create a source peer to satisfy downloader requests from
-	db, err := ethdb.NewDatabase(ctx.Args().First())
-	if err != nil {
-		return err
-	}
+	db := ethdb.MustOpen(ctx.Args().First())
 	hc, err := core.NewHeaderChain(db, chain.Config(), chain.Engine(), func() bool { return false })
 	if err != nil {
 		return err

--- a/cmd/geth/chaincmd.go
+++ b/cmd/geth/chaincmd.go
@@ -418,7 +418,7 @@ func copyDb(ctx *cli.Context) error {
 	dl := downloader.New(0, chainDb, syncBloom, new(event.TypeMux), chain, nil, nil, ethdb.DefaultStorageMode)
 
 	// Create a source peer to satisfy downloader requests from
-	db, err := ethdb.NewBoltDatabase(ctx.Args().First())
+	db, err := ethdb.NewDatabase(ctx.Args().First())
 	if err != nil {
 		return err
 	}

--- a/cmd/geth/dao_test.go
+++ b/cmd/geth/dao_test.go
@@ -125,10 +125,7 @@ func testDAOForkBlockNewChain(t *testing.T, test int, genesis string, expectBloc
 	}
 	// Retrieve the DAO config flag from the database
 	path := filepath.Join(datadir, "geth", "chaindata")
-	db, err := ethdb.NewDatabase(path)
-	if err != nil {
-		panic(err)
-	}
+	db := ethdb.MustOpen(path)
 	defer db.Close()
 
 	genesisHash := common.HexToHash("0xd4e56740f876aef8c010b86a40d5f56745a118d0906a34e69aec8c0db1cb8fa3")

--- a/cmd/geth/dao_test.go
+++ b/cmd/geth/dao_test.go
@@ -125,9 +125,9 @@ func testDAOForkBlockNewChain(t *testing.T, test int, genesis string, expectBloc
 	}
 	// Retrieve the DAO config flag from the database
 	path := filepath.Join(datadir, "geth", "chaindata")
-	db, err := ethdb.NewBoltDatabase(path)
+	db, err := ethdb.NewDatabase(path)
 	if err != nil {
-		t.Fatalf("test %d: failed to open test database: %v", test, err)
+		panic(err)
 	}
 	defer db.Close()
 
@@ -137,7 +137,7 @@ func testDAOForkBlockNewChain(t *testing.T, test int, genesis string, expectBloc
 	}
 	config := rawdb.ReadChainConfig(db, genesisHash)
 	if config == nil {
-		t.Errorf("test %d: failed to retrieve chain config: %v", test, err)
+		t.Errorf("test %d: failed to retrieve chain config", test)
 		return // we want to return here, the other checks can't make it past this point (nil panic).
 	}
 	// Validate the DAO hard-fork block number against the expected value

--- a/cmd/geth/retesteth.go
+++ b/cmd/geth/retesteth.go
@@ -421,7 +421,7 @@ func (api *RetestethAPI) SetChainParams(_ context.Context, chainParams ChainPara
 	}
 	api.engine = engine
 	api.blockchain = blockchain
-	//api.db = state.NewDatabase(api.ethDb)
+	//api.db = state.Open(api.ethDb)
 	api.txMap = make(map[common.Address]map[uint64]*types.Transaction)
 	api.txSenders = make(map[common.Address]struct{})
 	api.blockInterval = 0

--- a/cmd/geth/retesteth.go
+++ b/cmd/geth/retesteth.go
@@ -421,7 +421,7 @@ func (api *RetestethAPI) SetChainParams(_ context.Context, chainParams ChainPara
 	}
 	api.engine = engine
 	api.blockchain = blockchain
-	//api.db = state.Open(api.ethDb)
+	//api.db = state.NewDatabase(api.ethDb)
 	api.txMap = make(map[common.Address]map[uint64]*types.Transaction)
 	api.txSenders = make(map[common.Address]struct{})
 	api.blockInterval = 0

--- a/cmd/hack/hack.go
+++ b/cmd/hack/hack.go
@@ -787,9 +787,8 @@ func execToBlock(chaindata string, block uint64, fromScratch bool) {
 	if fromScratch {
 		os.Remove("statedb")
 	}
-	stateDB := ethdb.NewObjectDatabase(ethdb.NewLMDB().Path("statedb").MustOpen())
-	//stateDB, err := ethdb.NewBadgerDatabase("statedb")
-	//check(err)
+	stateDB, err := ethdb.NewDatabase("statedb")
+	check(err)
 	defer stateDB.Close()
 
 	//_, _, _, err = core.SetupGenesisBlock(stateDB, core.DefaultGenesisBlock())

--- a/cmd/hack/hack.go
+++ b/cmd/hack/hack.go
@@ -848,7 +848,7 @@ Loop:
 }
 
 func extractTrie(block int) {
-	stateDb, err := ethdb.NewBoltDatabase("statedb")
+	stateDb, err := ethdb.NewDatabase("statedb")
 	check(err)
 	defer stateDb.Close()
 	bc, err := core.NewBlockChain(stateDb, nil, params.RopstenChainConfig, ethash.NewFaker(), vm.Config{}, nil, nil, nil)
@@ -1144,8 +1144,8 @@ func relayoutKeys() {
 }
 
 func upgradeBlocks() {
-	//ethDb, err := ethdb.NewBoltDatabase(node.DefaultDataDir() + "/geth/chaindata")
-	ethDb, err := ethdb.NewBoltDatabase("/home/akhounov/.ethereum/geth/chaindata")
+	//ethDb, err := ethdb.NewDatabase(node.DefaultDataDir() + "/geth/chaindata")
+	ethDb, err := ethdb.NewDatabase("/home/akhounov/.ethereum/geth/chaindata")
 	check(err)
 	defer ethDb.Close()
 	start := []byte{}
@@ -2446,13 +2446,11 @@ func searchChangeSet(chaindata string, key []byte) error {
 }
 
 func openDB(chaindata string) *ethdb.ObjectDatabase {
-	if strings.HasSuffix(chaindata, "_lmdb") {
-		return ethdb.NewObjectDatabase(ethdb.NewLMDB().Path(chaindata).MustOpen())
+	db, err := ethdb.NewDatabase(chaindata)
+	if err != nil {
+		panic(err)
 	}
-	if strings.HasSuffix(chaindata, "_badger") {
-		return ethdb.NewObjectDatabase(ethdb.NewBadger().Path(chaindata).MustOpen())
-	}
-	return ethdb.NewObjectDatabase(ethdb.NewBolt().Path(chaindata).MustOpen())
+	return db
 }
 
 func main() {

--- a/cmd/pics/state.go
+++ b/cmd/pics/state.go
@@ -286,8 +286,10 @@ func stateDatabaseComparison(first ethdb.KV, second ethdb.KV, number int) error 
 func initialState1() error {
 	fmt.Printf("Initial state 1\n")
 	// Configure and generate a sample block chain
+	db := ethdb.NewMemDatabase()
+	defer db.Close()
+	kv := db.KV()
 	var (
-		db, kv   = ethdb.NewMemDatabase2()
 		key, _   = crypto.HexToECDSA("b71c71a67e1177ad4e901695e1b4b9ee17ae16c6668d313eac2f96dbcda3f291")
 		key1, _  = crypto.HexToECDSA("49a7b37aa6f6645917e7b807e9d1c00d4fa71f18343b0d4122a4d2df64dd6fee")
 		key2, _  = crypto.HexToECDSA("8a1f9a8f95be41cd7ccb6168179afb4504aefe388d1e14474d32c45c72ce7b7a")

--- a/cmd/restapi/apis/common.go
+++ b/cmd/restapi/apis/common.go
@@ -10,6 +10,6 @@ var ErrEntityNotFound = errors.New("entity not found")
 
 type Env struct {
 	DB              ethdb.KV
-	BoltPath        string
+	Chaindata       string
 	RemoteDBAddress string
 }

--- a/cmd/restapi/commands/root.go
+++ b/cmd/restapi/commands/root.go
@@ -14,13 +14,13 @@ import (
 
 var (
 	remoteDbAddress string
-	boltPath        string
+	chaindata       string
 	listenAddress   string
 )
 
 func init() {
 	rootCmd.Flags().StringVar(&remoteDbAddress, "remote-db-addr", "", "address of remote DB listener of a turbo-geth node")
-	rootCmd.Flags().StringVar(&boltPath, "bolt-path", "", "path to the boltdb database")
+	rootCmd.Flags().StringVar(&chaindata, "chaindata", "", "path to the boltdb database")
 	rootCmd.Flags().StringVar(&listenAddress, "rpcaddr", "localhost:8080", "REST server listening interface")
 }
 
@@ -28,7 +28,7 @@ var rootCmd = &cobra.Command{
 	Use:   "restapi",
 	Short: "restapi exposes read-only blockchain APIs through REST (requires running turbo-geth node)",
 	RunE: func(cmd *cobra.Command, args []string) error {
-		return rest.ServeREST(cmd.Context(), listenAddress, remoteDbAddress, boltPath)
+		return rest.ServeREST(cmd.Context(), listenAddress, remoteDbAddress, chaindata)
 	},
 }
 

--- a/cmd/restapi/rest/serve_rest.go
+++ b/cmd/restapi/rest/serve_rest.go
@@ -36,7 +36,7 @@ func ServeREST(ctx context.Context, localAddress, remoteDBAddress string, chaind
 	if remoteDBAddress != "" {
 		db, err = ethdb.NewRemote().Path(remoteDBAddress).Open()
 	} else if chaindata != "" {
-		database, errOpen := ethdb.NewDatabase(chaindata)
+		database, errOpen := ethdb.Open(chaindata)
 		if errOpen != nil {
 			return errOpen
 		}

--- a/cmd/restapi/rest/serve_rest.go
+++ b/cmd/restapi/rest/serve_rest.go
@@ -20,7 +20,7 @@ func printError(name string, err error) {
 	}
 }
 
-func ServeREST(ctx context.Context, localAddress, remoteDBAddress string, boltPath string) error {
+func ServeREST(ctx context.Context, localAddress, remoteDBAddress string, chaindata string) error {
 	r := gin.Default()
 	root := r.Group("api/v1")
 	allowCORS(root)
@@ -35,8 +35,12 @@ func ServeREST(ctx context.Context, localAddress, remoteDBAddress string, boltPa
 	var err error
 	if remoteDBAddress != "" {
 		db, err = ethdb.NewRemote().Path(remoteDBAddress).Open()
-	} else if boltPath != "" {
-		db, err = ethdb.NewBolt().Path(boltPath).ReadOnly().Open()
+	} else if chaindata != "" {
+		database, errOpen := ethdb.NewDatabase(chaindata)
+		if errOpen != nil {
+			return errOpen
+		}
+		db = database.KV()
 	} else {
 		err = fmt.Errorf("either remote db or bolt db must be specified")
 	}
@@ -47,7 +51,7 @@ func ServeREST(ctx context.Context, localAddress, remoteDBAddress string, boltPa
 	e := &apis.Env{
 		DB:              db,
 		RemoteDBAddress: remoteDBAddress,
-		BoltPath:        boltPath,
+		Chaindata:       chaindata,
 	}
 
 	if err = apis.RegisterRemoteDBAPI(root.Group("remote-db"), e); err != nil {

--- a/cmd/rpctest/proofs.go
+++ b/cmd/rpctest/proofs.go
@@ -24,13 +24,13 @@ import (
 
 func proofs(chaindata string, url string, block int) {
 	fileName := "trie.txt"
-	ethDb, err := ethdb.NewBoltDatabase(chaindata)
+	ethDb, err := ethdb.NewDatabase(chaindata)
 	if err != nil {
 		panic(err)
 	}
 	defer ethDb.Close()
 	var t *trie.Trie
-	if _, err = os.Stat(fileName); err != nil {
+	if _, err := os.Stat(fileName); err != nil {
 		if os.IsNotExist(err) {
 			// Resolve 6 top levels of the accounts trie
 			l := trie.NewSubTrieLoader(uint64(block))
@@ -91,7 +91,7 @@ func proofs(chaindata string, url string, block int) {
 			}
 			var account common.Address
 			var found bool
-			err = ethDb.Walk(dbutils.PreimagePrefix, startKey[:], 4*len(diffKey), func(k, v []byte) (bool, error) {
+			err := ethDb.Walk(dbutils.PreimagePrefix, startKey[:], 4*len(diffKey), func(k, v []byte) (bool, error) {
 				if len(v) == common.AddressLength {
 					copy(account[:], v)
 					found = true
@@ -172,7 +172,7 @@ func proofs(chaindata string, url string, block int) {
 }
 
 func fixState(chaindata string, url string) {
-	stateDb, err := ethdb.NewBoltDatabase(chaindata)
+	stateDb, err := ethdb.NewDatabase(chaindata)
 	if err != nil {
 		panic(err)
 	}

--- a/cmd/state/commands/stateless.go
+++ b/cmd/state/commands/stateless.go
@@ -61,7 +61,7 @@ var statelessCmd = &cobra.Command{
 	Short: "Stateless Ethereum prototype",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		createDb := func(path string) (ethdb.Database, error) {
-			return ethdb.NewBoltDatabase(path)
+			return ethdb.NewDatabase(path)
 		}
 		ctx := rootContext()
 

--- a/cmd/state/commands/stateless.go
+++ b/cmd/state/commands/stateless.go
@@ -61,7 +61,7 @@ var statelessCmd = &cobra.Command{
 	Short: "Stateless Ethereum prototype",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		createDb := func(path string) (ethdb.Database, error) {
-			return ethdb.NewDatabase(path)
+			return ethdb.Open(path)
 		}
 		ctx := rootContext()
 

--- a/cmd/state/generate/regenerate_index.go
+++ b/cmd/state/generate/regenerate_index.go
@@ -13,10 +13,7 @@ import (
 )
 
 func RegenerateIndex(chaindata string, csBucket []byte) error {
-	db, err := ethdb.NewDatabase(chaindata)
-	if err != nil {
-		return err
-	}
+	db := ethdb.MustOpen(chaindata)
 	ch := make(chan os.Signal, 1)
 	quitCh := make(chan struct{})
 	signal.Notify(ch, os.Interrupt)

--- a/cmd/state/generate/regenerate_index.go
+++ b/cmd/state/generate/regenerate_index.go
@@ -2,17 +2,18 @@ package generate
 
 import (
 	"errors"
+	"os"
+	"os/signal"
+	"time"
+
 	"github.com/ledgerwatch/turbo-geth/core"
 	"github.com/ledgerwatch/turbo-geth/eth/stagedsync/stages"
 	"github.com/ledgerwatch/turbo-geth/ethdb"
 	"github.com/ledgerwatch/turbo-geth/log"
-	"os"
-	"os/signal"
-	"time"
 )
 
 func RegenerateIndex(chaindata string, csBucket []byte) error {
-	db, err := ethdb.NewBoltDatabase(chaindata)
+	db, err := ethdb.NewDatabase(chaindata)
 	if err != nil {
 		return err
 	}

--- a/cmd/state/generate/regenerate_tx_lookup.go
+++ b/cmd/state/generate/regenerate_tx_lookup.go
@@ -13,13 +13,9 @@ import (
 )
 
 func RegenerateTxLookup(chaindata string) error {
-	db, err := ethdb.NewDatabase(chaindata)
-	if err != nil {
-		return err
-	}
+	db := ethdb.MustOpen(chaindata)
 	defer db.Close()
-	err = db.ClearBuckets(dbutils.TxLookupPrefix)
-	if err != nil {
+	if err := db.ClearBuckets(dbutils.TxLookupPrefix); err != nil {
 		return err
 	}
 	startTime := time.Now()

--- a/cmd/state/generate/regenerate_tx_lookup.go
+++ b/cmd/state/generate/regenerate_tx_lookup.go
@@ -1,14 +1,15 @@
 package generate
 
 import (
+	"os"
+	"os/signal"
+	"time"
+
 	"github.com/ledgerwatch/turbo-geth/common/dbutils"
 	"github.com/ledgerwatch/turbo-geth/eth/stagedsync"
 	"github.com/ledgerwatch/turbo-geth/eth/stagedsync/stages"
 	"github.com/ledgerwatch/turbo-geth/ethdb"
 	"github.com/ledgerwatch/turbo-geth/log"
-	"os"
-	"os/signal"
-	"time"
 )
 
 func RegenerateTxLookup(chaindata string) error {
@@ -16,7 +17,10 @@ func RegenerateTxLookup(chaindata string) error {
 	if err != nil {
 		return err
 	}
-	db.DeleteBucket(dbutils.TxLookupPrefix) //nolint
+	err = db.ClearBuckets(dbutils.TxLookupPrefix)
+	if err != nil {
+		return err
+	}
 	startTime := time.Now()
 	ch := make(chan os.Signal, 1)
 	quitCh := make(chan struct{})

--- a/cmd/state/generate/regenerate_tx_lookup.go
+++ b/cmd/state/generate/regenerate_tx_lookup.go
@@ -3,7 +3,6 @@ package generate
 import (
 	"os"
 	"os/signal"
-	"strings"
 	"time"
 
 	"github.com/ledgerwatch/turbo-geth/common/dbutils"
@@ -14,9 +13,13 @@ import (
 )
 
 func RegenerateTxLookup(chaindata string) error {
-	db := openDB(chaindata)
+	db, err := ethdb.NewDatabase(chaindata)
+	if err != nil {
+		return err
+	}
 	defer db.Close()
-	if err := db.ClearBuckets(dbutils.TxLookupPrefix); err != nil {
+	err = db.ClearBuckets(dbutils.TxLookupPrefix)
+	if err != nil {
 		return err
 	}
 	startTime := time.Now()
@@ -44,14 +47,4 @@ func RegenerateTxLookup(chaindata string) error {
 	}
 	log.Info("TxLookup index is successfully regenerated", "it took", time.Since(startTime))
 	return nil
-}
-
-func openDB(chaindata string) *ethdb.ObjectDatabase {
-	if strings.HasSuffix(chaindata, "_lmdb") {
-		return ethdb.NewObjectDatabase(ethdb.NewLMDB().Path(chaindata).MustOpen())
-	}
-	if strings.HasSuffix(chaindata, "_badger") {
-		return ethdb.NewObjectDatabase(ethdb.NewBadger().Path(chaindata).MustOpen())
-	}
-	return ethdb.NewObjectDatabase(ethdb.NewBolt().Path(chaindata).MustOpen())
 }

--- a/cmd/state/stateless/check_change_sets.go
+++ b/cmd/state/stateless/check_change_sets.go
@@ -38,14 +38,14 @@ func CheckChangeSets(genesis *core.Genesis, blockNum uint64, chaindata string, h
 		interruptCh <- true
 	}()
 
-	chainDb, err := ethdb.NewBoltDatabase(chaindata)
+	chainDb, err := ethdb.NewDatabase(chaindata)
 	if err != nil {
 		return err
 	}
 	defer chainDb.Close()
 	historyDb := chainDb
 	if chaindata != historyfile {
-		historyDb, err = ethdb.NewBoltDatabase(historyfile)
+		historyDb, err = ethdb.NewDatabase(historyfile)
 		if err != nil {
 			return err
 		}

--- a/cmd/state/stateless/check_change_sets.go
+++ b/cmd/state/stateless/check_change_sets.go
@@ -38,17 +38,11 @@ func CheckChangeSets(genesis *core.Genesis, blockNum uint64, chaindata string, h
 		interruptCh <- true
 	}()
 
-	chainDb, err := ethdb.NewDatabase(chaindata)
-	if err != nil {
-		return err
-	}
+	chainDb := ethdb.MustOpen(chaindata)
 	defer chainDb.Close()
 	historyDb := chainDb
 	if chaindata != historyfile {
-		historyDb, err = ethdb.NewDatabase(historyfile)
-		if err != nil {
-			return err
-		}
+		historyDb = ethdb.MustOpen(historyfile)
 	}
 
 	chainConfig := genesis.Config

--- a/cmd/state/stateless/deps.go
+++ b/cmd/state/stateless/deps.go
@@ -122,8 +122,7 @@ func dataDependencies(blockNum uint64) {
 		interruptCh <- true
 	}()
 
-	ethDb, err := ethdb.NewDatabase("/Volumes/tb4/turbo-geth-10/geth/chaindata")
-	check(err)
+	ethDb := ethdb.MustOpen("/Volumes/tb4/turbo-geth-10/geth/chaindata")
 	defer ethDb.Close()
 	chainConfig := params.MainnetChainConfig
 	depFile, err := os.OpenFile("/Volumes/tb4/turbo-geth/data_dependencies.csv", os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0600)

--- a/cmd/state/stateless/deps.go
+++ b/cmd/state/stateless/deps.go
@@ -122,7 +122,7 @@ func dataDependencies(blockNum uint64) {
 		interruptCh <- true
 	}()
 
-	ethDb, err := ethdb.NewBoltDatabase("/Volumes/tb4/turbo-geth-10/geth/chaindata")
+	ethDb, err := ethdb.NewDatabase("/Volumes/tb4/turbo-geth-10/geth/chaindata")
 	check(err)
 	defer ethDb.Close()
 	chainConfig := params.MainnetChainConfig

--- a/cmd/state/stateless/fee_market.go
+++ b/cmd/state/stateless/fee_market.go
@@ -27,9 +27,9 @@ func feemarket(blockNum uint64) {
 		<-sigs
 		interruptCh <- true
 	}()
-	ethDb, err := ethdb.NewBoltDatabase("/Volumes/tb4/turbo-geth-10/geth/chaindata")
-	//ethDb, err := ethdb.NewBoltDatabase("/Users/alexeyakhunov/Library/Ethereum/geth/chaindata")
-	//ethDb, err := ethdb.NewBoltDatabase("/home/akhounov/.ethereum/geth/chaindata1")
+	ethDb, err := ethdb.NewDatabase("/Volumes/tb4/turbo-geth-10/geth/chaindata")
+	//ethDb, err := ethdb.NewDatabase("/Users/alexeyakhunov/Library/Ethereum/geth/chaindata")
+	//ethDb, err := ethdb.NewDatabase("/home/akhounov/.ethereum/geth/chaindata1")
 	check(err)
 	defer ethDb.Close()
 	chainConfig := params.MainnetChainConfig

--- a/cmd/state/stateless/fee_market.go
+++ b/cmd/state/stateless/fee_market.go
@@ -27,21 +27,20 @@ func feemarket(blockNum uint64) {
 		<-sigs
 		interruptCh <- true
 	}()
-	ethDb, err := ethdb.NewDatabase("/Volumes/tb4/turbo-geth-10/geth/chaindata")
-	//ethDb, err := ethdb.NewDatabase("/Users/alexeyakhunov/Library/Ethereum/geth/chaindata")
-	//ethDb, err := ethdb.NewDatabase("/home/akhounov/.ethereum/geth/chaindata1")
-	check(err)
+	ethDb := ethdb.MustOpen("/Volumes/tb4/turbo-geth-10/geth/chaindata")
+	//ethDb := ethdb.MustOpen("/Users/alexeyakhunov/Library/Ethereum/geth/chaindata")
+	//ethDb := ethdb.MustOpen("/home/akhounov/.ethereum/geth/chaindata1")
 	defer ethDb.Close()
 	chainConfig := params.MainnetChainConfig
-	fmFile, err := os.OpenFile("fee_market.csv", os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0600)
-	check(err)
+	fmFile, openErr := os.OpenFile("fee_market.csv", os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0600)
+	check(openErr)
 	defer fmFile.Close()
 	w := bufio.NewWriter(fmFile)
 	defer w.Flush()
 	vmConfig := vm.Config{}
 	engine := ethash.NewFullFaker()
-	bcb, err := core.NewBlockChain(ethDb, nil, chainConfig, engine, vmConfig, nil, nil, nil)
-	check(err)
+	bcb, openErr := core.NewBlockChain(ethDb, nil, chainConfig, engine, vmConfig, nil, nil, nil)
+	check(openErr)
 	interrupt := false
 	txCount := 0
 	MinFeeMaxChangeDenominator := big.NewInt(8)

--- a/cmd/state/stateless/naked_accouts.go
+++ b/cmd/state/stateless/naked_accouts.go
@@ -83,7 +83,7 @@ func accountsReadWrites(blockNum uint64) {
 		interruptCh <- true
 	}()
 
-	ethDb, err := ethdb.NewBoltDatabase("/Volumes/tb41/turbo-geth-10/geth/chaindata")
+	ethDb, err := ethdb.NewDatabase("/Volumes/tb41/turbo-geth-10/geth/chaindata")
 	check(err)
 	defer ethDb.Close()
 	chainConfig := params.MainnetChainConfig

--- a/cmd/state/stateless/naked_accouts.go
+++ b/cmd/state/stateless/naked_accouts.go
@@ -83,8 +83,7 @@ func accountsReadWrites(blockNum uint64) {
 		interruptCh <- true
 	}()
 
-	ethDb, err := ethdb.NewDatabase("/Volumes/tb41/turbo-geth-10/geth/chaindata")
-	check(err)
+	ethDb := ethdb.MustOpen("/Volumes/tb41/turbo-geth-10/geth/chaindata")
 	defer ethDb.Close()
 	chainConfig := params.MainnetChainConfig
 	srwFile, err := os.OpenFile("/Volumes/tb41/turbo-geth/account_read_writes.csv", os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0600)

--- a/cmd/state/stateless/naked_storage.go
+++ b/cmd/state/stateless/naked_storage.go
@@ -111,8 +111,7 @@ func storageReadWrites(blockNum uint64) {
 		interruptCh <- true
 	}()
 
-	ethDb, err := ethdb.NewDatabase("/Volumes/tb41/turbo-geth-10/geth/chaindata")
-	check(err)
+	ethDb := ethdb.MustOpen("/Volumes/tb41/turbo-geth-10/geth/chaindata")
 	defer ethDb.Close()
 	chainConfig := params.MainnetChainConfig
 	srwFile, err := os.OpenFile("/Volumes/tb41/turbo-geth/storage_read_writes.csv", os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0600)

--- a/cmd/state/stateless/naked_storage.go
+++ b/cmd/state/stateless/naked_storage.go
@@ -111,7 +111,7 @@ func storageReadWrites(blockNum uint64) {
 		interruptCh <- true
 	}()
 
-	ethDb, err := ethdb.NewBoltDatabase("/Volumes/tb41/turbo-geth-10/geth/chaindata")
+	ethDb, err := ethdb.NewDatabase("/Volumes/tb41/turbo-geth-10/geth/chaindata")
 	check(err)
 	defer ethDb.Close()
 	chainConfig := params.MainnetChainConfig

--- a/cmd/state/stateless/spec_exec.go
+++ b/cmd/state/stateless/spec_exec.go
@@ -158,8 +158,7 @@ func speculativeExecution(blockNum uint64) {
 		interruptCh <- true
 	}()
 
-	ethDb, err := ethdb.NewDatabase("/Volumes/tb41/turbo-geth-10/geth/chaindata")
-	check(err)
+	ethDb := ethdb.MustOpen("/Volumes/tb41/turbo-geth-10/geth/chaindata")
 	defer ethDb.Close()
 	chainConfig := params.MainnetChainConfig
 	depFile, err := os.OpenFile("/Volumes/tb41/turbo-geth/spec_execution.csv", os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0600)

--- a/cmd/state/stateless/spec_exec.go
+++ b/cmd/state/stateless/spec_exec.go
@@ -158,7 +158,7 @@ func speculativeExecution(blockNum uint64) {
 		interruptCh <- true
 	}()
 
-	ethDb, err := ethdb.NewBoltDatabase("/Volumes/tb41/turbo-geth-10/geth/chaindata")
+	ethDb, err := ethdb.NewDatabase("/Volumes/tb41/turbo-geth-10/geth/chaindata")
 	check(err)
 	defer ethDb.Close()
 	chainConfig := params.MainnetChainConfig

--- a/cmd/state/stateless/state.go
+++ b/cmd/state/stateless/state.go
@@ -1371,10 +1371,9 @@ func makeCreators(blockNum uint64) {
 		interruptCh <- true
 	}()
 
-	//ethDb, err := ethdb.NewDatabase("/home/akhounov/.ethereum/geth/chaindata")
-	ethDb, err := ethdb.NewDatabase("/Volumes/tb41/turbo-geth/geth/chaindata")
-	//ethDb, err := ethdb.NewDatabase("/Users/alexeyakhunov/Library/Ethereum/geth/chaindata")
-	check(err)
+	//ethDb := ethdb.MustOpen("/home/akhounov/.ethereum/geth/chaindata")
+	ethDb := ethdb.MustOpen("/Volumes/tb41/turbo-geth/geth/chaindata")
+	//ethDb := ethdb.MustOpen("/Users/alexeyakhunov/Library/Ethereum/geth/chaindata")
 	defer ethDb.Close()
 	f, err := os.OpenFile("/Volumes/tb41/turbo-geth/creators.csv", os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0600)
 	check(err)
@@ -1421,10 +1420,9 @@ func makeCreators(blockNum uint64) {
 
 func storageUsage() {
 	startTime := time.Now()
-	//db, err := bolt.Open("/home/akhounov/.ethereum/geth/chaindata", 0600, &bolt.Options{ReadOnly: true})
-	db, err := bolt.Open("/Volumes/tb4/turbo-geth-10/geth/chaindata", 0600, &bolt.Options{ReadOnly: true})
-	//db, err := bolt.Open("/Users/alexeyakhunov/Library/Ethereum/geth/chaindata", 0600, &bolt.Options{ReadOnly: true})
-	check(err)
+	//db := ethdb.MustOpen("/home/akhounov/.ethereum/geth/chaindata")
+	db := ethdb.MustOpen("/Volumes/tb4/turbo-geth-10/geth/chaindata")
+	//db := ethdb.MustOpen("/Users/alexeyakhunov/Library/Ethereum/geth/chaindata")
 	defer db.Close()
 	/*
 		creatorsFile, err := os.Open("creators.csv")
@@ -1436,8 +1434,8 @@ func storageUsage() {
 			creators[common.HexToAddress(records[0])] = common.HexToAddress(records[1])
 		}
 	*/
-	addrFile, err := os.Open("addresses.csv")
-	check(err)
+	addrFile, openErr := os.Open("addresses.csv")
+	check(openErr)
 	defer addrFile.Close()
 	addrReader := csv.NewReader(bufio.NewReader(addrFile))
 	names := make(map[common.Address]string)
@@ -1452,13 +1450,16 @@ func storageUsage() {
 	//itemsByCreator := make(map[common.Address]int)
 	count := 0
 	var leafSize uint64
-	err = db.View(func(tx *bolt.Tx) error {
+	if err := db.KV().View(context.Background(), func(tx ethdb.Tx) error {
 		b := tx.Bucket(dbutils.CurrentStateBucket)
 		if b == nil {
 			return nil
 		}
 		c := b.Cursor()
-		for k, v := c.First(); k != nil; k, v = c.Next() {
+		for k, v, err := c.First(); k != nil; k, v, err = c.Next() {
+			if err != nil {
+				return err
+			}
 			if len(k) == 32 {
 				continue
 			}
@@ -1484,8 +1485,9 @@ func storageUsage() {
 			}
 		}
 		return nil
-	})
-	check(err)
+	}); err != nil {
+		panic(err)
+	}
 	fmt.Printf("Processing took %s\n", time.Since(startTime))
 	fmt.Printf("Average leaf size: %d/%d\n", leafSize, count)
 	iba := NewIntSorterAddr(len(itemsByAddress))
@@ -1539,21 +1541,20 @@ func storageUsage() {
 
 func tokenUsage() {
 	startTime := time.Now()
-	//remoteDB, err := bolt.Open("/home/akhounov/.ethereum/geth/chaindata", 0600, &bolt.Options{ReadOnly: true})
-	db, err := bolt.Open("/Volumes/tb4/turbo-geth/geth/chaindata", 0600, &bolt.Options{ReadOnly: true})
-	//remoteDB, err := bolt.Open("/Users/alexeyakhunov/Library/Ethereum/geth/chaindata", 0600, &bolt.Options{ReadOnly: true})
-	check(err)
+	//remoteDB := ethdb.MustOpen("/home/akhounov/.ethereum/geth/chaindata")
+	db := ethdb.MustOpen("/Volumes/tb4/turbo-geth/geth/chaindata")
+	//remoteDB := ethdb.MustOpen("/Users/alexeyakhunov/Library/Ethereum/geth/chaindata")
 	defer db.Close()
-	tokensFile, err := os.Open("tokens.csv")
-	check(err)
+	tokensFile, errOpen := os.Open("tokens.csv")
+	check(errOpen)
 	defer tokensFile.Close()
 	tokensReader := csv.NewReader(bufio.NewReader(tokensFile))
 	tokens := make(map[common.Address]struct{})
 	for records, _ := tokensReader.Read(); records != nil; records, _ = tokensReader.Read() {
 		tokens[common.HexToAddress(records[0])] = struct{}{}
 	}
-	addrFile, err := os.Open("addresses.csv")
-	check(err)
+	addrFile, errOpen := os.Open("addresses.csv")
+	check(errOpen)
 	defer addrFile.Close()
 	addrReader := csv.NewReader(bufio.NewReader(addrFile))
 	names := make(map[common.Address]string)
@@ -1565,13 +1566,16 @@ func tokenUsage() {
 	itemsByAddress := make(map[common.Address]int)
 	//itemsByCreator := make(map[common.Address]int)
 	count := 0
-	err = db.View(func(tx *bolt.Tx) error {
+	if err := db.KV().View(context.Background(), func(tx ethdb.Tx) error {
 		b := tx.Bucket(dbutils.CurrentStateBucket)
 		if b == nil {
 			return nil
 		}
 		c := b.Cursor()
-		for k, _ := c.First(); k != nil; k, _ = c.Next() {
+		for k, _, err := c.First(); k != nil; k, _, err = c.Next() {
+			if err != nil {
+				return err
+			}
 			if len(k) == 32 {
 				continue
 			}
@@ -1585,8 +1589,9 @@ func tokenUsage() {
 			}
 		}
 		return nil
-	})
-	check(err)
+	}); err != nil {
+		panic(err)
+	}
 	fmt.Printf("Processing took %s\n", time.Since(startTime))
 	iba := NewIntSorterAddr(len(itemsByAddress))
 	idx := 0
@@ -1618,21 +1623,20 @@ func tokenUsage() {
 
 func nonTokenUsage() {
 	startTime := time.Now()
-	//db, err := bolt.Open("/home/akhounov/.ethereum/geth/chaindata", 0600, &bolt.Options{ReadOnly: true})
-	db, err := bolt.Open("/Volumes/tb4/turbo-geth/geth/chaindata", 0600, &bolt.Options{ReadOnly: true})
-	//db, err := bolt.Open("/Users/alexeyakhunov/Library/Ethereum/geth/chaindata", 0600, &bolt.Options{ReadOnly: true})
-	check(err)
+	//db := ethdb.MustOpen("/home/akhounov/.ethereum/geth/chaindata")
+	db := ethdb.MustOpen("/Volumes/tb4/turbo-geth/geth/chaindata")
+	//db := ethdb.MustOpen("/Users/alexeyakhunov/Library/Ethereum/geth/chaindata")
 	defer db.Close()
-	tokensFile, err := os.Open("tokens.csv")
-	check(err)
+	tokensFile, errOpen := os.Open("tokens.csv")
+	check(errOpen)
 	defer tokensFile.Close()
 	tokensReader := csv.NewReader(bufio.NewReader(tokensFile))
 	tokens := make(map[common.Address]struct{})
 	for records, _ := tokensReader.Read(); records != nil; records, _ = tokensReader.Read() {
 		tokens[common.HexToAddress(records[0])] = struct{}{}
 	}
-	addrFile, err := os.Open("addresses.csv")
-	check(err)
+	addrFile, errOpen := os.Open("addresses.csv")
+	check(errOpen)
 	defer addrFile.Close()
 	addrReader := csv.NewReader(bufio.NewReader(addrFile))
 	names := make(map[common.Address]string)
@@ -1644,13 +1648,16 @@ func nonTokenUsage() {
 	itemsByAddress := make(map[common.Address]int)
 	//itemsByCreator := make(map[common.Address]int)
 	count := 0
-	err = db.View(func(tx *bolt.Tx) error {
+	if err := db.KV().View(context.Background(), func(tx ethdb.Tx) error {
 		b := tx.Bucket(dbutils.CurrentStateBucket)
 		if b == nil {
 			return nil
 		}
 		c := b.Cursor()
-		for k, _ := c.First(); k != nil; k, _ = c.Next() {
+		for k, _, err := c.First(); k != nil; k, _, err = c.Next() {
+			if err != nil {
+				return err
+			}
 			if len(k) == 32 {
 				continue
 			}
@@ -1664,8 +1671,9 @@ func nonTokenUsage() {
 			}
 		}
 		return nil
-	})
-	check(err)
+	}); err != nil {
+		panic(err)
+	}
 	fmt.Printf("Processing took %s\n", time.Since(startTime))
 	iba := NewIntSorterAddr(len(itemsByAddress))
 	idx := 0
@@ -1775,10 +1783,9 @@ func oldStorage() {
 
 func dustEOA() {
 	startTime := time.Now()
-	//db, err := bolt.Open("/home/akhounov/.ethereum/geth/chaindata", 0600, &bolt.Options{ReadOnly: true})
-	db, err := bolt.Open("/Volumes/tb4/turbo-geth/geth/chaindata", 0600, &bolt.Options{ReadOnly: true})
-	//db, err := bolt.Open("/Users/alexeyakhunov/Library/Ethereum/geth/chaindata", 0600, &bolt.Options{ReadOnly: true})
-	check(err)
+	//db := ethdb.MustOpen("/home/akhounov/.ethereum/geth/chaindata")
+	db := ethdb.MustOpen("/Volumes/tb4/turbo-geth/geth/chaindata")
+	//db := ethdb.MustOpen("/Users/alexeyakhunov/Library/Ethereum/geth/chaindata")
 	defer db.Close()
 	count := 0
 	eoas := 0
@@ -1786,13 +1793,16 @@ func dustEOA() {
 	// Go through the current state
 	thresholdMap := make(map[uint64]int)
 	var a accounts.Account
-	err = db.View(func(tx *bolt.Tx) error {
+	if err := db.KV().View(context.Background(), func(tx ethdb.Tx) error {
 		b := tx.Bucket(dbutils.CurrentStateBucket)
 		if b == nil {
 			return nil
 		}
 		c := b.Cursor()
-		for k, v := c.First(); k != nil; k, v = c.Next() {
+		for k, v, err := c.First(); k != nil; k, v, err = c.Next() {
+			if err != nil {
+				return err
+			}
 			if len(k) != 32 {
 				continue
 			}
@@ -1814,8 +1824,9 @@ func dustEOA() {
 			}
 		}
 		return nil
-	})
-	check(err)
+	}); err != nil {
+		panic(err)
+	}
 	fmt.Printf("Total accounts: %d, EOAs: %d\n", count, eoas)
 	tsi := NewTimeSorterInt(len(thresholdMap))
 	idx := 0
@@ -1951,10 +1962,9 @@ func makeSha3Preimages(blockNum uint64) {
 		interruptCh <- true
 	}()
 
-	//ethDb, err := ethdb.NewDatabase("/home/akhounov/.ethereum/geth/chaindata")
-	ethDb, err := ethdb.NewDatabase("/Volumes/tb4/turbo-geth/geth/chaindata")
-	//ethDb, err := ethdb.NewDatabase("/Users/alexeyakhunov/Library/Ethereum/geth/chaindata")
-	check(err)
+	//ethDb := ethdb.MustOpen("/home/akhounov/.ethereum/geth/chaindata")
+	ethDb := ethdb.MustOpen("/Volumes/tb4/turbo-geth/geth/chaindata")
+	//ethDb := ethdb.MustOpen("/Users/alexeyakhunov/Library/Ethereum/geth/chaindata")
 	defer ethDb.Close()
 	f, err := bolt.Open("/Volumes/tb4/turbo-geth/sha3preimages", 0600, &bolt.Options{})
 	check(err)

--- a/cmd/state/stateless/state.go
+++ b/cmd/state/stateless/state.go
@@ -1371,9 +1371,9 @@ func makeCreators(blockNum uint64) {
 		interruptCh <- true
 	}()
 
-	//ethDb, err := ethdb.NewBoltDatabase("/home/akhounov/.ethereum/geth/chaindata")
-	ethDb, err := ethdb.NewBoltDatabase("/Volumes/tb41/turbo-geth/geth/chaindata")
-	//ethDb, err := ethdb.NewBoltDatabase("/Users/alexeyakhunov/Library/Ethereum/geth/chaindata")
+	//ethDb, err := ethdb.NewDatabase("/home/akhounov/.ethereum/geth/chaindata")
+	ethDb, err := ethdb.NewDatabase("/Volumes/tb41/turbo-geth/geth/chaindata")
+	//ethDb, err := ethdb.NewDatabase("/Users/alexeyakhunov/Library/Ethereum/geth/chaindata")
 	check(err)
 	defer ethDb.Close()
 	f, err := os.OpenFile("/Volumes/tb41/turbo-geth/creators.csv", os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0600)
@@ -1951,9 +1951,9 @@ func makeSha3Preimages(blockNum uint64) {
 		interruptCh <- true
 	}()
 
-	//ethDb, err := ethdb.NewBoltDatabase("/home/akhounov/.ethereum/geth/chaindata")
-	ethDb, err := ethdb.NewBoltDatabase("/Volumes/tb4/turbo-geth/geth/chaindata")
-	//ethDb, err := ethdb.NewBoltDatabase("/Users/alexeyakhunov/Library/Ethereum/geth/chaindata")
+	//ethDb, err := ethdb.NewDatabase("/home/akhounov/.ethereum/geth/chaindata")
+	ethDb, err := ethdb.NewDatabase("/Volumes/tb4/turbo-geth/geth/chaindata")
+	//ethDb, err := ethdb.NewDatabase("/Users/alexeyakhunov/Library/Ethereum/geth/chaindata")
 	check(err)
 	defer ethDb.Close()
 	f, err := bolt.Open("/Volumes/tb4/turbo-geth/sha3preimages", 0600, &bolt.Options{})

--- a/cmd/state/stateless/state_snapshot.go
+++ b/cmd/state/stateless/state_snapshot.go
@@ -293,7 +293,7 @@ func checkRoots(stateDb ethdb.Database, rootHash common.Hash, blockNum uint64) {
 }
 
 func VerifySnapshot(path string) {
-	ethDb, err := ethdb.NewBoltDatabase(path)
+	ethDb, err := ethdb.NewDatabase(path)
 	check(err)
 	defer ethDb.Close()
 	hash := rawdb.ReadHeadBlockHash(ethDb)

--- a/cmd/state/stateless/stateless_block_providers.go
+++ b/cmd/state/stateless/stateless_block_providers.go
@@ -140,7 +140,7 @@ func getTempFileName() string {
 }
 
 func mustCreateTempDatabase() ethdb.Database {
-	db, err := ethdb.NewBoltDatabase(getTempFileName())
+	db, err := ethdb.NewDatabase(getTempFileName())
 	if err != nil {
 		panic(fmt.Errorf("failed to create a temp db for headers: %w", err))
 	}

--- a/cmd/state/stateless/stateless_block_providers.go
+++ b/cmd/state/stateless/stateless_block_providers.go
@@ -125,7 +125,7 @@ func NewBlockProviderFromExportFile(fn string) (BlockProvider, error) {
 	stream := rlp.NewStream(reader, 0)
 	engine := ethash.NewFullFaker()
 	// keeping all the past block headers in memory
-	headersDB := mustCreateTempDatabase()
+	headersDB := ethdb.MustOpen(getTempFileName())
 	return &ExportFileBlockProvider{stream, engine, headersDB, nil, fh, reader, -1}, nil
 }
 
@@ -137,14 +137,6 @@ func getTempFileName() string {
 	tmpfile.Close()
 	fmt.Printf("creating a temp headers db @ %s\n", tmpfile.Name())
 	return tmpfile.Name()
-}
-
-func mustCreateTempDatabase() ethdb.Database {
-	db, err := ethdb.NewDatabase(getTempFileName())
-	if err != nil {
-		panic(fmt.Errorf("failed to create a temp db for headers: %w", err))
-	}
-	return db
 }
 
 func (p *ExportFileBlockProvider) Close() error {

--- a/cmd/state/stateless/tokens.go
+++ b/cmd/state/stateless/tokens.go
@@ -128,10 +128,9 @@ func makeTokens(blockNum uint64) {
 		interruptCh <- true
 	}()
 
-	//ethDb, err := ethdb.NewDatabase("/home/akhounov/.ethereum/geth/chaindata")
-	ethDb, err := ethdb.NewDatabase("/Volumes/tb41/turbo-geth/geth/chaindata")
-	//ethDb, err := ethdb.NewDatabase("/Users/alexeyakhunov/Library/Ethereum/geth/chaindata")
-	check(err)
+	//ethDb err := ethdb.MustOpen("/home/akhounov/.ethereum/geth/chaindata")
+	ethDb := ethdb.MustOpen("/Volumes/tb41/turbo-geth/geth/chaindata")
+	//ethDb := ethdb.MustOpen("/Users/alexeyakhunov/Library/Ethereum/geth/chaindata")
 	defer ethDb.Close()
 	chainConfig := params.MainnetChainConfig
 	tt := NewTokenTracer()
@@ -190,10 +189,9 @@ func makeTokens(blockNum uint64) {
 }
 
 func makeTokenBalances() {
-	//ethDb, err := ethdb.NewDatabase("/home/akhounov/.ethereum/geth/chaindata")
-	ethDb, err := ethdb.NewDatabase("/Volumes/tb41/turbo-geth/geth/chaindata")
-	//ethDb, err := ethdb.NewDatabase("/Users/alexeyakhunov/Library/Ethereum/geth/chaindata")
-	check(err)
+	//ethDb := ethdb.MustOpen("/home/akhounov/.ethereum/geth/chaindata")
+	ethDb := ethdb.MustOpen("/Volumes/tb41/turbo-geth/geth/chaindata")
+	//ethDb := ethdb.MustOpen("/Users/alexeyakhunov/Library/Ethereum/geth/chaindata")
 	defer ethDb.Close()
 	bc, err := core.NewBlockChain(ethDb, nil, params.MainnetChainConfig, ethash.NewFaker(), vm.Config{}, nil, nil, nil)
 	check(err)
@@ -410,10 +408,9 @@ func tokenBalances() {
 }
 
 func makeTokenAllowances() {
-	//ethDb, err := ethdb.NewDatabase("/home/akhounov/.ethereum/geth/chaindata")
-	ethDb, err := ethdb.NewDatabase("/Volumes/tb41/turbo-geth/geth/chaindata")
-	//ethDb, err := ethdb.NewDatabase("/Users/alexeyakhunov/Library/Ethereum/geth/chaindata")
-	check(err)
+	//ethDb := ethdb.MustOpen("/home/akhounov/.ethereum/geth/chaindata")
+	ethDb := ethdb.MustOpen("/Volumes/tb41/turbo-geth/geth/chaindata")
+	//ethDb := ethdb.MustOpen("/Users/alexeyakhunov/Library/Ethereum/geth/chaindata")
 	defer ethDb.Close()
 	bc, err := core.NewBlockChain(ethDb, nil, params.MainnetChainConfig, ethash.NewFaker(), vm.Config{}, nil, nil, nil)
 	check(err)

--- a/cmd/state/stateless/tokens.go
+++ b/cmd/state/stateless/tokens.go
@@ -128,9 +128,9 @@ func makeTokens(blockNum uint64) {
 		interruptCh <- true
 	}()
 
-	//ethDb, err := ethdb.NewBoltDatabase("/home/akhounov/.ethereum/geth/chaindata")
-	ethDb, err := ethdb.NewBoltDatabase("/Volumes/tb41/turbo-geth/geth/chaindata")
-	//ethDb, err := ethdb.NewBoltDatabase("/Users/alexeyakhunov/Library/Ethereum/geth/chaindata")
+	//ethDb, err := ethdb.NewDatabase("/home/akhounov/.ethereum/geth/chaindata")
+	ethDb, err := ethdb.NewDatabase("/Volumes/tb41/turbo-geth/geth/chaindata")
+	//ethDb, err := ethdb.NewDatabase("/Users/alexeyakhunov/Library/Ethereum/geth/chaindata")
 	check(err)
 	defer ethDb.Close()
 	chainConfig := params.MainnetChainConfig
@@ -190,9 +190,9 @@ func makeTokens(blockNum uint64) {
 }
 
 func makeTokenBalances() {
-	//ethDb, err := ethdb.NewBoltDatabase("/home/akhounov/.ethereum/geth/chaindata")
-	ethDb, err := ethdb.NewBoltDatabase("/Volumes/tb41/turbo-geth/geth/chaindata")
-	//ethDb, err := ethdb.NewBoltDatabase("/Users/alexeyakhunov/Library/Ethereum/geth/chaindata")
+	//ethDb, err := ethdb.NewDatabase("/home/akhounov/.ethereum/geth/chaindata")
+	ethDb, err := ethdb.NewDatabase("/Volumes/tb41/turbo-geth/geth/chaindata")
+	//ethDb, err := ethdb.NewDatabase("/Users/alexeyakhunov/Library/Ethereum/geth/chaindata")
 	check(err)
 	defer ethDb.Close()
 	bc, err := core.NewBlockChain(ethDb, nil, params.MainnetChainConfig, ethash.NewFaker(), vm.Config{}, nil, nil, nil)
@@ -410,9 +410,9 @@ func tokenBalances() {
 }
 
 func makeTokenAllowances() {
-	//ethDb, err := ethdb.NewBoltDatabase("/home/akhounov/.ethereum/geth/chaindata")
-	ethDb, err := ethdb.NewBoltDatabase("/Volumes/tb41/turbo-geth/geth/chaindata")
-	//ethDb, err := ethdb.NewBoltDatabase("/Users/alexeyakhunov/Library/Ethereum/geth/chaindata")
+	//ethDb, err := ethdb.NewDatabase("/home/akhounov/.ethereum/geth/chaindata")
+	ethDb, err := ethdb.NewDatabase("/Volumes/tb41/turbo-geth/geth/chaindata")
+	//ethDb, err := ethdb.NewDatabase("/Users/alexeyakhunov/Library/Ethereum/geth/chaindata")
 	check(err)
 	defer ethDb.Close()
 	bc, err := core.NewBlockChain(ethDb, nil, params.MainnetChainConfig, ethash.NewFaker(), vm.Config{}, nil, nil, nil)

--- a/cmd/state/stateless/transaction_stats.go
+++ b/cmd/state/stateless/transaction_stats.go
@@ -167,10 +167,9 @@ func transactionStats(blockNum uint64) {
 		interruptCh <- true
 	}()
 
-	ethDb, err := ethdb.NewDatabase("/home/akhounov/.ethereum/geth/chaindata")
-	//ethDb, err := ethdb.NewDatabase("/Volumes/tb41/turbo-geth/geth/chaindata")
-	//ethDb, err := ethdb.NewDatabase("/Users/alexeyakhunov/Library/Ethereum/geth/chaindata")
-	check(err)
+	ethDb := ethdb.MustOpen("/home/akhounov/.ethereum/geth/chaindata")
+	//ethDb := ethdb.MustOpen("/Volumes/tb41/turbo-geth/geth/chaindata")
+	//ethDb := ethdb.MustOpen("/Users/alexeyakhunov/Library/Ethereum/geth/chaindata")
 	defer ethDb.Close()
 	f, err := os.OpenFile("txs.csv", os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0600)
 	check(err)

--- a/cmd/state/stateless/transaction_stats.go
+++ b/cmd/state/stateless/transaction_stats.go
@@ -167,9 +167,9 @@ func transactionStats(blockNum uint64) {
 		interruptCh <- true
 	}()
 
-	ethDb, err := ethdb.NewBoltDatabase("/home/akhounov/.ethereum/geth/chaindata")
-	//ethDb, err := ethdb.NewBoltDatabase("/Volumes/tb41/turbo-geth/geth/chaindata")
-	//ethDb, err := ethdb.NewBoltDatabase("/Users/alexeyakhunov/Library/Ethereum/geth/chaindata")
+	ethDb, err := ethdb.NewDatabase("/home/akhounov/.ethereum/geth/chaindata")
+	//ethDb, err := ethdb.NewDatabase("/Volumes/tb41/turbo-geth/geth/chaindata")
+	//ethDb, err := ethdb.NewDatabase("/Users/alexeyakhunov/Library/Ethereum/geth/chaindata")
 	check(err)
 	defer ethDb.Close()
 	f, err := os.OpenFile("txs.csv", os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0600)

--- a/cmd/state/stats/index_stats.go
+++ b/cmd/state/stats/index_stats.go
@@ -4,18 +4,19 @@ import (
 	"bytes"
 	"encoding/csv"
 	"fmt"
-	"github.com/ledgerwatch/turbo-geth/common"
-	"github.com/ledgerwatch/turbo-geth/common/dbutils"
-	"github.com/ledgerwatch/turbo-geth/ethdb"
 	"log"
 	"os"
 	"sort"
 	"strconv"
 	"time"
+
+	"github.com/ledgerwatch/turbo-geth/common"
+	"github.com/ledgerwatch/turbo-geth/common/dbutils"
+	"github.com/ledgerwatch/turbo-geth/ethdb"
 )
 
 func IndexStats(chaindata string, indexBucket []byte, statsFile string) error {
-	db, err := ethdb.NewBoltDatabase(chaindata)
+	db, err := ethdb.NewDatabase(chaindata)
 	if err != nil {
 		return err
 	}

--- a/cmd/state/stats/index_stats.go
+++ b/cmd/state/stats/index_stats.go
@@ -16,10 +16,7 @@ import (
 )
 
 func IndexStats(chaindata string, indexBucket []byte, statsFile string) error {
-	db, err := ethdb.NewDatabase(chaindata)
-	if err != nil {
-		return err
-	}
+	db := ethdb.MustOpen(chaindata)
 	startTime := time.Now()
 	lenOfKey := common.HashLength
 	if bytes.HasPrefix(indexBucket, dbutils.StorageHistoryBucket) {
@@ -38,7 +35,7 @@ func IndexStats(chaindata string, indexBucket []byte, statsFile string) error {
 	count := uint64(1)
 	added := false
 	i := uint64(0)
-	err = db.Walk(indexBucket, []byte{}, 0, func(k, v []byte) (b bool, e error) {
+	if err := db.Walk(indexBucket, []byte{}, 0, func(k, v []byte) (b bool, e error) {
 		if i%100_000 == 0 {
 			fmt.Printf("Processed %dK, %s\n", i/1000, time.Since(startTime))
 		}
@@ -73,8 +70,7 @@ func IndexStats(chaindata string, indexBucket []byte, statsFile string) error {
 		}
 
 		return true, nil
-	})
-	if err != nil {
+	}); err != nil {
 		return err
 	}
 

--- a/cmd/state/verify/check_changeset_enc.go
+++ b/cmd/state/verify/check_changeset_enc.go
@@ -22,10 +22,7 @@ type Walker interface {
 }
 
 func CheckEnc(chaindata string) error {
-	db, err := ethdb.NewDatabase(chaindata)
-	if err != nil {
-		return err
-	}
+	db := ethdb.MustOpen(chaindata)
 	defer db.Close()
 	var (
 		currentSize uint64
@@ -86,7 +83,7 @@ func CheckEnc(chaindata string) error {
 					}
 					j := 0
 
-					err = walker.Walk(func(kk, vv []byte) error {
+					err := walker.Walk(func(kk, vv []byte) error {
 						if !bytes.Equal(kk, cs2.Changes[j].Key) {
 							return fmt.Errorf("incorrect order. block: %d, element: %v", blockNum, j)
 						}
@@ -141,7 +138,7 @@ func CheckEnc(chaindata string) error {
 			return true, nil
 		})
 	})
-	err = g.Wait()
+	err := g.Wait()
 	if err != nil {
 		return err
 	}

--- a/cmd/state/verify/check_changeset_enc.go
+++ b/cmd/state/verify/check_changeset_enc.go
@@ -22,7 +22,10 @@ type Walker interface {
 }
 
 func CheckEnc(chaindata string) error {
-	db := ethdb.NewObjectDatabase(ethdb.NewBolt().Path(chaindata).MustOpen())
+	db, err := ethdb.NewDatabase(chaindata)
+	if err != nil {
+		return err
+	}
 	defer db.Close()
 	var (
 		currentSize uint64
@@ -83,7 +86,7 @@ func CheckEnc(chaindata string) error {
 					}
 					j := 0
 
-					err := walker.Walk(func(kk, vv []byte) error {
+					err = walker.Walk(func(kk, vv []byte) error {
 						if !bytes.Equal(kk, cs2.Changes[j].Key) {
 							return fmt.Errorf("incorrect order. block: %d, element: %v", blockNum, j)
 						}
@@ -138,7 +141,7 @@ func CheckEnc(chaindata string) error {
 			return true, nil
 		})
 	})
-	err := g.Wait()
+	err = g.Wait()
 	if err != nil {
 		return err
 	}

--- a/cmd/state/verify/check_changeset_enc.go
+++ b/cmd/state/verify/check_changeset_enc.go
@@ -4,15 +4,16 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"reflect"
+	"runtime"
+	"sync/atomic"
+	"time"
+
 	"github.com/ledgerwatch/turbo-geth/common"
 	"github.com/ledgerwatch/turbo-geth/common/changeset"
 	"github.com/ledgerwatch/turbo-geth/common/dbutils"
 	"github.com/ledgerwatch/turbo-geth/ethdb"
 	"golang.org/x/sync/errgroup"
-	"reflect"
-	"runtime"
-	"sync/atomic"
-	"time"
 )
 
 type Walker interface {
@@ -21,10 +22,8 @@ type Walker interface {
 }
 
 func CheckEnc(chaindata string) error {
-	db, err := ethdb.NewBoltDatabase(chaindata)
-	if err != nil {
-		return err
-	}
+	db := ethdb.NewObjectDatabase(ethdb.NewBolt().Path(chaindata).MustOpen())
+	defer db.Close()
 	var (
 		currentSize uint64
 		newSize     uint64
@@ -84,7 +83,7 @@ func CheckEnc(chaindata string) error {
 					}
 					j := 0
 
-					err = walker.Walk(func(kk, vv []byte) error {
+					err := walker.Walk(func(kk, vv []byte) error {
 						if !bytes.Equal(kk, cs2.Changes[j].Key) {
 							return fmt.Errorf("incorrect order. block: %d, element: %v", blockNum, j)
 						}
@@ -139,7 +138,7 @@ func CheckEnc(chaindata string) error {
 			return true, nil
 		})
 	})
-	err = g.Wait()
+	err := g.Wait()
 	if err != nil {
 		return err
 	}

--- a/cmd/state/verify/check_indexes.go
+++ b/cmd/state/verify/check_indexes.go
@@ -13,7 +13,7 @@ import (
 )
 
 func CheckIndex(chaindata string, changeSetBucket []byte, indexBucket []byte) error {
-	db, err := ethdb.NewBoltDatabase(chaindata)
+	db, err := ethdb.NewDatabase(chaindata)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/cmd/state/verify/check_indexes.go
+++ b/cmd/state/verify/check_indexes.go
@@ -3,7 +3,6 @@ package verify
 import (
 	"bytes"
 	"fmt"
-	"log"
 	"time"
 
 	"github.com/ledgerwatch/turbo-geth/common"
@@ -13,10 +12,7 @@ import (
 )
 
 func CheckIndex(chaindata string, changeSetBucket []byte, indexBucket []byte) error {
-	db, err := ethdb.NewDatabase(chaindata)
-	if err != nil {
-		log.Fatal(err)
-	}
+	db := ethdb.MustOpen(chaindata)
 	startTime := time.Now()
 
 	var walker func([]byte) changeset.Walker
@@ -32,15 +28,15 @@ func CheckIndex(chaindata string, changeSetBucket []byte, indexBucket []byte) er
 		}
 	}
 
-	err = db.Walk(changeSetBucket, []byte{}, 0, func(k, v []byte) (b bool, e error) {
+	if err := db.Walk(changeSetBucket, []byte{}, 0, func(k, v []byte) (b bool, e error) {
 		blockNum, _ := dbutils.DecodeTimestamp(k)
 		if blockNum%100_000 == 0 {
 			fmt.Printf("Processed %dK, %s\n", blockNum/1000, time.Since(startTime))
 		}
 
-		err = walker(v).Walk(func(key, val []byte) error {
+		if err := walker(v).Walk(func(key, val []byte) error {
 			indexBytes, innerErr := db.GetIndexChunk(indexBucket, key, blockNum)
-			if err != nil {
+			if innerErr != nil {
 				return innerErr
 			}
 
@@ -49,14 +45,11 @@ func CheckIndex(chaindata string, changeSetBucket []byte, indexBucket []byte) er
 				return fmt.Errorf("%v,%v,%v", blockNum, findVal, common.Bytes2Hex(key))
 			}
 			return nil
-		})
-		if err != nil {
+		}); err != nil {
 			return false, err
 		}
 		return true, nil
-	})
-
-	if err != nil {
+	}); err != nil {
 		return err
 	}
 

--- a/cmd/state/verify/verify_export_file.go
+++ b/cmd/state/verify/verify_export_file.go
@@ -19,7 +19,7 @@ func ExportFile(filePath, chaindataPath string) error {
 	}
 
 	createDb := func(path string) (ethdb.Database, error) {
-		return ethdb.NewBoltDatabase(path)
+		return ethdb.NewDatabase(path)
 	}
 
 	chaindata, err := stateless.NewBlockProviderFromDB(chaindataPath, createDb)

--- a/cmd/state/verify/verify_export_file.go
+++ b/cmd/state/verify/verify_export_file.go
@@ -19,7 +19,7 @@ func ExportFile(filePath, chaindataPath string) error {
 	}
 
 	createDb := func(path string) (ethdb.Database, error) {
-		return ethdb.NewDatabase(path)
+		return ethdb.Open(path)
 	}
 
 	chaindata, err := stateless.NewBlockProviderFromDB(chaindataPath, createDb)

--- a/cmd/state/verify/verify_txlookup.go
+++ b/cmd/state/verify/verify_txlookup.go
@@ -3,19 +3,20 @@ package verify
 import (
 	"bytes"
 	"fmt"
+	"math/big"
+	"os"
+	"os/signal"
+	"time"
+
 	"github.com/ledgerwatch/turbo-geth/common"
 	"github.com/ledgerwatch/turbo-geth/common/dbutils"
 	"github.com/ledgerwatch/turbo-geth/core/rawdb"
 	"github.com/ledgerwatch/turbo-geth/ethdb"
 	"github.com/ledgerwatch/turbo-geth/log"
-	"math/big"
-	"os"
-	"os/signal"
-	"time"
 )
 
 func ValidateTxLookups(chaindata string) error {
-	db, err := ethdb.NewBoltDatabase(chaindata)
+	db, err := ethdb.NewDatabase(chaindata)
 	if err != nil {
 		return err
 	}

--- a/cmd/state/verify/verify_txlookup.go
+++ b/cmd/state/verify/verify_txlookup.go
@@ -16,10 +16,7 @@ import (
 )
 
 func ValidateTxLookups(chaindata string) error {
-	db, err := ethdb.NewDatabase(chaindata)
-	if err != nil {
-		return err
-	}
+	db := ethdb.MustOpen(chaindata)
 
 	ch := make(chan os.Signal, 1)
 	quitCh := make(chan struct{})

--- a/common/debug/hack/cs_test.go
+++ b/common/debug/hack/cs_test.go
@@ -14,10 +14,7 @@ import (
 func TestDecodeNewStorageDebug(t *testing.T) {
 	t.Skip("debug test")
 	pathToDB := ""
-	db, err := ethdb.NewDatabase(pathToDB)
-	if err != nil {
-		t.Fatal(err)
-	}
+	db := ethdb.MustOpen(pathToDB)
 
 	data, err := db.Get(dbutils.StorageChangeSetBucket, dbutils.EncodeTimestamp(116526))
 	if err != nil {

--- a/common/debug/hack/cs_test.go
+++ b/common/debug/hack/cs_test.go
@@ -3,17 +3,18 @@ package hack
 import (
 	"bytes"
 	"fmt"
+	"testing"
+
 	"github.com/ledgerwatch/turbo-geth/common"
 	"github.com/ledgerwatch/turbo-geth/common/changeset"
 	"github.com/ledgerwatch/turbo-geth/common/dbutils"
 	"github.com/ledgerwatch/turbo-geth/ethdb"
-	"testing"
 )
 
 func TestDecodeNewStorageDebug(t *testing.T) {
 	t.Skip("debug test")
 	pathToDB := ""
-	db, err := ethdb.NewBoltDatabase(pathToDB)
+	db, err := ethdb.NewDatabase(pathToDB)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/core/bench_test.go
+++ b/core/bench_test.go
@@ -161,7 +161,7 @@ func benchInsertChain(b *testing.B, disk bool, gen func(int, *BlockGen)) {
 			b.Fatalf("cannot create temporary directory: %v", err)
 		}
 		defer os.RemoveAll(dir)
-		db, err = ethdb.NewBoltDatabase(dir)
+		db, err = ethdb.NewDatabase(dir)
 		if err != nil {
 			b.Fatalf("cannot create temporary database: %v", err)
 		}
@@ -263,7 +263,7 @@ func benchWriteChain(b *testing.B, full bool, count uint64) {
 		if err != nil {
 			b.Fatalf("cannot create temporary directory: %v", err)
 		}
-		db, err := ethdb.NewBoltDatabase(dir)
+		db, err := ethdb.NewDatabase(dir)
 		if err != nil {
 			b.Fatalf("error opening database at %v: %v", dir, err)
 		}
@@ -280,7 +280,7 @@ func benchReadChain(b *testing.B, full bool, count uint64) {
 	}
 	defer os.RemoveAll(dir)
 
-	db, err := ethdb.NewBoltDatabase(dir)
+	db, err := ethdb.NewDatabase(dir)
 	if err != nil {
 		b.Fatalf("error opening database at %v: %v", dir, err)
 	}
@@ -291,7 +291,7 @@ func benchReadChain(b *testing.B, full bool, count uint64) {
 	b.ResetTimer()
 
 	for i := 0; i < b.N; i++ {
-		db, err := ethdb.NewBoltDatabase(dir)
+		db, err := ethdb.NewDatabase(dir)
 		if err != nil {
 			b.Fatalf("error opening database at %v: %v", dir, err)
 		}

--- a/core/bench_test.go
+++ b/core/bench_test.go
@@ -161,10 +161,7 @@ func benchInsertChain(b *testing.B, disk bool, gen func(int, *BlockGen)) {
 			b.Fatalf("cannot create temporary directory: %v", err)
 		}
 		defer os.RemoveAll(dir)
-		db, err = ethdb.NewDatabase(dir)
-		if err != nil {
-			b.Fatalf("cannot create temporary database: %v", err)
-		}
+		db = ethdb.MustOpen(dir)
 		defer db.Close()
 	}
 
@@ -263,10 +260,7 @@ func benchWriteChain(b *testing.B, full bool, count uint64) {
 		if err != nil {
 			b.Fatalf("cannot create temporary directory: %v", err)
 		}
-		db, err := ethdb.NewDatabase(dir)
-		if err != nil {
-			b.Fatalf("error opening database at %v: %v", dir, err)
-		}
+		db := ethdb.MustOpen(dir)
 		makeChainForBench(db, full, count)
 		db.Close()
 		os.RemoveAll(dir)
@@ -280,10 +274,7 @@ func benchReadChain(b *testing.B, full bool, count uint64) {
 	}
 	defer os.RemoveAll(dir)
 
-	db, err := ethdb.NewDatabase(dir)
-	if err != nil {
-		b.Fatalf("error opening database at %v: %v", dir, err)
-	}
+	db := ethdb.MustOpen(dir)
 	makeChainForBench(db, full, count)
 	db.Close()
 
@@ -291,10 +282,7 @@ func benchReadChain(b *testing.B, full bool, count uint64) {
 	b.ResetTimer()
 
 	for i := 0; i < b.N; i++ {
-		db, err := ethdb.NewDatabase(dir)
-		if err != nil {
-			b.Fatalf("error opening database at %v: %v", dir, err)
-		}
+		db := ethdb.MustOpen(dir)
 		chain, err := NewBlockChain(db, nil, params.TestChainConfig, ethash.NewFaker(), vm.Config{}, nil, nil, nil)
 		if err != nil {
 			b.Fatalf("error creating chain: %v", err)

--- a/core/generate_index.go
+++ b/core/generate_index.go
@@ -5,15 +5,16 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
+	"os"
+	"runtime"
+	"time"
+
 	"github.com/ledgerwatch/turbo-geth/common"
 	"github.com/ledgerwatch/turbo-geth/common/changeset"
 	"github.com/ledgerwatch/turbo-geth/common/dbutils"
 	"github.com/ledgerwatch/turbo-geth/common/etl"
 	"github.com/ledgerwatch/turbo-geth/ethdb"
 	"github.com/ledgerwatch/turbo-geth/log"
-	"os"
-	"runtime"
-	"time"
 )
 
 func NewIndexGenerator(db ethdb.Database, quitCh chan struct{}) *IndexGenerator {
@@ -203,7 +204,7 @@ func (ig *IndexGenerator) DropIndex(bucket []byte) error {
 	//todo add truncate to all db
 	if bolt, ok := ig.db.(*ethdb.BoltDatabase); ok {
 		log.Warn("Remove bucket", "bucket", string(bucket))
-		err := bolt.DeleteBucket(bucket)
+		err := bolt.ClearBuckets(bucket)
 		if err != nil {
 			return err
 		}

--- a/eth/filters/bench_test.go
+++ b/eth/filters/bench_test.go
@@ -147,7 +147,9 @@ var bloomBitsPrefix = []byte("BloomBits")
 
 func clearBloomBits(db ethdb.Database) {
 	fmt.Println("Clearing bloombits data...")
-	db.(*ethdb.BoltDatabase).DeleteBucket(bloomBitsPrefix)
+	if err := db.(*ethdb.BoltDatabase).ClearBuckets(bloomBitsPrefix); err != nil {
+		panic(err)
+	}
 }
 
 func BenchmarkNoBloomBits(b *testing.B) {

--- a/eth/filters/bench_test.go
+++ b/eth/filters/bench_test.go
@@ -65,7 +65,7 @@ func benchmarkBloomBits(b *testing.B, sectionSize uint64) {
 	benchDataDir := node.DefaultDataDir() + "/geth/chaindata"
 	b.Log("Running bloombits benchmark   section size:", sectionSize)
 
-	db, err := ethdb.NewBoltDatabase(benchDataDir)
+	db, err := ethdb.NewDatabase(benchDataDir)
 	if err != nil {
 		b.Fatalf("error opening database at %v: %v", benchDataDir, err)
 	}
@@ -126,7 +126,7 @@ func benchmarkBloomBits(b *testing.B, sectionSize uint64) {
 	for i := 0; i < benchFilterCnt; i++ {
 		if i%20 == 0 {
 			db.Close()
-			db, _ = ethdb.NewBoltDatabase(benchDataDir)
+			db, _ = ethdb.NewDatabase(benchDataDir)
 			backend = &testBackend{db: db, sections: cnt}
 		}
 		var addr common.Address
@@ -155,7 +155,7 @@ func clearBloomBits(db ethdb.Database) {
 func BenchmarkNoBloomBits(b *testing.B) {
 	benchDataDir := node.DefaultDataDir() + "/geth/chaindata"
 	fmt.Println("Running benchmark without bloombits")
-	db, err := ethdb.NewBoltDatabase(benchDataDir)
+	db, err := ethdb.NewDatabase(benchDataDir)
 	if err != nil {
 		b.Fatalf("error opening database at %v: %v", benchDataDir, err)
 	}

--- a/eth/filters/bench_test.go
+++ b/eth/filters/bench_test.go
@@ -65,10 +65,7 @@ func benchmarkBloomBits(b *testing.B, sectionSize uint64) {
 	benchDataDir := node.DefaultDataDir() + "/geth/chaindata"
 	b.Log("Running bloombits benchmark   section size:", sectionSize)
 
-	db, err := ethdb.NewDatabase(benchDataDir)
-	if err != nil {
-		b.Fatalf("error opening database at %v: %v", benchDataDir, err)
-	}
+	db := ethdb.MustOpen(benchDataDir)
 	head := rawdb.ReadHeadBlockHash(db)
 	if head == (common.Hash{}) {
 		b.Fatalf("chain data not found at %v", benchDataDir)
@@ -126,7 +123,7 @@ func benchmarkBloomBits(b *testing.B, sectionSize uint64) {
 	for i := 0; i < benchFilterCnt; i++ {
 		if i%20 == 0 {
 			db.Close()
-			db, _ = ethdb.NewDatabase(benchDataDir)
+			db = ethdb.MustOpen(benchDataDir)
 			backend = &testBackend{db: db, sections: cnt}
 		}
 		var addr common.Address
@@ -155,10 +152,7 @@ func clearBloomBits(db ethdb.Database) {
 func BenchmarkNoBloomBits(b *testing.B) {
 	benchDataDir := node.DefaultDataDir() + "/geth/chaindata"
 	fmt.Println("Running benchmark without bloombits")
-	db, err := ethdb.NewDatabase(benchDataDir)
-	if err != nil {
-		b.Fatalf("error opening database at %v: %v", benchDataDir, err)
-	}
+	db := ethdb.MustOpen(benchDataDir)
 	head := rawdb.ReadHeadBlockHash(db)
 	if head == (common.Hash{}) {
 		b.Fatalf("chain data not found at %v", benchDataDir)

--- a/eth/filters/filter_test.go
+++ b/eth/filters/filter_test.go
@@ -52,10 +52,7 @@ func BenchmarkFilters(b *testing.B) {
 	}
 	defer os.RemoveAll(dir)
 
-	db, err := ethdb.NewDatabase(dir)
-	if err != nil {
-		b.Fatal(err)
-	}
+	db := ethdb.MustOpen(dir)
 	defer db.Close()
 	var (
 		backend = &testBackend{db: db}

--- a/eth/filters/filter_test.go
+++ b/eth/filters/filter_test.go
@@ -52,8 +52,9 @@ func BenchmarkFilters(b *testing.B) {
 	}
 	defer os.RemoveAll(dir)
 
+	db := ethdb.NewObjectDatabase(ethdb.NewBolt().Path(dir).MustOpen())
+	defer db.Close()
 	var (
-		db, _   = ethdb.NewBoltDatabase(dir)
 		backend = &testBackend{db: db}
 		key1, _ = crypto.HexToECDSA("b71c71a67e1177ad4e901695e1b4b9ee17ae16c6668d313eac2f96dbcda3f291")
 		addr1   = crypto.PubkeyToAddress(key1.PublicKey)
@@ -61,7 +62,6 @@ func BenchmarkFilters(b *testing.B) {
 		addr3   = common.BytesToAddress([]byte("ethereum"))
 		addr4   = common.BytesToAddress([]byte("random addresses please"))
 	)
-	defer db.Close()
 
 	genesis := core.GenesisBlockForTesting(db, addr1, big.NewInt(1000000))
 	chain, receipts := core.GenerateChain(context.Background(), params.TestChainConfig, genesis, ethash.NewFaker(), db, 100010, func(i int, gen *core.BlockGen) {

--- a/eth/filters/filter_test.go
+++ b/eth/filters/filter_test.go
@@ -52,7 +52,10 @@ func BenchmarkFilters(b *testing.B) {
 	}
 	defer os.RemoveAll(dir)
 
-	db := ethdb.NewObjectDatabase(ethdb.NewBolt().Path(dir).MustOpen())
+	db, err := ethdb.NewDatabase(dir)
+	if err != nil {
+		b.Fatal(err)
+	}
 	defer db.Close()
 	var (
 		backend = &testBackend{db: db}

--- a/eth/handler.go
+++ b/eth/handler.go
@@ -999,7 +999,7 @@ func (pm *ProtocolManager) handleDebugMsg(p *debugPeer) error {
 		}
 
 		_ = os.Remove("simulator")
-		ethDb, err := ethdb.NewBoltDatabase("simulator")
+		ethDb, err := ethdb.NewDatabase("simulator")
 		if err != nil {
 			return err
 		}

--- a/eth/handler.go
+++ b/eth/handler.go
@@ -999,10 +999,7 @@ func (pm *ProtocolManager) handleDebugMsg(p *debugPeer) error {
 		}
 
 		_ = os.Remove("simulator")
-		ethDb, err := ethdb.NewDatabase("simulator")
-		if err != nil {
-			return err
-		}
+		ethDb := ethdb.MustOpen("simulator")
 		chainConfig, _, _, err := core.SetupGenesisBlock(ethDb, genesis, true /* history */)
 		if err != nil {
 			return fmt.Errorf("SetupGenesisBlock: %w", err)

--- a/eth/stagedsync/stage_execute.go
+++ b/eth/stagedsync/stage_execute.go
@@ -172,7 +172,7 @@ func SpawnExecuteBlocksStage(s *StageState, stateDB ethdb.Database, blockchain B
 			if _, err = batch.Commit(); err != nil {
 				return err
 			}
-			log.Info("Batch committed", "in", time.Since(start))
+			log.Info("Batch committed", "in", time.Since(start), "size", common.StorageSize(batch.BatchSize()))
 		}
 
 		if prof {

--- a/eth/stagedsync/stage_headers.go
+++ b/eth/stagedsync/stage_headers.go
@@ -4,6 +4,12 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"math/big"
+	mrand "math/rand"
+	"os"
+	"runtime/pprof"
+	"time"
+
 	"github.com/ledgerwatch/turbo-geth/common"
 	"github.com/ledgerwatch/turbo-geth/consensus"
 	"github.com/ledgerwatch/turbo-geth/core/rawdb"
@@ -11,11 +17,6 @@ import (
 	"github.com/ledgerwatch/turbo-geth/ethdb"
 	"github.com/ledgerwatch/turbo-geth/log"
 	"github.com/ledgerwatch/turbo-geth/params"
-	"math/big"
-	mrand "math/rand"
-	"os"
-	"runtime/pprof"
-	"time"
 )
 
 func SpawnHeaderDownloadStage(s *StageState, u Unwinder, d DownloaderGlue, headersFetchers []func() error) error {

--- a/ethdb/badger_db.go
+++ b/ethdb/badger_db.go
@@ -376,6 +376,15 @@ func (db *BadgerDatabase) DiskSize(_ context.Context) (common.StorageSize, error
 	return common.StorageSize(lsm + vlog), nil
 }
 
+func (db *BadgerDatabase) ClearBuckets(buckets ...[]byte) error {
+	for _, bucket := range buckets {
+		if err := db.db.DropPrefix(bucket); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 func (db *BadgerDatabase) BucketsStat(ctx context.Context) (map[string]common.StorageBucketWriteStats, error) {
 	return nil, nil
 }

--- a/ethdb/bolt_db.go
+++ b/ethdb/bolt_db.go
@@ -425,14 +425,22 @@ func (db *BoltDatabase) Delete(bucket, key []byte) error {
 	return err
 }
 
-func (db *BoltDatabase) DeleteBucket(bucket []byte) error {
-	err := db.db.Update(func(tx *bolt.Tx) error {
-		if err := tx.DeleteBucket(bucket); err != nil {
+func (db *BoltDatabase) ClearBuckets(buckets ...[]byte) error {
+	for _, bucket := range buckets {
+		bucket := bucket
+		if err := db.db.Update(func(tx *bolt.Tx) error {
+			if err := tx.DeleteBucket(bucket); err != nil {
+				return err
+			}
+			if _, err := tx.CreateBucket(bucket, false); err != nil {
+				return err
+			}
+			return nil
+		}); err != nil {
 			return err
 		}
-		return nil
-	})
-	return err
+	}
+	return nil
 }
 
 func (db *BoltDatabase) Close() {

--- a/ethdb/kv_abstract.go
+++ b/ethdb/kv_abstract.go
@@ -33,6 +33,7 @@ type Bucket interface {
 	Cursor() Cursor
 
 	Size() (uint64, error)
+	Clear() error
 }
 
 type Cursor interface {

--- a/ethdb/kv_abstract.go
+++ b/ethdb/kv_abstract.go
@@ -12,6 +12,7 @@ type KV interface {
 	Close()
 
 	Begin(ctx context.Context, writable bool) (Tx, error)
+	IdealBatchSize() int
 }
 
 type NativeGet interface {

--- a/ethdb/kv_badger.go
+++ b/ethdb/kv_badger.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/dgraph-io/badger/v2"
 	"github.com/ledgerwatch/turbo-geth/common"
+	"github.com/ledgerwatch/turbo-geth/common/dbutils"
 	"github.com/ledgerwatch/turbo-geth/log"
 )
 
@@ -161,6 +162,7 @@ type badgerBucket struct {
 	nameLen uint
 	tx      *badgerTx
 	prefix  []byte
+	id      int
 }
 
 type badgerCursor struct {
@@ -201,7 +203,7 @@ func (db *badgerKV) Update(ctx context.Context, f func(tx Tx) error) (err error)
 }
 
 func (tx *badgerTx) Bucket(name []byte) Bucket {
-	b := badgerBucket{tx: tx, nameLen: uint(len(name))}
+	b := badgerBucket{tx: tx, nameLen: uint(len(name)), id: dbutils.BucketsIndex[string(name)]}
 	b.prefix = name
 	return b
 }
@@ -298,6 +300,10 @@ func (b badgerBucket) Delete(key []byte) error {
 
 func (b badgerBucket) Size() (uint64, error) {
 	panic("not implemented")
+}
+
+func (b badgerBucket) Clear() error {
+	return b.tx.db.badger.DropPrefix(dbutils.Buckets[b.id])
 }
 
 func (b badgerBucket) Cursor() Cursor {

--- a/ethdb/kv_badger.go
+++ b/ethdb/kv_badger.go
@@ -141,6 +141,10 @@ func (db *badgerKV) BucketsStat(_ context.Context) (map[string]common.StorageBuc
 	return map[string]common.StorageBucketWriteStats{}, nil
 }
 
+func (db *badgerKV) IdealBatchSize() int {
+	return int(db.badger.MaxBatchSize() / 2)
+}
+
 func (db *badgerKV) Begin(ctx context.Context, writable bool) (Tx, error) {
 	t := badgerTxPool.Get().(*badgerTx)
 	defer badgerTxPool.Put(t)

--- a/ethdb/kv_badger.go
+++ b/ethdb/kv_badger.go
@@ -3,11 +3,6 @@ package ethdb
 import (
 	"context"
 	"errors"
-	"fmt"
-	"math/rand"
-	"net/http"
-	"net/http/pprof"
-	"os"
 	"sync"
 	"time"
 
@@ -21,22 +16,6 @@ var (
 	badgerTxPool     = sync.Pool{New: func() interface{} { return &badgerTx{} }}     // pool of ethdb.badgerTx objects
 	badgerCursorPool = sync.Pool{New: func() interface{} { return &badgerCursor{} }} // pool of ethdb.badgerCursor objects
 )
-
-func init() {
-	// go tool pprof -http=:8081 http://localhost:6060/
-	_ = pprof.Handler // just to avoid adding manually: import _ "net/http/pprof"
-	go func() {
-		r := rand.New(rand.NewSource(int64(time.Now().Nanosecond())))
-		randomPort := func(min, max int) int {
-			return r.Intn(max-min) + min
-		}
-		port := randomPort(6000, 7000)
-
-		fmt.Fprintf(os.Stderr, "go tool pprof -lines -http=: :%d/%s\n", port, "\\?seconds\\=20")
-		fmt.Fprintf(os.Stderr, "go tool pprof -lines -http=: :%d/%s\n", port, "debug/pprof/heap")
-		fmt.Fprintf(os.Stderr, "%s\n", http.ListenAndServe(fmt.Sprintf("127.0.0.1:%d", port), nil))
-	}()
-}
 
 type badgerOpts struct {
 	Badger badger.Options

--- a/ethdb/kv_badger.go
+++ b/ethdb/kv_badger.go
@@ -3,6 +3,11 @@ package ethdb
 import (
 	"context"
 	"errors"
+	"fmt"
+	"math/rand"
+	"net/http"
+	"net/http/pprof"
+	"os"
 	"sync"
 	"time"
 
@@ -16,6 +21,22 @@ var (
 	badgerTxPool     = sync.Pool{New: func() interface{} { return &badgerTx{} }}     // pool of ethdb.badgerTx objects
 	badgerCursorPool = sync.Pool{New: func() interface{} { return &badgerCursor{} }} // pool of ethdb.badgerCursor objects
 )
+
+func init() {
+	// go tool pprof -http=:8081 http://localhost:6060/
+	_ = pprof.Handler // just to avoid adding manually: import _ "net/http/pprof"
+	go func() {
+		r := rand.New(rand.NewSource(int64(time.Now().Nanosecond())))
+		randomPort := func(min, max int) int {
+			return r.Intn(max-min) + min
+		}
+		port := randomPort(6000, 7000)
+
+		fmt.Fprintf(os.Stderr, "go tool pprof -lines -http=: :%d/%s\n", port, "\\?seconds\\=20")
+		fmt.Fprintf(os.Stderr, "go tool pprof -lines -http=: :%d/%s\n", port, "debug/pprof/heap")
+		fmt.Fprintf(os.Stderr, "%s\n", http.ListenAndServe(fmt.Sprintf("127.0.0.1:%d", port), nil))
+	}()
+}
 
 type badgerOpts struct {
 	Badger badger.Options

--- a/ethdb/kv_badger.go
+++ b/ethdb/kv_badger.go
@@ -3,6 +3,8 @@ package ethdb
 import (
 	"context"
 	"errors"
+	"fmt"
+	"os"
 	"sync"
 	"time"
 
@@ -42,6 +44,12 @@ func (opts badgerOpts) Open() (KV, error) {
 
 	if opts.Badger.InMemory {
 		opts.Badger = opts.Badger.WithEventLogging(false).WithNumCompactors(1)
+	}
+
+	if !opts.Badger.InMemory {
+		if err := os.MkdirAll(opts.Badger.Dir, 0744); err != nil {
+			return nil, fmt.Errorf("could not create dir: %s, %w", opts.Badger.Dir, err)
+		}
 	}
 
 	badgerDB, err := badger.Open(opts.Badger)

--- a/ethdb/kv_bolt.go
+++ b/ethdb/kv_bolt.go
@@ -3,7 +3,9 @@ package ethdb
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"os"
+	"path"
 	"strings"
 	"sync"
 	"time"
@@ -147,6 +149,12 @@ func (opts boltOpts) Path(path string) boltOpts {
 }
 
 func (opts boltOpts) Open() (KV, error) {
+	if !opts.Bolt.MemOnly {
+		if err := os.MkdirAll(path.Dir(opts.path), 0744); err != nil {
+			return nil, fmt.Errorf("could not create dir: %s, %w", opts.path, err)
+		}
+	}
+
 	boltDB, err := bolt.Open(opts.path, 0600, opts.Bolt)
 	if err != nil {
 		return nil, err

--- a/ethdb/kv_bolt.go
+++ b/ethdb/kv_bolt.go
@@ -419,12 +419,11 @@ func (b boltBucket) Cursor() Cursor {
 func (c *boltCursor) First() ([]byte, []byte, error) {
 	if len(c.prefix) == 0 {
 		c.k, c.v = c.bolt.First()
-	} else {
-		c.k, c.v = c.bolt.Seek(c.prefix)
+		return c.k, c.v, nil
 	}
-
+	c.k, c.v = c.bolt.Seek(c.prefix)
 	if !bytes.HasPrefix(c.k, c.prefix) {
-		c.k, c.v = nil, nil
+		return nil, nil, nil
 	}
 	return c.k, c.v, nil
 }
@@ -437,8 +436,10 @@ func (c *boltCursor) Seek(seek []byte) ([]byte, []byte, error) {
 	}
 
 	c.k, c.v = c.bolt.Seek(seek)
-	if !bytes.HasPrefix(c.k, c.prefix) {
-		c.k, c.v = nil, nil
+	if c.prefix != nil {
+		if !bytes.HasPrefix(c.k, c.prefix) {
+			return nil, nil, nil
+		}
 	}
 	return c.k, c.v, nil
 }
@@ -451,8 +452,10 @@ func (c *boltCursor) SeekTo(seek []byte) ([]byte, []byte, error) {
 	}
 
 	c.k, c.v = c.bolt.SeekTo(seek)
-	if !bytes.HasPrefix(c.k, c.prefix) {
-		c.k, c.v = nil, nil
+	if c.prefix != nil {
+		if !bytes.HasPrefix(c.k, c.prefix) {
+			return nil, nil, nil
+		}
 	}
 	return c.k, c.v, nil
 }
@@ -465,8 +468,10 @@ func (c *boltCursor) Next() ([]byte, []byte, error) {
 	}
 
 	c.k, c.v = c.bolt.Next()
-	if !bytes.HasPrefix(c.k, c.prefix) {
-		c.k, c.v = nil, nil
+	if c.prefix != nil {
+		if !bytes.HasPrefix(c.k, c.prefix) {
+			c.k, c.v = nil, nil
+		}
 	}
 	return c.k, c.v, nil
 }
@@ -531,7 +536,7 @@ func (c *noValuesBoltCursor) First() ([]byte, uint32, error) {
 
 	c.k, c.v = c.bolt.Seek(c.prefix)
 	if !bytes.HasPrefix(c.k, c.prefix) {
-		c.k, c.v = nil, nil
+		return nil, 0, nil
 	}
 	return c.k, uint32(len(c.v)), nil
 }
@@ -544,8 +549,10 @@ func (c *noValuesBoltCursor) Seek(seek []byte) ([]byte, uint32, error) {
 	}
 
 	c.k, c.v = c.bolt.Seek(seek)
-	if len(c.prefix) != 0 && !bytes.HasPrefix(c.k, c.prefix) {
-		c.k, c.v = nil, nil
+	if c.prefix != nil {
+		if !bytes.HasPrefix(c.k, c.prefix) {
+			return nil, 0, nil
+		}
 	}
 	return c.k, uint32(len(c.v)), nil
 }
@@ -558,8 +565,10 @@ func (c *noValuesBoltCursor) Next() ([]byte, uint32, error) {
 	}
 
 	c.k, c.v = c.bolt.Next()
-	if len(c.prefix) != 0 && !bytes.HasPrefix(c.k, c.prefix) {
-		return nil, 0, nil
+	if c.prefix != nil {
+		if !bytes.HasPrefix(c.k, c.prefix) {
+			return nil, 0, nil
+		}
 	}
 	return c.k, uint32(len(c.v)), nil
 }

--- a/ethdb/kv_bolt.go
+++ b/ethdb/kv_bolt.go
@@ -230,6 +230,10 @@ func (db *BoltKV) BucketsStat(_ context.Context) (map[string]common.StorageBucke
 	return res, nil
 }
 
+func (db *BoltKV) IdealBatchSize() int {
+	return 50 * 1024 * 1024 // 50 Mb
+}
+
 func (db *BoltKV) Get(ctx context.Context, bucket, key []byte) (val []byte, err error) {
 	err = db.bolt.View(func(tx *bolt.Tx) error {
 		v, _ := tx.Bucket(bucket).Get(key)

--- a/ethdb/kv_lmdb.go
+++ b/ethdb/kv_lmdb.go
@@ -450,6 +450,10 @@ func (b *lmdbBucket) Size() (uint64, error) {
 	return (st.LeafPages + st.BranchPages + st.OverflowPages) * uint64(os.Getpagesize()), nil
 }
 
+func (b *lmdbBucket) Clear() error {
+	return b.tx.tx.Drop(b.dbi, false)
+}
+
 func (b *lmdbBucket) Cursor() Cursor {
 	tx := b.tx
 	c := lmdbKvCursorPool.Get().(*lmdbCursor)

--- a/ethdb/kv_lmdb.go
+++ b/ethdb/kv_lmdb.go
@@ -218,6 +218,10 @@ func (db *LmdbKV) dbi(bucket []byte) lmdb.DBI {
 	panic(fmt.Errorf("unknown bucket: %s. add it to dbutils.Buckets", string(bucket)))
 }
 
+func (db *LmdbKV) IdealBatchSize() int {
+	return 50 * 1024 * 1024 // 50 Mb
+}
+
 func (db *LmdbKV) Get(ctx context.Context, bucket, key []byte) (val []byte, err error) {
 	err = db.View(ctx, func(tx Tx) error {
 		v, err2 := tx.(*lmdbTx).tx.Get(db.dbi(bucket), key)

--- a/ethdb/kv_remote.go
+++ b/ethdb/kv_remote.go
@@ -63,13 +63,11 @@ func (opts remoteOpts) Path(path string) remoteOpts {
 	return opts
 }
 
-// Example text code:
-//  writeDb, errOpen = ethdb.NewBolt().InMem().Open(ctx)
-//	require.NoError(t, errOpen)
+// Example test code:
+//  writeDb = ethdb.NewMemDatabase().KV()
 //	serverIn, clientOut := io.Pipe()
 //	clientIn, serverOut := io.Pipe()
-//	readDBs, errOpen = ethdb.NewRemote().InMem(clientIn, clientOut).Open(ctx)
-//	require.NoError(t, errOpen)
+//	readDBs = ethdb.NewRemote().InMem(clientIn, clientOut).MustOpen()
 //  go func() {
 // 	    if err := remotedbserver.Server(ctx, writeDb, serverIn, serverOut, nil); err != nil {
 //		    require.NoError(t, err)

--- a/ethdb/kv_remote.go
+++ b/ethdb/kv_remote.go
@@ -128,6 +128,10 @@ func (db *RemoteKV) BucketsStat(ctx context.Context) (map[string]common.StorageB
 	return db.remote.BucketsStat(ctx)
 }
 
+func (db *RemoteKV) IdealBatchSize() int {
+	panic("not supported")
+}
+
 func (db *RemoteKV) Begin(ctx context.Context, writable bool) (Tx, error) {
 	panic("remote db doesn't support managed transactions")
 }

--- a/ethdb/kv_remote.go
+++ b/ethdb/kv_remote.go
@@ -184,6 +184,10 @@ func (b remoteBucket) Size() (uint64, error) {
 	panic("not implemented")
 }
 
+func (b remoteBucket) Clear() error {
+	panic("not supporte")
+}
+
 func (b remoteBucket) Get(key []byte) (val []byte, err error) {
 	val, err = b.remote.Get(key)
 	return val, err

--- a/ethdb/object_db.go
+++ b/ethdb/object_db.go
@@ -31,6 +31,7 @@ import (
 type ObjectDatabase struct {
 	kv  KV
 	log log.Logger
+	id  uint64
 }
 
 // NewObjectDatabase returns a AbstractDB wrapper.
@@ -39,6 +40,7 @@ func NewObjectDatabase(kv KV) *ObjectDatabase {
 	return &ObjectDatabase{
 		kv:  kv,
 		log: logger,
+		id:  id(),
 	}
 }
 
@@ -50,18 +52,19 @@ func NewDatabase(path string) (*ObjectDatabase, error) {
 		if err != nil {
 			return nil, err
 		}
+		return NewObjectDatabase(kv), nil
 	}
 	if strings.HasSuffix(path, "_badger") {
 		kv, err = NewBadger().Path(path).Open()
 		if err != nil {
 			return nil, err
 		}
+		return NewObjectDatabase(kv), nil
 	}
 	kv, err = NewBolt().Path(path).Open()
 	if err != nil {
 		return nil, err
 	}
-
 	return NewObjectDatabase(kv), nil
 }
 
@@ -415,6 +418,5 @@ func (db *ObjectDatabase) TruncateAncients(items uint64) error {
 }
 
 func (db *ObjectDatabase) ID() uint64 {
-	panic("not implemented")
-	//return db.id
+	return db.id
 }

--- a/ethdb/object_db.go
+++ b/ethdb/object_db.go
@@ -44,7 +44,15 @@ func NewObjectDatabase(kv KV) *ObjectDatabase {
 	}
 }
 
-func NewDatabase(path string) (*ObjectDatabase, error) {
+func MustOpen(path string) *ObjectDatabase {
+	db, err := Open(path)
+	if err != nil {
+		panic(err)
+	}
+	return db
+}
+
+func Open(path string) (*ObjectDatabase, error) {
 	if strings.HasSuffix(path, "_lmdb") {
 		kv, err := NewLMDB().Path(path).Open()
 		if err != nil {

--- a/ethdb/object_db.go
+++ b/ethdb/object_db.go
@@ -282,8 +282,17 @@ func (db *ObjectDatabase) Delete(bucket, key []byte) error {
 	return err
 }
 
-func (db *ObjectDatabase) DeleteBucket(bucket []byte) error {
-	panic("not implemented") // probably need replace by TruncateBucket()?
+func (db *ObjectDatabase) ClearBuckets(buckets ...[]byte) error {
+	for _, bucket := range buckets {
+		bucket := bucket
+		if err := db.kv.Update(context.Background(), func(tx Tx) error {
+			return tx.Bucket(bucket).Clear()
+		}); err != nil {
+			return err
+		}
+	}
+
+	return nil
 }
 
 func (db *ObjectDatabase) Close() {

--- a/ethdb/object_db.go
+++ b/ethdb/object_db.go
@@ -45,23 +45,21 @@ func NewObjectDatabase(kv KV) *ObjectDatabase {
 }
 
 func NewDatabase(path string) (*ObjectDatabase, error) {
-	var kv KV
-	var err error
 	if strings.HasSuffix(path, "_lmdb") {
-		kv, err = NewLMDB().Path(path).Open()
+		kv, err := NewLMDB().Path(path).Open()
 		if err != nil {
 			return nil, err
 		}
 		return NewObjectDatabase(kv), nil
 	}
 	if strings.HasSuffix(path, "_badger") {
-		kv, err = NewBadger().Path(path).Open()
+		kv, err := NewBadger().Path(path).Open()
 		if err != nil {
 			return nil, err
 		}
 		return NewObjectDatabase(kv), nil
 	}
-	kv, err = NewBolt().Path(path).Open()
+	kv, err := NewBolt().Path(path).Open()
 	if err != nil {
 		return nil, err
 	}

--- a/ethdb/object_db.go
+++ b/ethdb/object_db.go
@@ -100,11 +100,17 @@ func (db *ObjectDatabase) Has(bucket, key []byte) (bool, error) {
 }
 
 func (db *ObjectDatabase) DiskSize(ctx context.Context) (common.StorageSize, error) {
-	return db.kv.(HasStats).DiskSize(ctx)
+	if casted, ok := db.kv.(HasStats); ok {
+		return casted.DiskSize(ctx)
+	}
+	return common.StorageSize(0), nil
 }
 
 func (db *ObjectDatabase) BucketsStat(ctx context.Context) (map[string]common.StorageBucketWriteStats, error) {
-	return db.kv.(HasStats).BucketsStat(ctx)
+	if casted, ok := db.kv.(HasStats); ok {
+		return casted.BucketsStat(ctx)
+	}
+	return nil, nil
 }
 
 // Get returns the value for a given key if it's present.
@@ -370,7 +376,7 @@ func (db *ObjectDatabase) NewBatch() DbWithPendingMutations {
 
 // IdealBatchSize defines the size of the data batches should ideally add in one write.
 func (db *ObjectDatabase) IdealBatchSize() int {
-	return 50 * 1024 * 1024 // 50 Mb
+	return db.kv.IdealBatchSize()
 }
 
 // [TURBO-GETH] Freezer support (not implemented yet)

--- a/ethdb/object_db.go
+++ b/ethdb/object_db.go
@@ -20,6 +20,7 @@ package ethdb
 import (
 	"bytes"
 	"context"
+	"strings"
 
 	"github.com/ledgerwatch/turbo-geth/common"
 	"github.com/ledgerwatch/turbo-geth/common/dbutils"
@@ -39,6 +40,29 @@ func NewObjectDatabase(kv KV) *ObjectDatabase {
 		kv:  kv,
 		log: logger,
 	}
+}
+
+func NewDatabase(path string) (*ObjectDatabase, error) {
+	var kv KV
+	var err error
+	if strings.HasSuffix(path, "_lmdb") {
+		kv, err = NewLMDB().Path(path).Open()
+		if err != nil {
+			return nil, err
+		}
+	}
+	if strings.HasSuffix(path, "_badger") {
+		kv, err = NewBadger().Path(path).Open()
+		if err != nil {
+			return nil, err
+		}
+	}
+	kv, err = NewBolt().Path(path).Open()
+	if err != nil {
+		return nil, err
+	}
+
+	return NewObjectDatabase(kv), nil
 }
 
 // Put inserts or updates a single entry.

--- a/node/node.go
+++ b/node/node.go
@@ -653,17 +653,17 @@ func (n *Node) OpenDatabase(name string) (ethdb.Database, error) {
 
 	if n.config.BadgerDB {
 		log.Info("Opening Database (Badger)")
-		return ethdb.NewBadgerDatabase(n.config.ResolvePath(name + "_badger"))
+		return ethdb.Open(n.config.ResolvePath(name + "_badger"))
 	}
 
 	if n.config.LMDB {
 		log.Info("Opening Database (LMDB)")
 		dir := n.config.ResolvePath(name + "_lmdb")
-		return ethdb.NewDatabase(dir)
+		return ethdb.Open(dir)
 	}
 
 	log.Info("Opening Database (Bolt)")
-	boltDb, err := ethdb.NewBoltDatabase(n.config.ResolvePath(name))
+	boltDb, err := ethdb.Open(n.config.ResolvePath(name))
 	if err != nil {
 		return nil, err
 	}

--- a/node/node.go
+++ b/node/node.go
@@ -659,11 +659,7 @@ func (n *Node) OpenDatabase(name string) (ethdb.Database, error) {
 	if n.config.LMDB {
 		log.Info("Opening Database (LMDB)")
 		dir := n.config.ResolvePath(name + "_lmdb")
-		kv, err := ethdb.NewLMDB().Path(dir).Open()
-		if err != nil {
-			return nil, err
-		}
-		return ethdb.NewObjectDatabase(kv), nil
+		return ethdb.NewDatabase(dir)
 	}
 
 	log.Info("Opening Database (Bolt)")

--- a/node/service.go
+++ b/node/service.go
@@ -59,11 +59,7 @@ func (ctx *ServiceContext) OpenDatabase(name string) (ethdb.Database, error) {
 	if ctx.Config.LMDB {
 		log.Info("Opening Database (LMDB)")
 		dir := ctx.Config.ResolvePath(name + "_lmdb")
-		kv, err := ethdb.NewLMDB().Path(dir).Open()
-		if err != nil {
-			return nil, err
-		}
-		return ethdb.NewObjectDatabase(kv), nil
+		return ethdb.NewDatabase(dir)
 	}
 
 	log.Info("Opening Database (Bolt)")

--- a/node/service.go
+++ b/node/service.go
@@ -53,17 +53,17 @@ func (ctx *ServiceContext) OpenDatabase(name string) (ethdb.Database, error) {
 
 	if ctx.Config.BadgerDB {
 		log.Info("Opening Database (Badger)")
-		return ethdb.NewBadgerDatabase(ctx.Config.ResolvePath(name + "_badger"))
+		return ethdb.Open(ctx.Config.ResolvePath(name + "_badger"))
 	}
 
 	if ctx.Config.LMDB {
 		log.Info("Opening Database (LMDB)")
 		dir := ctx.Config.ResolvePath(name + "_lmdb")
-		return ethdb.NewDatabase(dir)
+		return ethdb.Open(dir)
 	}
 
 	log.Info("Opening Database (Bolt)")
-	boltDb, err := ethdb.NewBoltDatabase(ctx.Config.ResolvePath(name))
+	boltDb, err := ethdb.Open(ctx.Config.ResolvePath(name))
 	if err != nil {
 		return nil, err
 	}

--- a/trie/trie_test.go
+++ b/trie/trie_test.go
@@ -474,11 +474,7 @@ func tempDB() (string, ethdb.Database) {
 	if err != nil {
 		panic(fmt.Sprintf("can't create temporary directory: %v", err))
 	}
-	diskdb, err := ethdb.NewDatabase(dir)
-	if err != nil {
-		panic(fmt.Sprintf("can't create temporary database: %v", err))
-	}
-	return dir, diskdb
+	return dir, ethdb.MustOpen(dir)
 }
 
 func getString(trie *Trie, k string) []byte {

--- a/trie/trie_test.go
+++ b/trie/trie_test.go
@@ -474,7 +474,7 @@ func tempDB() (string, ethdb.Database) {
 	if err != nil {
 		panic(fmt.Sprintf("can't create temporary directory: %v", err))
 	}
-	diskdb, err := ethdb.NewBoltDatabase(dir)
+	diskdb, err := ethdb.NewDatabase(dir)
 	if err != nil {
 		panic(fmt.Sprintf("can't create temporary database: %v", err))
 	}


### PR DESCRIPTION
Created methods `ethdb.Open(path)` and `ethdb.MustOpen(path)`: 
- Because now TurboGeth adding "_badger" and "_lmdb" suffixes to database folders - method chooses db based on path suffix
- Choose Bolt is by default
- Useful for `hack.go` and `restapi` - don't need additional flags or change code to use proper db driver
- It using `KV` abstraction inside for all databases: `ObjectDB(kv_bolt)` instead of `BoltDatabase` (But I can change back to `BoltDatabase` class if you prefer - it's easy)
- Prepare codebase for future default DB change



