### PR TITLE
Loader speed: do seek only when cursor is behind, NextSubtrie must produce shorter prefixes on overflow

### DIFF
--- a/common/dbutils/helper.go
+++ b/common/dbutils/helper.go
@@ -1,8 +1,5 @@
 package dbutils
 
-import (
-)
-
 // EncodeTimestamp has the property: if a < b, then Encoding(a) < Encoding(b) lexicographically
 func EncodeTimestamp(timestamp uint64) []byte {
 	var suffix []byte
@@ -55,7 +52,7 @@ func NextSubtree(in []byte) ([]byte, bool) {
 			return r, true
 		}
 
-		r[i] = 0
+		r = r[:i] // make it shorter, because in tries after 11ff goes 12, but not 1200
 	}
 	return nil, false
 }

--- a/trie/flatdb_sub_trie_loader.go
+++ b/trie/flatdb_sub_trie_loader.go
@@ -300,8 +300,8 @@ func (fstl *FlatDbSubTrieLoader) iteration(c, ih ethdb.Cursor, first bool) error
 			}
 			copy(fstl.accAddrHashWithInc[:], fstl.k)
 			binary.BigEndian.PutUint64(fstl.accAddrHashWithInc[32:], ^fstl.accountValue.Incarnation)
-			// Now we know the correct incarnation of the account, an
-			//d we can skip all irrelevant storage records
+
+			// Now we know the correct incarnation of the account, and we can skip all irrelevant storage records
 			// Since 0 incarnation if 0xfff...fff, and we do not expect any records like that, this automatically
 			// skips over all storage items
 			if fstl.k, fstl.v, err = c.SeekTo(fstl.accAddrHashWithInc[:]); err != nil {
@@ -310,7 +310,7 @@ func (fstl *FlatDbSubTrieLoader) iteration(c, ih ethdb.Cursor, first bool) error
 			if fstl.trace {
 				fmt.Printf("k after accountWalker and SeekTo: %x\n", fstl.k)
 			}
-			if !bytes.HasPrefix(fstl.ihK, fstl.accAddrHashWithInc[:]) {
+			if isBefore, _ := keyIsBefore(fstl.ihK, fstl.accAddrHashWithInc[:]); isBefore {
 				if fstl.ihK, fstl.ihV, err = ih.SeekTo(fstl.accAddrHashWithInc[:]); err != nil {
 					return err
 				}
@@ -398,7 +398,7 @@ func (fstl *FlatDbSubTrieLoader) iteration(c, ih ethdb.Cursor, first bool) error
 		fmt.Printf("next: %x\n", next)
 	}
 
-	if !bytes.HasPrefix(fstl.k, next) {
+	if isBefore, _ := keyIsBefore(fstl.k, next); isBefore {
 		if fstl.k, fstl.v, err = c.SeekTo(next); err != nil {
 			return err
 		}


### PR DESCRIPTION
- do seek only when the cursor is behind the target. (just check prefix is not correct).
- `common.NextSubtrie` - didn't make prefixes shorter on overflow, it prevented usage of short IH (which gives the biggest state-jumps). The rationale is: in tries after 11ff goes 12, but not 1200. 

Result: 100x less Seek calls (not the same gain in speed, but much less friction).