### PR TITLE
Fix loader crash (kludge)

### DIFF
--- a/common/etl/buffers.go
+++ b/common/etl/buffers.go
@@ -39,7 +39,7 @@ type sortableBufferEntry struct {
 var (
 	_ Buffer = &sortableBuffer{}
 	_ Buffer = &appendSortableBuffer{}
-    _ Buffer = oldestEntrySortableBuffer{}
+    _ Buffer = &oldestEntrySortableBuffer{}
 )
 
 func NewSortableBuffer(bufferOptimalSize int) *sortableBuffer {

--- a/common/etl/buffers.go
+++ b/common/etl/buffers.go
@@ -39,6 +39,7 @@ type sortableBufferEntry struct {
 var (
 	_ Buffer = &sortableBuffer{}
 	_ Buffer = &appendSortableBuffer{}
+    _ Buffer = oldestEntrySortableBuffer{}
 )
 
 func NewSortableBuffer(bufferOptimalSize int) *sortableBuffer {
@@ -186,6 +187,10 @@ func (b *oldestEntrySortableBuffer) Put(k, v []byte) {
 
 	b.size += len(k)
 	b.size += len(v)
+	k = common.CopyBytes(k)
+	if v != nil {
+		v = common.CopyBytes(v)
+	}
 	b.entries[string(k)] = v
 }
 
@@ -194,7 +199,7 @@ func (b *oldestEntrySortableBuffer) Size() int {
 }
 
 func (b *oldestEntrySortableBuffer) Len() int {
-	return len(b.entries)
+	return len(b.sortedBuf)
 }
 func (b *oldestEntrySortableBuffer) Sort() {
 	for k, v := range b.entries {

--- a/common/etl/buffers.go
+++ b/common/etl/buffers.go
@@ -39,7 +39,7 @@ type sortableBufferEntry struct {
 var (
 	_ Buffer = &sortableBuffer{}
 	_ Buffer = &appendSortableBuffer{}
-    _ Buffer = &oldestEntrySortableBuffer{}
+	_ Buffer = &oldestEntrySortableBuffer{}
 )
 
 func NewSortableBuffer(bufferOptimalSize int) *sortableBuffer {

--- a/common/etl/buffers.go
+++ b/common/etl/buffers.go
@@ -199,7 +199,7 @@ func (b *oldestEntrySortableBuffer) Size() int {
 }
 
 func (b *oldestEntrySortableBuffer) Len() int {
-	return len(b.sortedBuf)
+	return len(b.entries)
 }
 func (b *oldestEntrySortableBuffer) Sort() {
 	for k, v := range b.entries {

--- a/eth/stagedsync/stage_interhashes.go
+++ b/eth/stagedsync/stage_interhashes.go
@@ -235,6 +235,10 @@ func (r *Receiver) storageLoad(k []byte, value []byte, _ etl.State, _ etl.LoadNe
 		return err
 	}
 	newKStr := string(newK)
+	if _, ok := r.storageMap[newKStr]; ok {
+		//fmt.Printf("Duplicate: %x\n", newKStr)
+		return nil
+	}
 	if len(value) > 0 {
 		r.storageMap[newKStr] = common.CopyBytes(value)
 	} else {


### PR DESCRIPTION
I have inserted the de-duplication logic in the `storageLoad` (the same one as I put in the `accountLoad` earlier). But I do not know still why duplicates appear in the first place