### PR TITLE
Integration tests2

### DIFF
--- a/cmd/hack/hack.go
+++ b/cmd/hack/hack.go
@@ -1266,14 +1266,11 @@ func resetState(chaindata string) {
 		dbutils.PlainContractCodeBucket,
 		dbutils.IncarnationMapBucket,
 		dbutils.CodeBucket,
-		dbutils.IntermediateTrieHashBucket,
 	))
 	core.UsePlainStateExecution = true
 	_, _, err := core.DefaultGenesisBlock().CommitGenesisState(db, false)
 	check(err)
 	err = stages.SaveStageProgress(db, stages.Execution, 0, nil)
-	check(err)
-	err = stages.SaveStageProgress(db, stages.IntermediateHashes, 0, nil)
 	check(err)
 	fmt.Printf("Reset state done\n")
 }

--- a/cmd/hack/hack.go
+++ b/cmd/hack/hack.go
@@ -1656,7 +1656,7 @@ func testStage5(chaindata string, reset bool) error {
 	log.Info("Stage5", "progress", stage5progress)
 	core.UsePlainStateExecution = true
 	ch := make(chan struct{})
-	stageState := &stagedsync.StageState{Stage: stages.IntermediateHashes, BlockNumber: stage4progress}
+	stageState := &stagedsync.StageState{Stage: stages.IntermediateHashes, BlockNumber: stage5progress}
 	if err = stagedsync.SpawnIntermediateHashesStage(stageState, db, "", ch); err != nil {
 		return err
 	}
@@ -1672,14 +1672,10 @@ func testUnwind5(chaindata string, rewind uint64) error {
 	if stage5progress, _, err = stages.GetStageProgress(db, stages.IntermediateHashes); err != nil {
 		return err
 	}
-	var stage4progress uint64
-	if stage4progress, _, err = stages.GetStageProgress(db, stages.Execution); err != nil {
-		return err
-	}
 	log.Info("Stage5", "progress", stage5progress)
 	core.UsePlainStateExecution = true
 	ch := make(chan struct{})
-	u := &stagedsync.UnwindState{Stage: stages.IntermediateHashes, UnwindPoint: stage4progress - rewind}
+	u := &stagedsync.UnwindState{Stage: stages.IntermediateHashes, UnwindPoint: stage5progress - rewind}
 	s := &stagedsync.StageState{Stage: stages.IntermediateHashes, BlockNumber: stage5progress}
 	if err = stagedsync.UnwindHashStateStage(u, s, db, "", ch); err != nil {
 		return err

--- a/cmd/hack/hack.go
+++ b/cmd/hack/hack.go
@@ -50,9 +50,9 @@ import (
 
 var emptyCodeHash = crypto.Keccak256(nil)
 
+var verbosity = flag.Uint("verbosity", 3, "Logging verbosity: 0=silent, 1=error, 2=warn, 3=info, 4=debug, 5=detail (default 3)")
 var action = flag.String("action", "", "action to execute")
 var cpuprofile = flag.String("cpuprofile", "", "write cpu profile `file`")
-var reset = flag.Int("reset", -1, "reset to given block number")
 var rewind = flag.Int("rewind", 1, "rewind to given number of blocks")
 var block = flag.Int("block", 1, "specifies a block number for operation")
 var account = flag.String("account", "0x", "specifies account to investigate")
@@ -2281,6 +2281,8 @@ func buildHistory(chaindata string, reset bool) error {
 }
 
 func main() {
+	flag.Parse()
+
 	var (
 		ostream log.Handler
 		glogger *log.GlogHandler
@@ -2294,9 +2296,9 @@ func main() {
 	ostream = log.StreamHandler(output, log.TerminalFormat(usecolor))
 	glogger = log.NewGlogHandler(ostream)
 	log.Root().SetHandler(glogger)
-	glogger.Verbosity(log.LvlInfo)
 
-	flag.Parse()
+	glogger.Verbosity(log.Lvl(*verbosity))
+
 	if *cpuprofile != "" {
 		f, err := os.Create(*cpuprofile)
 		if err != nil {

--- a/cmd/integration/flags.go
+++ b/cmd/integration/flags.go
@@ -3,9 +3,10 @@ package main
 import "github.com/spf13/cobra"
 
 var (
-	chaindata string
-	block     uint64
-	stride    uint64
+	chaindata   string
+	stop        uint64
+	unwind      uint64
+	unwindEvery uint64
 )
 
 func must(err error) {
@@ -20,10 +21,14 @@ func withChaindata(cmd *cobra.Command) {
 	must(cmd.MarkFlagRequired("chaindata"))
 }
 
-func withBlockNumber(cmd *cobra.Command) {
-	cmd.Flags().Uint64Var(&block, "block", 0, "stop test at this block")
+func withStop(cmd *cobra.Command) {
+	cmd.Flags().Uint64Var(&stop, "stop", 0, "stop test at this block")
 }
 
-func withStride(cmd *cobra.Command) {
-	cmd.Flags().Uint64Var(&stride, "stride", 2, "how much blocks unwind/exec on each iteration")
+func withUnwind(cmd *cobra.Command) {
+	cmd.Flags().Uint64Var(&unwind, "unwind", 2, "how much blocks unwind on each iteration")
+}
+
+func withUnwindEvery(cmd *cobra.Command) {
+	cmd.Flags().Uint64Var(&unwindEvery, "unwind_every", 100, "each iteration test will move forward `--unwind_every` blocks, then unwind `--unwind` blocks")
 }

--- a/cmd/integration/flags.go
+++ b/cmd/integration/flags.go
@@ -16,6 +16,7 @@ func must(err error) {
 func withChaindata(cmd *cobra.Command) {
 	cmd.Flags().StringVar(&chaindata, "chaindata", "chaindata", "path to the db")
 	must(cmd.MarkFlagFilename("chaindata", ""))
+	must(cmd.MarkFlagRequired("chaindata"))
 }
 
 func withBlocksPerStep(cmd *cobra.Command) {

--- a/cmd/integration/flags.go
+++ b/cmd/integration/flags.go
@@ -4,9 +4,10 @@ import "github.com/spf13/cobra"
 
 var (
 	chaindata   string
-	stop        uint64
+	block       uint64
 	unwind      uint64
 	unwindEvery uint64
+	reset       bool //nolint
 )
 
 func must(err error) {
@@ -16,19 +17,23 @@ func must(err error) {
 }
 
 func withChaindata(cmd *cobra.Command) {
-	cmd.Flags().StringVar(&chaindata, "chaindata", "chaindata", "path to the db")
-	must(cmd.MarkFlagFilename("chaindata", ""))
+	cmd.Flags().StringVar(&chaindata, "chaindata", "", "path to the db")
+	must(cmd.MarkFlagDirname("chaindata"))
 	must(cmd.MarkFlagRequired("chaindata"))
 }
 
-func withStop(cmd *cobra.Command) {
-	cmd.Flags().Uint64Var(&stop, "stop", 0, "stop test at this block")
+func withBlock(cmd *cobra.Command) {
+	cmd.Flags().Uint64Var(&block, "block", 0, "block test at this block")
 }
 
 func withUnwind(cmd *cobra.Command) {
-	cmd.Flags().Uint64Var(&unwind, "unwind", 2, "how much blocks unwind on each iteration")
+	cmd.Flags().Uint64Var(&unwind, "unwind", 0, "how much blocks unwind on each iteration")
 }
 
 func withUnwindEvery(cmd *cobra.Command) {
 	cmd.Flags().Uint64Var(&unwindEvery, "unwind_every", 100, "each iteration test will move forward `--unwind_every` blocks, then unwind `--unwind` blocks")
+}
+
+func withReset(cmd *cobra.Command) { //nolint
+	cmd.Flags().BoolVar(&reset, "reset", false, "reset given stage")
 }

--- a/cmd/integration/flags.go
+++ b/cmd/integration/flags.go
@@ -3,8 +3,9 @@ package main
 import "github.com/spf13/cobra"
 
 var (
-	chaindata     string
-	blocksPerStep uint64
+	chaindata string
+	block     uint64
+	stride    uint64
 )
 
 func must(err error) {
@@ -19,6 +20,10 @@ func withChaindata(cmd *cobra.Command) {
 	must(cmd.MarkFlagRequired("chaindata"))
 }
 
-func withBlocksPerStep(cmd *cobra.Command) {
-	cmd.Flags().Uint64Var(&blocksPerStep, "blocks_per_step", 2, "how much blocks unwind/exec on each iteration")
+func withBlockNumber(cmd *cobra.Command) {
+	cmd.Flags().Uint64Var(&block, "block", 0, "stop test at this block")
+}
+
+func withStride(cmd *cobra.Command) {
+	cmd.Flags().Uint64Var(&stride, "stride", 2, "how much blocks unwind/exec on each iteration")
 }

--- a/cmd/integration/reset_state.go
+++ b/cmd/integration/reset_state.go
@@ -13,8 +13,8 @@ import (
 )
 
 var cmdResetState = &cobra.Command{
-	Use:   "reset",
-	Short: "Reset sync stages and buckets",
+	Use:   "reset_state",
+	Short: "Reset StateStages (4,5,6,7,8) and buckets",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		ctx := rootContext()
 		if err := resetState(ctx, chaindata); err != nil {

--- a/cmd/integration/reset_state.go
+++ b/cmd/integration/reset_state.go
@@ -1,0 +1,147 @@
+package main
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/ledgerwatch/turbo-geth/common/dbutils"
+	"github.com/ledgerwatch/turbo-geth/core"
+	"github.com/ledgerwatch/turbo-geth/eth/stagedsync/stages"
+	"github.com/ledgerwatch/turbo-geth/ethdb"
+	"github.com/ledgerwatch/turbo-geth/log"
+	"github.com/spf13/cobra"
+)
+
+var cmdResetState = &cobra.Command{
+	Use:   "reset",
+	Short: "Reset sync stages and buckets. All, but headers and blocks.",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		ctx := rootContext()
+		if err := resetState(ctx, chaindata); err != nil {
+			log.Error("Error", "err", err)
+		}
+		return nil
+	},
+}
+
+func init() {
+	withChaindata(cmdResetState)
+
+	rootCmd.AddCommand(cmdResetState)
+}
+
+func resetState(_ context.Context, chaindata string) error {
+	db := ethdb.MustOpen(chaindata)
+	defer db.Close()
+	fmt.Printf("Before reset: \n")
+	if err := printStages(db); err != nil {
+		return err
+	}
+
+	core.UsePlainStateExecution = true
+	if err := resetSenders(db); err != nil {
+		return err
+	}
+	if err := resetExec(db); err != nil {
+		return err
+	}
+	if err := resetHashState(db); err != nil {
+		return err
+	}
+	if err := resetHistory(db); err != nil {
+		return err
+	}
+
+	// set genesis after reset all buckets
+	if _, _, err := core.DefaultGenesisBlock().CommitGenesisState(db, false); err != nil {
+		return err
+	}
+
+	fmt.Printf("After reset: \n")
+	if err := printStages(db); err != nil {
+		return err
+	}
+	return nil
+}
+
+func resetSenders(db *ethdb.ObjectDatabase) error {
+	if err := db.ClearBuckets(
+		dbutils.Senders,
+	); err != nil {
+		return err
+	}
+	if err := stages.SaveStageProgress(db, stages.Senders, 0, nil); err != nil {
+		return err
+	}
+	return nil
+}
+
+func resetExec(db *ethdb.ObjectDatabase) error {
+	var err error
+	err = db.ClearBuckets(
+		dbutils.CurrentStateBucket,
+		dbutils.AccountChangeSetBucket,
+		dbutils.StorageChangeSetBucket,
+		dbutils.ContractCodeBucket,
+		dbutils.PlainStateBucket,
+		dbutils.PlainAccountChangeSetBucket,
+		dbutils.PlainStorageChangeSetBucket,
+		dbutils.PlainContractCodeBucket,
+		dbutils.IncarnationMapBucket,
+		dbutils.CodeBucket,
+	)
+	if err != nil {
+		return err
+	}
+	err = stages.SaveStageProgress(db, stages.Execution, 0, nil)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func resetHashState(db *ethdb.ObjectDatabase) error {
+	if err := db.ClearBuckets(
+		dbutils.CurrentStateBucket,
+		dbutils.ContractCodeBucket,
+		dbutils.IntermediateTrieHashBucket,
+	); err != nil {
+		return err
+	}
+	if err := stages.SaveStageProgress(db, stages.IntermediateHashes, 0, nil); err != nil {
+		return err
+	}
+	if err := stages.SaveStageProgress(db, stages.HashState, 0, nil); err != nil {
+		return err
+	}
+	return nil
+}
+
+func resetHistory(db *ethdb.ObjectDatabase) error {
+	if err := db.ClearBuckets(
+		dbutils.AccountsHistoryBucket,
+		dbutils.StorageHistoryBucket,
+	); err != nil {
+		return err
+	}
+	if err := stages.SaveStageProgress(db, stages.AccountHistoryIndex, 0, nil); err != nil {
+		return err
+	}
+	if err := stages.SaveStageProgress(db, stages.StorageHistoryIndex, 0, nil); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func printStages(db *ethdb.ObjectDatabase) error {
+	var err error
+	var progress uint64
+	for stage := stages.SyncStage(0); stage < stages.Finish; stage++ {
+		if progress, _, err = stages.GetStageProgress(db, stage); err != nil {
+			return err
+		}
+		fmt.Printf("Stage: %d, progress: %d\n", stage, progress)
+	}
+	return nil
+}

--- a/cmd/integration/reset_state.go
+++ b/cmd/integration/reset_state.go
@@ -14,7 +14,7 @@ import (
 
 var cmdResetState = &cobra.Command{
 	Use:   "reset",
-	Short: "Reset sync stages and buckets. All, but headers and blocks.",
+	Short: "Reset sync stages and buckets",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		ctx := rootContext()
 		if err := resetState(ctx, chaindata); err != nil {
@@ -39,9 +39,6 @@ func resetState(_ context.Context, chaindata string) error {
 	}
 
 	core.UsePlainStateExecution = true
-	if err := resetSenders(db); err != nil {
-		return err
-	}
 	if err := resetExec(db); err != nil {
 		return err
 	}
@@ -59,18 +56,6 @@ func resetState(_ context.Context, chaindata string) error {
 
 	fmt.Printf("After reset: \n")
 	if err := printStages(db); err != nil {
-		return err
-	}
-	return nil
-}
-
-func resetSenders(db *ethdb.ObjectDatabase) error {
-	if err := db.ClearBuckets(
-		dbutils.Senders,
-	); err != nil {
-		return err
-	}
-	if err := stages.SaveStageProgress(db, stages.Senders, 0, nil); err != nil {
 		return err
 	}
 	return nil

--- a/cmd/integration/sync_by_small_steps.go
+++ b/cmd/integration/sync_by_small_steps.go
@@ -43,11 +43,11 @@ func syncBySmallSteps(ctx context.Context, chaindata string) error {
 		return err
 	}
 	defer blockchain.Stop()
-	ch := ctx.Done()
+	ch := make(chan struct{})
+	defer close(ch)
 
 	stopAt := progress(db, stages.Senders).BlockNumber
 	for progress(db, stages.Execution).BlockNumber+2*blocksPerStep < stopAt {
-
 		select {
 		case <-ctx.Done():
 			return nil

--- a/cmd/integration/sync_by_small_steps.go
+++ b/cmd/integration/sync_by_small_steps.go
@@ -70,15 +70,13 @@ func syncBySmallSteps(ctx context.Context, chaindata string) error {
 			}
 		}
 
-		execProgress, ihProgress = progress(db)
 		{
-			s := &stagedsync.StageState{Stage: stages.Execution, BlockNumber: execProgress}
-			if err = stagedsync.SpawnExecuteBlocksStage(s, db, blockchain, execProgress+2*blocksPerStep, ctx.Done(), nil, false); err != nil {
+			s := &stagedsync.StageState{Stage: stages.Execution, BlockNumber: execProgress - rewind}
+			if err = stagedsync.SpawnExecuteBlocksStage(s, db, blockchain, execProgress+blocksPerStep, ctx.Done(), nil, false); err != nil {
 				return err
 			}
 		}
 
-		execProgress, ihProgress = progress(db)
 		// Stage 5: 1 step back, 2 forward
 		if ihProgress, _, err = stages.GetStageProgress(db, stages.IntermediateHashes); err != nil {
 			return err
@@ -92,10 +90,9 @@ func syncBySmallSteps(ctx context.Context, chaindata string) error {
 			}
 		}
 
-		execProgress, ihProgress = progress(db)
 		{
-			stageState := &stagedsync.StageState{Stage: stages.IntermediateHashes, BlockNumber: ihProgress}
-			if err = stagedsync.SpawnIntermediateHashesStage(stageState, db, "", ctx.Done()); err != nil {
+			s := &stagedsync.StageState{Stage: stages.IntermediateHashes, BlockNumber: execProgress - rewind}
+			if err = stagedsync.SpawnIntermediateHashesStage(s, db, "", ctx.Done()); err != nil {
 				return err
 			}
 		}

--- a/cmd/integration/sync_by_small_steps.go
+++ b/cmd/integration/sync_by_small_steps.go
@@ -56,11 +56,7 @@ func syncBySmallSteps(ctx context.Context, chaindata string) error {
 		rewind := blocksPerStep
 
 		execProgress, ihProgress = progress(db)
-		log.Info("Stages", "Exec", execProgress, "IH", ihProgress)
 
-		if execProgress <= blocksPerStep+1 {
-			rewind = 0
-		}
 		if execProgress <= blocksPerStep+1 {
 			rewind = 0
 		}
@@ -75,7 +71,6 @@ func syncBySmallSteps(ctx context.Context, chaindata string) error {
 		}
 
 		execProgress, ihProgress = progress(db)
-		log.Info("Stages", "Exec", execProgress, "IH", ihProgress)
 		{
 			s := &stagedsync.StageState{Stage: stages.Execution, BlockNumber: execProgress}
 			if err = stagedsync.SpawnExecuteBlocksStage(s, db, blockchain, execProgress+2*blocksPerStep, ctx.Done(), nil, false); err != nil {

--- a/cmd/integration/sync_by_small_steps.go
+++ b/cmd/integration/sync_by_small_steps.go
@@ -47,7 +47,7 @@ func syncBySmallSteps(ctx context.Context, chaindata string) error {
 			ch := make(chan struct{})
 			s := &stagedsync.StageState{Stage: stages.Execution, BlockNumber: stage4progress}
 			blockchain, _ := core.NewBlockChain(db, nil, params.MainnetChainConfig, ethash.NewFaker(), vm.Config{}, nil, nil, nil)
-			if err = stagedsync.SpawnExecuteBlocksStage(s, db, blockchain, stage4progress+2, ch, nil, false); err != nil {
+			if err = stagedsync.SpawnExecuteBlocksStage(s, db, blockchain, stage4progress+3, ch, nil, false); err != nil {
 				return err
 			}
 			close(ch)

--- a/cmd/integration/sync_by_small_steps.go
+++ b/cmd/integration/sync_by_small_steps.go
@@ -78,10 +78,6 @@ func syncBySmallSteps(ctx context.Context, chaindata string) error {
 		}
 
 		// Stage 5: 1 step back, 2 forward
-		if ihProgress, _, err = stages.GetStageProgress(db, stages.IntermediateHashes); err != nil {
-			return err
-		}
-
 		if ihProgress > blocksPerStep+1 {
 			u := &stagedsync.UnwindState{Stage: stages.IntermediateHashes, UnwindPoint: execProgress - rewind}
 			s := &stagedsync.StageState{Stage: stages.IntermediateHashes, BlockNumber: ihProgress}

--- a/cmd/integration/sync_by_small_steps.go
+++ b/cmd/integration/sync_by_small_steps.go
@@ -81,7 +81,7 @@ func syncBySmallSteps(ctx context.Context, chaindata string) error {
 		{
 			u := &stagedsync.UnwindState{Stage: stages.IntermediateHashes, UnwindPoint: stage5progress - rewind}
 			s := &stagedsync.StageState{Stage: stages.IntermediateHashes, BlockNumber: stage5progress}
-			if err = stagedsync.UnwindHashStateStage(u, s, db, "", ctx.Done()); err != nil {
+			if err = stagedsync.UnwindIntermediateHashesStage(u, s, db, "", ctx.Done()); err != nil {
 				return err
 			}
 		}

--- a/cmd/integration/sync_by_small_steps.go
+++ b/cmd/integration/sync_by_small_steps.go
@@ -96,8 +96,7 @@ func syncBySmallSteps(ctx context.Context, chaindata string) error {
 
 		// Stage 5: 2 forward
 		{
-			execProgress, ihProgress = progress(db)
-			s := &stagedsync.StageState{Stage: stages.IntermediateHashes, BlockNumber: ihProgress}
+			s := &stagedsync.StageState{Stage: stages.IntermediateHashes}
 			if err = stagedsync.SpawnIntermediateHashesStage(s, db, "", ctx.Done()); err != nil {
 				return err
 			}

--- a/cmd/integration/sync_by_small_steps.go
+++ b/cmd/integration/sync_by_small_steps.go
@@ -45,13 +45,16 @@ func syncBySmallSteps(ctx context.Context, chaindata string) error {
 	defer blockchain.Stop()
 	ch := ctx.Done()
 
-	for {
+	stopAt := progress(db, stages.Senders).BlockNumber
+	for progress(db, stages.Execution).BlockNumber+2*blocksPerStep < stopAt {
+
 		select {
 		case <-ctx.Done():
 			return nil
 		default:
 		}
 
+		// All stages forward to `execStage + 2*blocksPerStep` block
 		{
 			stage := progress(db, stages.Execution)
 			execToBlock := stage.BlockNumber + 2*blocksPerStep
@@ -124,6 +127,8 @@ func syncBySmallSteps(ctx context.Context, chaindata string) error {
 			}
 		}
 	}
+
+	return nil
 }
 
 func progress(db ethdb.Getter, stage stages.SyncStage) *stagedsync.StageState {

--- a/cmd/integration/sync_by_small_steps.go
+++ b/cmd/integration/sync_by_small_steps.go
@@ -56,21 +56,21 @@ func syncBySmallSteps(ctx context.Context, chaindata string) error {
 			stage := progress(db, stages.Execution)
 			execToBlock := stage.BlockNumber + 2*blocksPerStep
 			if err = stagedsync.SpawnExecuteBlocksStage(stage, db, blockchain, execToBlock, ch, nil, false); err != nil {
-				return fmt.Errorf("SpawnExecuteBlocksStage: %w", err)
+				return fmt.Errorf("spawnExecuteBlocksStage: %w", err)
 			}
 		}
 
 		{
 			stage := progress(db, stages.IntermediateHashes)
 			if err = stagedsync.SpawnIntermediateHashesStage(stage, db, "", ch); err != nil {
-				return fmt.Errorf("SpawnIntermediateHashesStage: %w", err)
+				return fmt.Errorf("spawnIntermediateHashesStage: %w", err)
 			}
 		}
 
 		{
 			stage := progress(db, stages.HashState)
 			if err = stagedsync.SpawnHashStateStage(stage, db, "", ch); err != nil {
-				return fmt.Errorf("SpawnHashStateStage: %w", err)
+				return fmt.Errorf("spawnHashStateStage: %w", err)
 			}
 		}
 
@@ -78,10 +78,10 @@ func syncBySmallSteps(ctx context.Context, chaindata string) error {
 			stage7 := progress(db, stages.AccountHistoryIndex)
 			stage8 := progress(db, stages.StorageHistoryIndex)
 			if err = stagedsync.SpawnAccountHistoryIndex(stage7, db, "", ch); err != nil {
-				return fmt.Errorf("SpawnAccountHistoryIndex: %w", err)
+				return fmt.Errorf("spawnAccountHistoryIndex: %w", err)
 			}
 			if err = stagedsync.SpawnStorageHistoryIndex(stage8, db, "", ch); err != nil {
-				return fmt.Errorf("SpawnStorageHistoryIndex: %w", err)
+				return fmt.Errorf("spawnStorageHistoryIndex: %w", err)
 			}
 		}
 
@@ -91,12 +91,12 @@ func syncBySmallSteps(ctx context.Context, chaindata string) error {
 		{
 			u := &stagedsync.UnwindState{Stage: stages.StorageHistoryIndex, UnwindPoint: to}
 			if err = stagedsync.UnwindStorageHistoryIndex(u, db, ch); err != nil {
-				return fmt.Errorf("UnwindStorageHistoryIndex: %w", err)
+				return fmt.Errorf("unwindStorageHistoryIndex: %w", err)
 			}
 
 			u = &stagedsync.UnwindState{Stage: stages.AccountHistoryIndex, UnwindPoint: to}
 			if err = stagedsync.UnwindAccountHistoryIndex(u, db, ch); err != nil {
-				return fmt.Errorf("UnwindAccountHistoryIndex: %w", err)
+				return fmt.Errorf("unwindAccountHistoryIndex: %w", err)
 			}
 		}
 
@@ -104,7 +104,7 @@ func syncBySmallSteps(ctx context.Context, chaindata string) error {
 			u := &stagedsync.UnwindState{Stage: stages.HashState, UnwindPoint: to}
 			stage := progress(db, stages.HashState)
 			if err = stagedsync.UnwindHashStateStage(u, stage, db, "", ch); err != nil {
-				return fmt.Errorf("UnwindHashStateStage: %w", err)
+				return fmt.Errorf("unwindHashStateStage: %w", err)
 			}
 		}
 
@@ -112,7 +112,7 @@ func syncBySmallSteps(ctx context.Context, chaindata string) error {
 			u := &stagedsync.UnwindState{Stage: stages.IntermediateHashes, UnwindPoint: to}
 			stage := progress(db, stages.IntermediateHashes)
 			if err = stagedsync.UnwindIntermediateHashesStage(u, stage, db, "", ch); err != nil {
-				return fmt.Errorf("UnwindIntermediateHashesStage: %w", err)
+				return fmt.Errorf("unwindIntermediateHashesStage: %w", err)
 			}
 		}
 
@@ -120,7 +120,7 @@ func syncBySmallSteps(ctx context.Context, chaindata string) error {
 			stage := progress(db, stages.Execution)
 			u := &stagedsync.UnwindState{Stage: stages.Execution, UnwindPoint: to}
 			if err = stagedsync.UnwindExecutionStage(u, stage, db); err != nil {
-				return fmt.Errorf("UnwindExecutionStage: %w", err)
+				return fmt.Errorf("unwindExecutionStage: %w", err)
 			}
 		}
 	}

--- a/common/etl/collector.go
+++ b/common/etl/collector.go
@@ -4,12 +4,13 @@ import (
 	"bytes"
 	"container/heap"
 	"fmt"
+	"io"
+	"runtime"
+
 	"github.com/ledgerwatch/turbo-geth/common"
 	"github.com/ledgerwatch/turbo-geth/ethdb"
 	"github.com/ledgerwatch/turbo-geth/log"
 	"github.com/ugorji/go/codec"
-	"io"
-	"runtime"
 )
 
 type LoadNextFunc func(originalK, k, v []byte) error
@@ -122,7 +123,7 @@ func loadFilesIntoBucket(db ethdb.Database, bucket []byte, providers []dataProvi
 				return err
 			}
 			runtime.ReadMemStats(&m)
-			log.Info(
+			log.Debug(
 				"Committed batch",
 				"bucket", string(bucket),
 				"size", common.StorageSize(batchSize),
@@ -160,7 +161,7 @@ func loadFilesIntoBucket(db ethdb.Database, bucket []byte, providers []dataProvi
 		return err
 	}
 	runtime.ReadMemStats(&m)
-	log.Info(
+	log.Debug(
 		"Committed batch",
 		"bucket", string(bucket),
 		"size", common.StorageSize(batchSize),

--- a/common/etl/collector.go
+++ b/common/etl/collector.go
@@ -123,7 +123,7 @@ func loadFilesIntoBucket(db ethdb.Database, bucket []byte, providers []dataProvi
 				return err
 			}
 			runtime.ReadMemStats(&m)
-			log.Debug(
+			log.Info(
 				"Committed batch",
 				"bucket", string(bucket),
 				"size", common.StorageSize(batchSize),

--- a/common/etl/collector.go
+++ b/common/etl/collector.go
@@ -161,7 +161,7 @@ func loadFilesIntoBucket(db ethdb.Database, bucket []byte, providers []dataProvi
 		return err
 	}
 	runtime.ReadMemStats(&m)
-	log.Debug(
+	log.Info(
 		"Committed batch",
 		"bucket", string(bucket),
 		"size", common.StorageSize(batchSize),

--- a/common/etl/etl.go
+++ b/common/etl/etl.go
@@ -88,11 +88,11 @@ func Transform(
 		disposeProviders(collector.dataProviders)
 		return err
 	}
-	log.Info("Extraction finished", "it took", time.Since(t))
+	log.Debug("Extraction finished", "it took", time.Since(t))
 
 	t = time.Now()
 	defer func() {
-		log.Info("Collection finished", "it took", time.Since(t))
+		log.Debug("Collection finished", "it took", time.Since(t))
 	}()
 	return collector.Load(db, toBucket, loadFunc, args)
 }

--- a/common/etl/etl.go
+++ b/common/etl/etl.go
@@ -90,10 +90,7 @@ func Transform(
 	}
 	log.Debug("Extraction finished", "it took", time.Since(t))
 
-	t = time.Now()
-	defer func() {
-		log.Debug("Collection finished", "it took", time.Since(t))
-	}()
+	defer func(t time.Time) { log.Debug("Collection finished", "it took", time.Since(t)) }(time.Now())
 	return collector.Load(db, toBucket, loadFunc, args)
 }
 

--- a/core/generate_index.go
+++ b/core/generate_index.go
@@ -16,7 +16,7 @@ import (
 	"github.com/ledgerwatch/turbo-geth/log"
 )
 
-func NewIndexGenerator(db ethdb.Database, quitCh chan struct{}) *IndexGenerator {
+func NewIndexGenerator(db ethdb.Database, quitCh <-chan struct{}) *IndexGenerator {
 	return &IndexGenerator{
 		db:               db,
 		ChangeSetBufSize: 256 * 1024 * 1024,
@@ -29,7 +29,7 @@ type IndexGenerator struct {
 	db               ethdb.Database
 	ChangeSetBufSize int
 	TempDir          string
-	quitCh           chan struct{}
+	quitCh           <-chan struct{}
 }
 
 var CSMapper = map[string]struct {
@@ -67,7 +67,7 @@ func (ig *IndexGenerator) GenerateIndex(startBlock, endBlock uint64, changeSetBu
 	if !ok {
 		return errors.New("unknown bucket type")
 	}
-	log.Info("Index generation started", "from", startBlock, "to", endBlock, "csbucket", string(changeSetBucket))
+	log.Debug("Index generation", "from", startBlock, "to", endBlock, "csbucket", string(changeSetBucket))
 	if endBlock < startBlock && endBlock != 0 {
 		return fmt.Errorf("generateIndex %s: endBlock %d smaller than startBlock %d", changeSetBucket, endBlock, startBlock)
 	}
@@ -90,7 +90,7 @@ func (ig *IndexGenerator) GenerateIndex(startBlock, endBlock uint64, changeSetBu
 		return err
 	}
 
-	log.Info("Index generation successfully finished", "csbucket", string(changeSetBucket), "it took", time.Since(t))
+	log.Debug("Index generation successfully finished", "csbucket", string(changeSetBucket), "it took", time.Since(t))
 	return nil
 }
 

--- a/eth/stagedsync/stage_execute.go
+++ b/eth/stagedsync/stage_execute.go
@@ -105,7 +105,7 @@ func SpawnExecuteBlocksStage(s *StageState, stateDB ethdb.Database, blockchain B
 	chainConfig := blockchain.Config()
 	engine := blockchain.Engine()
 	vmConfig := blockchain.GetVMConfig()
-	log.Info("Attempting to start execution from", "block", atomic.LoadUint64(&nextBlockNumber)+1)
+	log.Info("Attempting to start execution from", "block", atomic.LoadUint64(&nextBlockNumber)+1, "to", limit)
 	for {
 		if err := common.Stopped(quit); err != nil {
 			return err

--- a/eth/stagedsync/stage_execute.go
+++ b/eth/stagedsync/stage_execute.go
@@ -78,10 +78,10 @@ func (l *progressLogger) Stop() {
 }
 
 func SpawnExecuteBlocksStage(s *StageState, stateDB ethdb.Database, blockchain BlockChain, limit uint64, quit <-chan struct{}, dests vm.Cache, writeReceipts bool) error {
-	//if limit <= s.BlockNumber {
-	//	s.Done()
-	//	return nil
-	//}
+	if limit <= s.BlockNumber {
+		s.Done()
+		return nil
+	}
 
 	nextBlockNumber := s.BlockNumber
 	if prof {

--- a/eth/stagedsync/stage_execute.go
+++ b/eth/stagedsync/stage_execute.go
@@ -105,7 +105,7 @@ func SpawnExecuteBlocksStage(s *StageState, stateDB ethdb.Database, blockchain B
 	chainConfig := blockchain.Config()
 	engine := blockchain.Engine()
 	vmConfig := blockchain.GetVMConfig()
-	log.Info("Attempting to start execution from", "block", atomic.LoadUint64(&nextBlockNumber)+1, "to", limit)
+	log.Info("Attempting to start execution from", "block", atomic.LoadUint64(&nextBlockNumber)+1)
 	for {
 		if err := common.Stopped(quit); err != nil {
 			return err

--- a/eth/stagedsync/stage_execute.go
+++ b/eth/stagedsync/stage_execute.go
@@ -110,7 +110,7 @@ func SpawnExecuteBlocksStage(s *StageState, stateDB ethdb.Database, blockchain B
 	chainConfig := blockchain.Config()
 	engine := blockchain.Engine()
 	vmConfig := blockchain.GetVMConfig()
-	log.Info("Attempting to start execution from", "block", atomic.LoadUint64(&nextBlockNumber)+1, "to", limit-1)
+	log.Info("Blocks execution", "from", atomic.LoadUint64(&nextBlockNumber)+1, "to", limit-1)
 	for {
 		if err := common.Stopped(quit); err != nil {
 			return err

--- a/eth/stagedsync/stage_execute.go
+++ b/eth/stagedsync/stage_execute.go
@@ -50,7 +50,7 @@ func (l *progressLogger) Start(numberRef *uint64) {
 			speed := float64(now-prev) / float64(l.interval)
 			var m runtime.MemStats
 			runtime.ReadMemStats(&m)
-			log.Info("Executed blocks:",
+			log.Debug("Executed blocks:",
 				"currentBlock", now,
 				"speed (blk/second)", speed,
 				"state batch", common.StorageSize(l.batch.BatchSize()),

--- a/eth/stagedsync/stage_execute.go
+++ b/eth/stagedsync/stage_execute.go
@@ -78,6 +78,11 @@ func (l *progressLogger) Stop() {
 }
 
 func SpawnExecuteBlocksStage(s *StageState, stateDB ethdb.Database, blockchain BlockChain, limit uint64, quit <-chan struct{}, dests vm.Cache, writeReceipts bool) error {
+	//if limit <= s.BlockNumber {
+	//	s.Done()
+	//	return nil
+	//}
+
 	nextBlockNumber := s.BlockNumber
 	if prof {
 		f, err := os.Create(fmt.Sprintf("cpu-%d.prof", s.BlockNumber))
@@ -105,7 +110,7 @@ func SpawnExecuteBlocksStage(s *StageState, stateDB ethdb.Database, blockchain B
 	chainConfig := blockchain.Config()
 	engine := blockchain.Engine()
 	vmConfig := blockchain.GetVMConfig()
-	log.Info("Attempting to start execution from", "block", atomic.LoadUint64(&nextBlockNumber)+1)
+	log.Info("Attempting to start execution from", "block", atomic.LoadUint64(&nextBlockNumber)+1, "to", limit-1)
 	for {
 		if err := common.Stopped(quit); err != nil {
 			return err
@@ -207,6 +212,11 @@ func SpawnExecuteBlocksStage(s *StageState, stateDB ethdb.Database, blockchain B
 }
 
 func UnwindExecutionStage(u *UnwindState, s *StageState, stateDB ethdb.Database) error {
+	if u.UnwindPoint >= s.BlockNumber {
+		s.Done()
+		return nil
+	}
+
 	log.Info("Unwind Execution stage", "from", s.BlockNumber, "to", u.UnwindPoint)
 	mutation := stateDB.NewBatch()
 

--- a/eth/stagedsync/stage_hashstate.go
+++ b/eth/stagedsync/stage_hashstate.go
@@ -19,7 +19,7 @@ import (
 
 var cbor codec.CborHandle
 
-func SpawnHashStateStage(s *StageState, db ethdb.Database, datadir string, quit chan struct{}) error {
+func SpawnHashStateStage(s *StageState, db ethdb.Database, datadir string, quit <-chan struct{}) error {
 	syncHeadNumber, err := s.ExecutionAt(db)
 	if err != nil {
 		return err
@@ -503,7 +503,7 @@ func (p *Promoter) Unwind(s *StageState, u *UnwindState, storage bool, codes boo
 	)
 }
 
-func promoteHashedStateIncrementally(s *StageState, from, to uint64, db ethdb.Database, datadir string, quit chan struct{}) error {
+func promoteHashedStateIncrementally(s *StageState, from, to uint64, db ethdb.Database, datadir string, quit <-chan struct{}) error {
 	prom := NewPromoter(db, quit)
 	prom.TempDir = datadir
 	if err := prom.Promote(s, from, to, false /* storage */, false /* codes */, 0x00); err != nil {

--- a/eth/stagedsync/stage_hashstate.go
+++ b/eth/stagedsync/stage_hashstate.go
@@ -370,7 +370,7 @@ func (p *Promoter) Promote(s *StageState, from, to uint64, storage bool, codes b
 	} else {
 		changeSetBucket = dbutils.PlainAccountChangeSetBucket
 	}
-	log.Info("Incremental promotion started", "from", from, "to", to, "csbucket", string(changeSetBucket))
+	log.Debug("Incremental promotion started", "from", from, "to", to, "csbucket", string(changeSetBucket))
 
 	startkey := dbutils.EncodeTimestamp(from + 1)
 	skip := false

--- a/eth/stagedsync/stage_hashstate.go
+++ b/eth/stagedsync/stage_hashstate.go
@@ -440,7 +440,7 @@ func (p *Promoter) Unwind(s *StageState, u *UnwindState, storage bool, codes boo
 	from := s.BlockNumber
 	to := u.UnwindPoint
 
-	log.Info("Unwinding started", "from", from, "to", to, "storage", storage, "codes", codes)
+	log.Debug("Unwinding started", "from", from, "to", to, "storage", storage, "codes", codes)
 
 	startkey := dbutils.EncodeTimestamp(to + 1)
 

--- a/eth/stagedsync/stage_indexes.go
+++ b/eth/stagedsync/stage_indexes.go
@@ -27,7 +27,7 @@ func SpawnAccountHistoryIndex(s *StageState, db ethdb.Database, datadir string, 
 	ig.TempDir = datadir
 
 	if err := ig.GenerateIndex(blockNum, endBlock, dbutils.PlainAccountChangeSetBucket); err != nil {
-		return err
+		return fmt.Errorf("account history index: fail to generate index: %w", err)
 	}
 
 	return s.DoneAndUpdate(db, endBlock)
@@ -50,7 +50,7 @@ func SpawnStorageHistoryIndex(s *StageState, db ethdb.Database, datadir string, 
 	ig := core.NewIndexGenerator(db, quitCh)
 	ig.TempDir = datadir
 	if err := ig.GenerateIndex(blockNum, endBlock, dbutils.PlainStorageChangeSetBucket); err != nil {
-		return err
+		return fmt.Errorf("storage history index: fail to generate index: %w", err)
 	}
 
 	return s.DoneAndUpdate(db, endBlock)
@@ -59,7 +59,7 @@ func SpawnStorageHistoryIndex(s *StageState, db ethdb.Database, datadir string, 
 func UnwindAccountHistoryIndex(u *UnwindState, db ethdb.Database, quitCh <-chan struct{}) error {
 	ig := core.NewIndexGenerator(db, quitCh)
 	if err := ig.Truncate(u.UnwindPoint, dbutils.PlainAccountChangeSetBucket); err != nil {
-		return err
+		return fmt.Errorf("account history index: fail to truncate index: %w", err)
 	}
 	if err := u.Done(db); err != nil {
 		return fmt.Errorf("unwind AccountHistorytIndex: %w", err)
@@ -70,7 +70,7 @@ func UnwindAccountHistoryIndex(u *UnwindState, db ethdb.Database, quitCh <-chan 
 func UnwindStorageHistoryIndex(u *UnwindState, db ethdb.Database, quitCh <-chan struct{}) error {
 	ig := core.NewIndexGenerator(db, quitCh)
 	if err := ig.Truncate(u.UnwindPoint, dbutils.PlainStorageChangeSetBucket); err != nil {
-		return err
+		return fmt.Errorf("storage history index: fail to truncate index: %w", err)
 	}
 	if err := u.Done(db); err != nil {
 		return fmt.Errorf("unwind StorageHistorytIndex: %w", err)

--- a/eth/stagedsync/stage_indexes.go
+++ b/eth/stagedsync/stage_indexes.go
@@ -2,12 +2,13 @@ package stagedsync
 
 import (
 	"fmt"
+
 	"github.com/ledgerwatch/turbo-geth/common/dbutils"
 	"github.com/ledgerwatch/turbo-geth/core"
 	"github.com/ledgerwatch/turbo-geth/ethdb"
 )
 
-func SpawnAccountHistoryIndex(s *StageState, db ethdb.Database, datadir string, quitCh chan struct{}) error {
+func SpawnAccountHistoryIndex(s *StageState, db ethdb.Database, datadir string, quitCh <-chan struct{}) error {
 	endBlock, err := s.ExecutionAt(db)
 	if err != nil {
 		return fmt.Errorf("account history index: getting last executed block: %w", err)
@@ -32,7 +33,7 @@ func SpawnAccountHistoryIndex(s *StageState, db ethdb.Database, datadir string, 
 	return s.DoneAndUpdate(db, endBlock)
 }
 
-func SpawnStorageHistoryIndex(s *StageState, db ethdb.Database, datadir string, quitCh chan struct{}) error {
+func SpawnStorageHistoryIndex(s *StageState, db ethdb.Database, datadir string, quitCh <-chan struct{}) error {
 	endBlock, err := s.ExecutionAt(db)
 	if err != nil {
 		return fmt.Errorf("storage history index: getting last executed block: %w", err)
@@ -55,7 +56,7 @@ func SpawnStorageHistoryIndex(s *StageState, db ethdb.Database, datadir string, 
 	return s.DoneAndUpdate(db, endBlock)
 }
 
-func UnwindAccountHistoryIndex(u *UnwindState, db ethdb.Database, quitCh chan struct{}) error {
+func UnwindAccountHistoryIndex(u *UnwindState, db ethdb.Database, quitCh <-chan struct{}) error {
 	ig := core.NewIndexGenerator(db, quitCh)
 	if err := ig.Truncate(u.UnwindPoint, dbutils.PlainAccountChangeSetBucket); err != nil {
 		return err
@@ -66,7 +67,7 @@ func UnwindAccountHistoryIndex(u *UnwindState, db ethdb.Database, quitCh chan st
 	return nil
 }
 
-func UnwindStorageHistoryIndex(u *UnwindState, db ethdb.Database, quitCh chan struct{}) error {
+func UnwindStorageHistoryIndex(u *UnwindState, db ethdb.Database, quitCh <-chan struct{}) error {
 	ig := core.NewIndexGenerator(db, quitCh)
 	if err := ig.Truncate(u.UnwindPoint, dbutils.PlainStorageChangeSetBucket); err != nil {
 		return err

--- a/eth/stagedsync/stage_interhashes.go
+++ b/eth/stagedsync/stage_interhashes.go
@@ -85,7 +85,7 @@ func regenerateIntermediateHashes(db ethdb.Database, datadir string, expectedRoo
 		return err
 	}
 	if err := collector.Load(db, dbutils.IntermediateTrieHashBucket, etl.IdentityLoadFunc, etl.TransformArgs{Quit: quit}); err != nil {
-		return fmt.Errorf("gen ih stage: fail load data to bucket: %d\n", err)
+		return fmt.Errorf("gen ih stage: fail load data to bucket: %d", err)
 	}
 	log.Info("Regeneration ended")
 	return nil

--- a/eth/stagedsync/stage_interhashes.go
+++ b/eth/stagedsync/stage_interhashes.go
@@ -459,14 +459,14 @@ func incrementIntermediateHashes(s *StageState, db ethdb.Database, from, to uint
 	return nil
 }
 
-func UnwindIntermediateHashesStage(u *UnwindState, s *StageState, db ethdb.Database, datadir string, quit chan struct{}) error {
+func UnwindIntermediateHashesStage(u *UnwindState, s *StageState, db ethdb.Database, datadir string, quit <-chan struct{}) error {
 	hash := rawdb.ReadCanonicalHash(db, u.UnwindPoint)
 	syncHeadHeader := rawdb.ReadHeader(db, hash, u.UnwindPoint)
 	expectedRootHash := syncHeadHeader.Root
 	return unwindIntermediateHashesStageImpl(u, s, db, datadir, expectedRootHash, quit)
 }
 
-func unwindIntermediateHashesStageImpl(u *UnwindState, s *StageState, db ethdb.Database, datadir string, expectedRootHash common.Hash, quit chan struct{}) error {
+func unwindIntermediateHashesStageImpl(u *UnwindState, s *StageState, db ethdb.Database, datadir string, expectedRootHash common.Hash, quit <-chan struct{}) error {
 	p := NewHashPromoter(db, quit)
 	p.TempDir = datadir
 	r := NewReceiver()

--- a/eth/stagedsync/stage_interhashes.go
+++ b/eth/stagedsync/stage_interhashes.go
@@ -24,7 +24,6 @@ func SpawnIntermediateHashesStage(s *StageState, db ethdb.Database, datadir stri
 	if err != nil {
 		return err
 	}
-	fmt.Printf("2: %d, %d\n", s.BlockNumber, syncHeadNumber)
 
 	if s.BlockNumber == syncHeadNumber {
 		// we already did hash check for this block

--- a/eth/stagedsync/stage_interhashes.go
+++ b/eth/stagedsync/stage_interhashes.go
@@ -25,7 +25,6 @@ func SpawnIntermediateHashesStage(s *StageState, db ethdb.Database, datadir stri
 		return err
 	}
 
-	fmt.Printf("22: %d %d\n", s.BlockNumber, syncHeadNumber)
 	if s.BlockNumber == syncHeadNumber {
 		// we already did hash check for this block
 		// we don't do the obvious `if s.BlockNumber > syncHeadNumber` to support reorgs more naturally

--- a/eth/stagedsync/stage_interhashes.go
+++ b/eth/stagedsync/stage_interhashes.go
@@ -85,7 +85,7 @@ func regenerateIntermediateHashes(db ethdb.Database, datadir string, expectedRoo
 		return err
 	}
 	if err := collector.Load(db, dbutils.IntermediateTrieHashBucket, etl.IdentityLoadFunc, etl.TransformArgs{Quit: quit}); err != nil {
-		return err
+		return fmt.Errorf("gen ih stage: fail load data to bucket: %d\n", err)
 	}
 	log.Info("Regeneration ended")
 	return nil

--- a/eth/stagedsync/stage_interhashes.go
+++ b/eth/stagedsync/stage_interhashes.go
@@ -25,6 +25,7 @@ func SpawnIntermediateHashesStage(s *StageState, db ethdb.Database, datadir stri
 		return err
 	}
 
+	fmt.Printf("22: %d %d\n", s.BlockNumber, syncHeadNumber)
 	if s.BlockNumber == syncHeadNumber {
 		// we already did hash check for this block
 		// we don't do the obvious `if s.BlockNumber > syncHeadNumber` to support reorgs more naturally
@@ -458,7 +459,6 @@ func incrementIntermediateHashes(s *StageState, db ethdb.Database, from, to uint
 func UnwindIntermediateHashesStage(u *UnwindState, s *StageState, db ethdb.Database, datadir string, quit <-chan struct{}) error {
 	hash := rawdb.ReadCanonicalHash(db, u.UnwindPoint)
 	syncHeadHeader := rawdb.ReadHeader(db, hash, u.UnwindPoint)
-	fmt.Printf("1: %d, %d\n", syncHeadHeader.Number, u.UnwindPoint)
 	expectedRootHash := syncHeadHeader.Root
 	return unwindIntermediateHashesStageImpl(u, s, db, datadir, expectedRootHash, quit)
 }

--- a/eth/stagedsync/stage_senders.go
+++ b/eth/stagedsync/stage_senders.go
@@ -239,7 +239,7 @@ func recoverSenders(cryptoContext *secp256k1.Context, config *params.ChainConfig
 	}
 }
 
-func unwindSendersStage(u *UnwindState, stateDB ethdb.Database) error {
+func UnwindSendersStage(u *UnwindState, stateDB ethdb.Database) error {
 	// Does not require any special processing
 	mutation := stateDB.NewBatch()
 	err := u.Done(mutation)

--- a/eth/stagedsync/stage_senders.go
+++ b/eth/stagedsync/stage_senders.go
@@ -189,7 +189,6 @@ func SpawnRecoverSendersStage(cfg Stage3Config, s *StageState, db ethdb.Database
 	if err := collector.Load(db, dbutils.Senders, loadFunc, etl.TransformArgs{Quit: quitCh}); err != nil {
 		return err
 	}
-	fmt.Printf("2: %d\n", toBlockNumber)
 	return s.DoneAndUpdate(db, toBlockNumber)
 }
 

--- a/eth/stagedsync/stage_senders.go
+++ b/eth/stagedsync/stage_senders.go
@@ -189,7 +189,7 @@ func SpawnRecoverSendersStage(cfg Stage3Config, s *StageState, db ethdb.Database
 	if err := collector.Load(db, dbutils.Senders, loadFunc, etl.TransformArgs{Quit: quitCh}); err != nil {
 		return err
 	}
-
+	fmt.Printf("2: %d\n", toBlockNumber)
 	return s.DoneAndUpdate(db, toBlockNumber)
 }
 

--- a/eth/stagedsync/stage_senders.go
+++ b/eth/stagedsync/stage_senders.go
@@ -84,7 +84,7 @@ func SpawnRecoverSendersStage(cfg Stage3Config, s *StageState, db ethdb.Database
 	}
 	log.Info("Senders recovery", "from", s.BlockNumber+1, "to", toBlockNumber)
 
-	canonical := make([]common.Hash, toBlockNumber-s.BlockNumber)
+	canonical := make([]common.Hash, toBlockNumber-s.BlockNumber+1)
 	currentHeaderIdx := uint64(0)
 
 	err = db.Walk(dbutils.HeaderPrefix, dbutils.EncodeBlockNumber(s.BlockNumber+1), 0, func(k, v []byte) (bool, error) {
@@ -97,7 +97,7 @@ func SpawnRecoverSendersStage(cfg Stage3Config, s *StageState, db ethdb.Database
 			return true, nil
 		}
 
-		if currentHeaderIdx >= toBlockNumber-s.BlockNumber { // if header stage is ehead of body stage
+		if currentHeaderIdx > toBlockNumber-s.BlockNumber { // if header stage is ehead of body stage
 			return false, nil
 		}
 
@@ -117,7 +117,7 @@ func SpawnRecoverSendersStage(cfg Stage3Config, s *StageState, db ethdb.Database
 
 			blockNumber := binary.BigEndian.Uint64(k[:8])
 			blockHash := common.BytesToHash(k[8:])
-			if blockNumber >= toBlockNumber {
+			if blockNumber > toBlockNumber {
 				return false, nil
 			}
 

--- a/eth/stagedsync/stage_senders.go
+++ b/eth/stagedsync/stage_senders.go
@@ -201,7 +201,7 @@ type senderRecoveryJob struct {
 	err         error
 }
 
-func recoverSenders(cryptoContext *secp256k1.Context, config *params.ChainConfig, in, out chan *senderRecoveryJob, quit chan struct{}) {
+func recoverSenders(cryptoContext *secp256k1.Context, config *params.ChainConfig, in, out chan *senderRecoveryJob, quit <-chan struct{}) {
 	for job := range in {
 		if job == nil {
 			return

--- a/eth/stagedsync/stagedsync.go
+++ b/eth/stagedsync/stagedsync.go
@@ -67,7 +67,7 @@ func PrepareStagedSync(
 				return SpawnRecoverSendersStage(cfg, s, stateDB, blockchain.Config(), 0, datadir, quitCh)
 			},
 			UnwindFunc: func(u *UnwindState, s *StageState) error {
-				return unwindSendersStage(u, stateDB)
+				return UnwindSendersStage(u, stateDB)
 			},
 		},
 		{

--- a/ethdb/kv_lmdb.go
+++ b/ethdb/kv_lmdb.go
@@ -197,7 +197,7 @@ func (db *LmdbKV) Close() {
 		if err := db.env.Close(); err != nil {
 			db.log.Warn("failed to close DB", "err", err)
 		} else {
-			db.log.Info("database closed")
+			db.log.Info("database closed (LMDB)")
 		}
 	}
 


### PR DESCRIPTION
```
go run ./cmd/integration reset --chaindata=...
go run ./cmd/integration state_stages -h
go run ./cmd/integration state_stages  --chaindata=... --verbosity=3 --block=2_000_000 --unwind=10 --unwind_every=1_000 
```
Also, it inherits flags from geth:
```
--pprof.cpuprofile=./cpu.out   // to file
--pprof --pprof.port=6060     // launch pprof server
--metrics                  //  sends to prometheus 
```
