### PR TITLE
Fix broken witness generation due to EXTCODESIZE

### DIFF
--- a/core/state/database.go
+++ b/core/state/database.go
@@ -432,7 +432,9 @@ func (tds *TrieDbState) buildStorageWrites() (common.StorageKeys, [][]byte) {
 // Populate pending block proof so that it will be sufficient for accessing all storage slots in storageTouches
 func (tds *TrieDbState) populateStorageBlockProof(storageTouches common.StorageKeys) error { //nolint
 	for _, storageKey := range storageTouches {
-		tds.retainListBuilder.AddStorageTouch(storageKey[:])
+		addr, _, hash := dbutils.ParseCompositeStorageKey(storageKey[:])
+		key := dbutils.GenerateCompositeTrieKey(addr, hash)
+		tds.retainListBuilder.AddStorageTouch(key[:])
 	}
 	return nil
 }

--- a/core/state/stateless.go
+++ b/core/state/stateless.go
@@ -164,6 +164,10 @@ func (s *Stateless) ReadAccountCodeSize(address common.Address, codeHash common.
 		return len(code), nil
 	}
 
+	if codeSize, ok := s.t.GetAccountCodeSize(addrHash[:]); ok {
+		return codeSize, nil
+	}
+
 	return 0, fmt.Errorf("could not find bytecode for hash %x", codeHash)
 }
 

