### PR TITLE
Fix broken export file usage.

### DIFF
--- a/cmd/state/stateless/stateless_block_providers.go
+++ b/cmd/state/stateless/stateless_block_providers.go
@@ -130,7 +130,7 @@ func NewBlockProviderFromExportFile(fn string) (BlockProvider, error) {
 }
 
 func getTempFileName() string {
-	tmpfile, err := ioutil.TempFile("", "headers.bolt")
+	tmpfile, err := ioutil.TempFile("", "headers.*_bolt")
 	if err != nil {
 		panic(fmt.Errorf("failed to create a temp file: %w", err))
 	}


### PR DESCRIPTION
Some of the recent updates broke using the export file as a source for the stateless prototype. This commit fixes it.