### PR TITLE
Reduce amount of c.Next calls in loader

### DIFF
--- a/eth/stagedsync/stage_interhashes.go
+++ b/eth/stagedsync/stage_interhashes.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"sort"
+	"time"
 
 	"github.com/ledgerwatch/turbo-geth/common"
 	"github.com/ledgerwatch/turbo-geth/common/dbutils"
@@ -53,19 +54,27 @@ func regenerateIntermediateHashes(db ethdb.Database, datadir string, expectedRoo
 		if len(keyHex)%2 != 0 || len(keyHex) == 0 {
 			return nil
 		}
-		var k []byte
+		k := make([]byte, len(keyHex)/2)
 		trie.CompressNibbles(keyHex, &k)
+		if hash == nil {
+			return collector.Collect(k, nil)
+		}
 		return collector.Collect(k, common.CopyBytes(hash))
 	}
 	loader := trie.NewFlatDbSubTrieLoader()
 	if err := loader.Reset(db, trie.NewRetainList(0), trie.NewRetainList(0), hashCollector /* HashCollector */, [][]byte{nil}, []int{0}, false); err != nil {
 		return err
 	}
+	t := time.Now()
 	if subTries, err := loader.LoadSubTries(); err == nil {
+		generationIHTook := time.Since(t)
 		if subTries.Hashes[0] != expectedRootHash {
 			return fmt.Errorf("wrong trie root: %x, expected (from header): %x", subTries.Hashes[0], expectedRootHash)
 		}
-		log.Info("Collection finished", "root hash", subTries.Hashes[0].Hex())
+		log.Info("Collection finished",
+			"root hash", subTries.Hashes[0].Hex(),
+			"gen IH", generationIHTook,
+		)
 	} else {
 		return err
 	}
@@ -355,7 +364,7 @@ func incrementIntermediateHashes(s *StageState, db ethdb.Database, from, to uint
 		if len(keyHex)%2 != 0 || len(keyHex) == 0 {
 			return nil
 		}
-		var k []byte
+		k := make([]byte, len(keyHex)/2)
 		trie.CompressNibbles(keyHex, &k)
 		if hash == nil {
 			return collector.Collect(k, nil)
@@ -370,14 +379,20 @@ func incrementIntermediateHashes(s *StageState, db ethdb.Database, from, to uint
 	// hashCollector in the line below will collect creations of new intermediate hashes
 	r.defaultReceiver.Reset(trie.NewRetainList(0), hashCollector, false)
 	loader.SetStreamReceiver(r)
-	if subTries, err := loader.LoadSubTries(); err == nil {
-		if subTries.Hashes[0] != expectedRootHash {
-			return fmt.Errorf("wrong trie root: %x, expected (from header): %x", subTries.Hashes[0], expectedRootHash)
-		}
-		log.Info("Collection finished", "root hash", subTries.Hashes[0].Hex())
-	} else {
+	t := time.Now()
+	subTries, err := loader.LoadSubTries()
+	if err != nil {
 		return err
 	}
+	generationIHTook := time.Since(t)
+	if subTries.Hashes[0] != expectedRootHash {
+		return fmt.Errorf("wrong trie root: %x, expected (from header): %x", subTries.Hashes[0], expectedRootHash)
+	}
+	log.Info("Collection finished",
+		"root hash", subTries.Hashes[0].Hex(),
+		"gen IH", generationIHTook,
+	)
+
 	if err := collector.Load(db, dbutils.IntermediateTrieHashBucket, etl.IdentityLoadFunc, etl.TransformArgs{Quit: quit}); err != nil {
 		return err
 	}
@@ -423,7 +438,7 @@ func unwindIntermediateHashesStageImpl(u *UnwindState, s *StageState, db ethdb.D
 		if len(keyHex)%2 != 0 || len(keyHex) == 0 {
 			return nil
 		}
-		var k []byte
+		k := make([]byte, len(keyHex)/2)
 		trie.CompressNibbles(keyHex, &k)
 		if hash == nil {
 			return collector.Collect(k, nil)
@@ -438,14 +453,19 @@ func unwindIntermediateHashesStageImpl(u *UnwindState, s *StageState, db ethdb.D
 	// hashCollector in the line below will collect creations of new intermediate hashes
 	r.defaultReceiver.Reset(trie.NewRetainList(0), hashCollector, false)
 	loader.SetStreamReceiver(r)
-	if subTries, err := loader.LoadSubTries(); err == nil {
-		if subTries.Hashes[0] != expectedRootHash {
-			return fmt.Errorf("wrong trie root: %x, expected (from header): %x", subTries.Hashes[0], expectedRootHash)
-		}
-		log.Info("Collection finished", "root hash", subTries.Hashes[0].Hex())
-	} else {
+	t := time.Now()
+	subTries, err := loader.LoadSubTries()
+	if err != nil {
 		return err
 	}
+	generationIHTook := time.Since(t)
+	if subTries.Hashes[0] != expectedRootHash {
+		return fmt.Errorf("wrong trie root: %x, expected (from header): %x", subTries.Hashes[0], expectedRootHash)
+	}
+	log.Info("Collection finished",
+		"root hash", subTries.Hashes[0].Hex(),
+		"gen IH", generationIHTook,
+	)
 	if err := collector.Load(db, dbutils.IntermediateTrieHashBucket, etl.IdentityLoadFunc, etl.TransformArgs{Quit: quit}); err != nil {
 		return err
 	}


### PR DESCRIPTION
Main bottleneck now is the amount of c.Next calls (on retain list of 1K items I see millions of .Next calls). 
- Reduced 100x amount of c.Next calls by removing next part: https://github.com/ledgerwatch/turbo-geth/compare/skip_too_much_ih?expand=1#diff-c75c86eeedd7661f1a471993b71b8774L419  - this logic is correct for `c` cursor, but not applicable for `ih` cursor. If `ih` cursor after jump to short prefix returns long `ihK` - it's still valid and can be used - no reason of jump to a next account. 
- Another minor improvement - reduce the amount of `.SeekTo` calls: funcion `keyIsBefore` returns true if keys are equal, but if keys are equal - no reason to call `.SeekTo`. Introduced function `keyIsBeforeOrEqual` and distinguish from `keyIsBefore`. 

Timings:
- Unwind of 1 block (300 items in RetainList) speedup from 5 sec to 200ms 
- Unwind of 1000 block (80K items in RetainList) speedup from 30 sec to 15 sec

- Bottleneck now moved to too-much small jumps over state after use of IH, will solve it in next PR.