--- a/trie/gen_struct_step.go
+++ b/trie/gen_struct_step.go
@@ -31,7 +31,7 @@ import (
 type structInfoReceiver interface {
 	leaf(length int, keyHex []byte, val rlphacks.RlpSerializable) error
 	leafHash(length int, keyHex []byte, val rlphacks.RlpSerializable) error
-	accountLeaf(length int, keyHex []byte, balance *uint256.Int, nonce uint64, incarnation uint64, fieldset uint32) error
+	accountLeaf(length int, keyHex []byte, balance *uint256.Int, nonce uint64, incarnation uint64, fieldset uint32, codeSize int) error
 	accountLeafHash(length int, keyHex []byte, balance *uint256.Int, nonce uint64, incarnation uint64, fieldset uint32) error
 	extension(key []byte) error
 	extensionHash(key []byte) error
@@ -139,7 +139,7 @@ func GenStructStep(
 				buildExtensions = true
 			case *GenStructStepAccountData:
 				if retain(curr[:maxLen]) {
-					if err := e.accountLeaf(remainderLen, curr, &v.Balance, v.Nonce, v.Incarnation, v.FieldSet); err != nil {
+					if err := e.accountLeaf(remainderLen, curr, &v.Balance, v.Nonce, v.Incarnation, v.FieldSet, codeSizeUncached); err != nil {
 						return nil, err
 					}
 				} else {

--- a/trie/hashbuilder.go
+++ b/trie/hashbuilder.go
@@ -187,7 +187,7 @@ func (hb *HashBuilder) leafHash(length int, keyHex []byte, val rlphacks.RlpSeria
 	return hb.leafHashWithKeyVal(key, val)
 }
 
-func (hb *HashBuilder) accountLeaf(length int, keyHex []byte, balance *uint256.Int, nonce uint64, incarnation uint64, fieldSet uint32) (err error) {
+func (hb *HashBuilder) accountLeaf(length int, keyHex []byte, balance *uint256.Int, nonce uint64, incarnation uint64, fieldSet uint32, accountCodeSize int) (err error) {
 	if hb.trace {
 		fmt.Printf("ACCOUNTLEAF %d (%b)\n", length, fieldSet)
 	}
@@ -231,7 +231,6 @@ func (hb *HashBuilder) accountLeaf(length int, keyHex []byte, balance *uint256.I
 	var accCopy accounts.Account
 	accCopy.Copy(&hb.acc)
 
-	accountCodeSize := codeSizeUncached
 	if !bytes.Equal(accCopy.CodeHash[:], EmptyCodeHash[:]) && accountCode != nil {
 		accountCodeSize = len(accountCode)
 	}

--- a/trie/trie_from_witness.go
+++ b/trie/trie_from_witness.go
@@ -68,9 +68,9 @@ func BuildTrieFromWitness(witness *Witness, isBinary bool, trace bool) (*Trie, e
 			// Incarnation is always needed for a hashbuilder.
 			// but it is just our implementation detail needed for contract self-descruction suport with our
 			// db structure. Stateless clients don't access the DB so we can just pass 0 here.
-			incarnaton := uint64(0)
+			incarnation := uint64(0)
 
-			if err := hb.accountLeaf(len(op.Key), op.Key, balance, nonce, incarnaton, fieldSet); err != nil {
+			if err := hb.accountLeaf(len(op.Key), op.Key, balance, nonce, incarnation, fieldSet, int(op.CodeSize)); err != nil {
 				return nil, err
 			}
 		case *OperatorEmptyRoot:

--- a/trie/witness_operators.go
+++ b/trie/witness_operators.go
@@ -108,6 +108,7 @@ type OperatorLeafAccount struct {
 	Balance    *big.Int
 	HasCode    bool
 	HasStorage bool
+	CodeSize   uint64
 }
 
 func (o *OperatorLeafAccount) WriteTo(output *OperatorMarshaller) error {
@@ -145,7 +146,15 @@ func (o *OperatorLeafAccount) WriteTo(output *OperatorMarshaller) error {
 	}
 
 	if o.Balance.Sign() != 0 {
-		return output.WriteByteArrayValue(o.Balance.Bytes())
+		if err := output.WriteByteArrayValue(o.Balance.Bytes()); err != nil {
+			return err
+		}
+	}
+
+	if o.HasCode {
+		if err := output.WriteUint64Value(o.CodeSize); err != nil {
+			return err
+		}
 	}
 
 	return nil
@@ -185,6 +194,14 @@ func (o *OperatorLeafAccount) LoadFrom(loader *OperatorUnmarshaller) error {
 	}
 
 	o.Balance = balance
+
+	if o.HasCode {
+		if codeSize, err := loader.ReadUInt64(); err == nil {
+			o.CodeSize = codeSize
+		} else {
+			return err
+		}
+	}
 
 	return nil
 }

--- a/trie/witness_operators_test.go
+++ b/trie/witness_operators_test.go
@@ -60,6 +60,7 @@ func TestAccountBigBalance(t *testing.T) {
 		balance,
 		false,
 		false,
+		0,
 	}
 
 	var buff bytes.Buffer
@@ -97,6 +98,7 @@ func TestAccountCompactWriteTo(t *testing.T) {
 		big.NewInt(0),
 		false,
 		false,
+		0,
 	}
 
 	var buff bytes.Buffer
@@ -125,6 +127,7 @@ func TestAccountFullWriteTo(t *testing.T) {
 		big.NewInt(10),
 		true,
 		true,
+		0,
 	}
 
 	var buff bytes.Buffer
@@ -165,6 +168,7 @@ func TestAccountPartialNoNonceWriteTo(t *testing.T) {
 		big.NewInt(10),
 		true,
 		true,
+		0,
 	}
 
 	var buff bytes.Buffer
@@ -204,6 +208,7 @@ func TestAccountPartialNoBalanceWriteTo(t *testing.T) {
 		big.NewInt(0),
 		true,
 		true,
+		0,
 	}
 
 	var buff bytes.Buffer

--- a/trie/witness_test.go
+++ b/trie/witness_test.go
@@ -23,6 +23,7 @@ func generateOperands() []WitnessOperator {
 			big.NewInt(552),
 			true,
 			false,
+			10,
 		},
 		&OperatorLeafAccount{
 			[]byte{2, 2, 4, 5, 7},
@@ -30,6 +31,7 @@ func generateOperands() []WitnessOperator {
 			big.NewInt(334),
 			true,
 			true,
+			11,
 		},
 		&OperatorLeafAccount{
 			[]byte{2, 2, 4, 5, 8},
@@ -37,6 +39,7 @@ func generateOperands() []WitnessOperator {
 			big.NewInt(11112),
 			false,
 			false,
+			12,
 		},
 		&OperatorLeafAccount{
 			[]byte{2, 2, 4, 5, 9},
@@ -44,6 +47,7 @@ func generateOperands() []WitnessOperator {
 			big.NewInt(0),
 			false,
 			false,
+			13,
 		},
 	}
 }


### PR DESCRIPTION
Fix 1: Retain List for witness generation should have no incarnations.

Fix 2: EXTCODESIZE should be supported even when there is no code in the witness.