### PR TITLE
Command for long and heavy integration tests

### DIFF
--- a/cmd/integration/flags.go
+++ b/cmd/integration/flags.go
@@ -1,0 +1,23 @@
+package main
+
+import "github.com/spf13/cobra"
+
+var (
+	chaindata     string
+	blocksPerStep uint64
+)
+
+func must(err error) {
+	if err != nil {
+		panic(err)
+	}
+}
+
+func withChaindata(cmd *cobra.Command) {
+	cmd.Flags().StringVar(&chaindata, "chaindata", "chaindata", "path to the db")
+	must(cmd.MarkFlagFilename("chaindata", ""))
+}
+
+func withBlocksPerStep(cmd *cobra.Command) {
+	cmd.Flags().Uint64Var(&blocksPerStep, "blocks_per_step", 2, "how much blocks unwind/exec on each iteration")
+}

--- a/cmd/integration/main.go
+++ b/cmd/integration/main.go
@@ -1,0 +1,61 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/signal"
+	"syscall"
+
+	"github.com/ledgerwatch/turbo-geth/cmd/utils"
+	"github.com/ledgerwatch/turbo-geth/internal/debug"
+	"github.com/ledgerwatch/turbo-geth/log"
+	"github.com/spf13/cobra"
+)
+
+var (
+	chaindata string
+)
+
+var rootCmd = &cobra.Command{
+	Use:   "integration",
+	Short: "long and heavy integration tests for turbo-geth",
+	PersistentPreRun: func(cmd *cobra.Command, args []string) {
+		if err := debug.SetupCobra(cmd); err != nil {
+			panic(err)
+		}
+	},
+	PersistentPostRun: func(cmd *cobra.Command, args []string) {
+		debug.Exit()
+	},
+}
+
+func init() {
+	utils.CobraFlags(rootCmd, append(debug.Flags, utils.MetricsEnabledFlag, utils.MetricsEnabledExpensiveFlag))
+	rootCmd.PersistentFlags().StringVar(&chaindata, "chaindata", "", "path to db")
+}
+
+func main() {
+	if err := rootCmd.ExecuteContext(rootContext()); err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+}
+
+func rootContext() context.Context {
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		ch := make(chan os.Signal, 1)
+		signal.Notify(ch, os.Interrupt, syscall.SIGTERM)
+		defer signal.Stop(ch)
+
+		select {
+		case <-ch:
+			log.Info("Got interrupt, shutting down...")
+		case <-ctx.Done():
+		}
+
+		cancel()
+	}()
+	return ctx
+}

--- a/cmd/integration/main.go
+++ b/cmd/integration/main.go
@@ -13,10 +13,6 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var (
-	chaindata string
-)
-
 var rootCmd = &cobra.Command{
 	Use:   "integration",
 	Short: "long and heavy integration tests for turbo-geth",
@@ -32,7 +28,6 @@ var rootCmd = &cobra.Command{
 
 func init() {
 	utils.CobraFlags(rootCmd, append(debug.Flags, utils.MetricsEnabledFlag, utils.MetricsEnabledExpensiveFlag))
-	rootCmd.PersistentFlags().StringVar(&chaindata, "chaindata", "", "path to db")
 }
 
 func main() {

--- a/cmd/integration/sync_by_small_steps.go
+++ b/cmd/integration/sync_by_small_steps.go
@@ -1,0 +1,95 @@
+package main
+
+import (
+	"context"
+
+	"github.com/ledgerwatch/turbo-geth/consensus/ethash"
+	"github.com/ledgerwatch/turbo-geth/core"
+	"github.com/ledgerwatch/turbo-geth/core/vm"
+	"github.com/ledgerwatch/turbo-geth/eth/stagedsync"
+	"github.com/ledgerwatch/turbo-geth/eth/stagedsync/stages"
+	"github.com/ledgerwatch/turbo-geth/ethdb"
+	"github.com/ledgerwatch/turbo-geth/log"
+	"github.com/ledgerwatch/turbo-geth/params"
+	"github.com/spf13/cobra"
+)
+
+var syncBySmallSteps = &cobra.Command{
+	Use:   "sync_by_small_steps",
+	Short: "Staged sync in mode '1 step back 2 steps forward' with integrity checks after each step",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		ctx := rootContext()
+		return testStagesIntegration(ctx, chaindata)
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(syncBySmallSteps)
+}
+
+func testStagesIntegration(ctx context.Context, chaindata string) error {
+	var stage4progress, stage5progress uint64
+	blocksPerIteration := uint64(1) // how much blocks unwind/exec on each iteration
+	db := ethdb.MustOpen(chaindata)
+	defer db.Close()
+	var err error
+
+	blockchain, err := core.NewBlockChain(db, nil, params.MainnetChainConfig, ethash.NewFaker(), vm.Config{}, nil, nil, nil)
+	if err != nil {
+		return err
+	}
+	ch := make(chan struct{})
+	defer close(ch)
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		default:
+		}
+
+		rewind := blocksPerIteration
+
+		if stage4progress, _, err = stages.GetStageProgress(db, stages.Execution); err != nil {
+			return err
+		}
+		if stage5progress, _, err = stages.GetStageProgress(db, stages.IntermediateHashes); err != nil {
+			return err
+		}
+		log.Info("Stages", "Exec", stage4progress, "IH", stage5progress)
+		core.UsePlainStateExecution = true
+		if stage4progress == 0 {
+			rewind = 0
+		}
+
+		// Stage 4: 1 step back, 2 forward
+		{
+			u := &stagedsync.UnwindState{Stage: stages.Execution, UnwindPoint: stage4progress - rewind}
+			s := &stagedsync.StageState{Stage: stages.Execution, BlockNumber: stage4progress}
+			if err = stagedsync.UnwindExecutionStage(u, s, db); err != nil {
+				return err
+			}
+		}
+		{
+			s := &stagedsync.StageState{Stage: stages.Execution, BlockNumber: stage4progress}
+			if err = stagedsync.SpawnExecuteBlocksStage(s, db, blockchain, stage4progress+blocksPerIteration, ch, nil, false); err != nil {
+				return err
+			}
+		}
+
+		// Stage 5: 1 step back, 2 forward
+		{
+			u := &stagedsync.UnwindState{Stage: stages.IntermediateHashes, UnwindPoint: stage5progress - rewind}
+			s := &stagedsync.StageState{Stage: stages.IntermediateHashes, BlockNumber: stage5progress}
+			if err = stagedsync.UnwindHashStateStage(u, s, db, "", ch); err != nil {
+				return err
+			}
+		}
+		{
+			stageState := &stagedsync.StageState{Stage: stages.IntermediateHashes, BlockNumber: stage5progress}
+			if err = stagedsync.SpawnIntermediateHashesStage(stageState, db, "", ch); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}

--- a/cmd/tester/main.go
+++ b/cmd/tester/main.go
@@ -45,10 +45,10 @@ var (
 
 func init() {
 
-	// Initialize the CLI app and start Geth
+	// Initialize the CLI app and start TurboGeth
 	app.Action = tester
 	app.HideVersion = true // we have a command to print the version
-	app.Copyright = "Copyright 2018 The go-ethereum Authors"
+	app.Copyright = "Copyright 2020 The turbo-geth Authors"
 	app.Commands = []cli.Command{}
 	sort.Sort(cli.CommandsByName(app.Commands))
 

--- a/common/chan.go
+++ b/common/chan.go
@@ -4,7 +4,7 @@ import "errors"
 
 var ErrStopped = errors.New("stopped")
 
-func Stopped(ch chan struct{}) error {
+func Stopped(ch <-chan struct{}) error {
 	if ch == nil {
 		return nil
 	}

--- a/common/etl/etl.go
+++ b/common/etl/etl.go
@@ -62,7 +62,7 @@ type TransformArgs struct {
 	BufferType      int
 	BufferSize      int
 	LoadStartKey    []byte
-	Quit            chan struct{}
+	Quit            <-chan struct{}
 	OnLoadCommit    LoadCommitHandler
 	loadBatchSize   int // used in testing
 }
@@ -105,7 +105,7 @@ func extractBucketIntoFiles(
 	fixedBits int,
 	collector *Collector,
 	extractFunc ExtractFunc,
-	quit chan struct{},
+	quit <-chan struct{},
 ) error {
 	if err := db.Walk(bucket, startkey, fixedBits, func(k, v []byte) (bool, error) {
 		if err := common.Stopped(quit); err != nil {
@@ -135,7 +135,7 @@ func disposeProviders(providers []dataProvider) {
 type bucketState struct {
 	getter ethdb.Getter
 	bucket []byte
-	quit   chan struct{}
+	quit   <-chan struct{}
 }
 
 func (s *bucketState) Get(key []byte) ([]byte, error) {

--- a/eth/stagedsync/stage_execute.go
+++ b/eth/stagedsync/stage_execute.go
@@ -77,7 +77,7 @@ func (l *progressLogger) Stop() {
 	close(l.quit)
 }
 
-func SpawnExecuteBlocksStage(s *StageState, stateDB ethdb.Database, blockchain BlockChain, limit uint64, quit chan struct{}, dests vm.Cache, writeReceipts bool) error {
+func SpawnExecuteBlocksStage(s *StageState, stateDB ethdb.Database, blockchain BlockChain, limit uint64, quit <-chan struct{}, dests vm.Cache, writeReceipts bool) error {
 	nextBlockNumber := s.BlockNumber
 	if prof {
 		f, err := os.Create(fmt.Sprintf("cpu-%d.prof", s.BlockNumber))

--- a/eth/stagedsync/stage_hashstate.go
+++ b/eth/stagedsync/stage_hashstate.go
@@ -45,7 +45,7 @@ func SpawnHashStateStage(s *StageState, db ethdb.Database, datadir string, quit 
 	return s.DoneAndUpdate(db, syncHeadNumber)
 }
 
-func UnwindHashStateStage(u *UnwindState, s *StageState, db ethdb.Database, datadir string, quit chan struct{}) error {
+func UnwindHashStateStage(u *UnwindState, s *StageState, db ethdb.Database, datadir string, quit <-chan struct{}) error {
 	if err := unwindHashStateStageImpl(u, s, db, datadir, quit); err != nil {
 		return err
 	}
@@ -55,7 +55,7 @@ func UnwindHashStateStage(u *UnwindState, s *StageState, db ethdb.Database, data
 	return nil
 }
 
-func unwindHashStateStageImpl(u *UnwindState, s *StageState, stateDB ethdb.Database, datadir string, quit chan struct{}) error {
+func unwindHashStateStageImpl(u *UnwindState, s *StageState, stateDB ethdb.Database, datadir string, quit <-chan struct{}) error {
 	// Currently it does not require unwinding because it does not create any Intemediate Hash records
 	// and recomputes the state root from scratch
 	prom := NewPromoter(stateDB, quit)
@@ -72,7 +72,7 @@ func unwindHashStateStageImpl(u *UnwindState, s *StageState, stateDB ethdb.Datab
 	return nil
 }
 
-func promoteHashedStateCleanly(s *StageState, db ethdb.Database, to uint64, datadir string, quit chan struct{}) error {
+func promoteHashedStateCleanly(s *StageState, db ethdb.Database, to uint64, datadir string, quit <-chan struct{}) error {
 	var err error
 	if err = common.Stopped(quit); err != nil {
 		return err
@@ -229,7 +229,7 @@ func (l OldestAppearedLoad) LoadFunc(k []byte, value []byte, state etl.State, ne
 	return l.innerLoadFunc(k, value, state, next)
 }
 
-func NewPromoter(db ethdb.Database, quitCh chan struct{}) *Promoter {
+func NewPromoter(db ethdb.Database, quitCh <-chan struct{}) *Promoter {
 	return &Promoter{
 		db:               db,
 		ChangeSetBufSize: 256 * 1024 * 1024,


### PR DESCRIPTION
We need to run integration(acceptance) tests. For example "run genesis sync in 1 hop" or "run genesis sync with multiple unwind/rewind steps and with multiple integrity checks on each step". Such tests may take a few days. Here is a basic place to put them (to help `hack.go` deal with depression).

Exapmples: 
`go run ./cmd/integration -h` 
`go run ./cmd/integration sync_by_small_steps -h`
`go run ./cmd/integration sync_by_small_steps  --blocks_per_step=10 --chaindata=... --verbosity=2`


Added test: 
- Staged sync in mode '1 step back 2 steps forward' with integrity checks after each step
- For Exec and IH stages only for now 
