### PR TITLE
integration test - to use same blockchain config as production

### DIFF
--- a/cmd/integration/stages.go
+++ b/cmd/integration/stages.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/ledgerwatch/turbo-geth/consensus/ethash"
 	"github.com/ledgerwatch/turbo-geth/core"
-	"github.com/ledgerwatch/turbo-geth/core/vm"
+	"github.com/ledgerwatch/turbo-geth/eth"
 	"github.com/ledgerwatch/turbo-geth/eth/stagedsync"
 	"github.com/ledgerwatch/turbo-geth/eth/stagedsync/stages"
 	"github.com/ledgerwatch/turbo-geth/ethdb"
@@ -198,15 +198,18 @@ func stage4(ctx context.Context) error {
 		// TODO
 	}
 
+	blockchain, err := newBlockChain(db)
+	if err != nil {
+		return err
+	}
 	stage4 := progress(db, stages.Execution)
 	log.Info("Stage4", "progress", stage4.BlockNumber)
 	ch := ctx.Done()
-	blockchain, _ := core.NewBlockChain(db, nil, params.MainnetChainConfig, ethash.NewFaker(), vm.Config{}, nil, nil, nil)
 	if unwind > 0 {
 		u := &stagedsync.UnwindState{Stage: stages.Execution, UnwindPoint: stage4.BlockNumber - unwind}
 		return stagedsync.UnwindExecutionStage(u, stage4, db)
 	}
-	return stagedsync.SpawnExecuteBlocksStage(stage4, db, blockchain, block, ch, nil, false)
+	return stagedsync.SpawnExecuteBlocksStage(stage4, db, blockchain, block, ch, blockchain.DestsCache, false)
 }
 
 func stage5(ctx context.Context) error {
@@ -319,4 +322,14 @@ func printAllStages(_ context.Context) error {
 	defer db.Close()
 
 	return printStages(db)
+}
+
+func newBlockChain(db ethdb.Database) (*core.BlockChain, error) {
+	config := eth.DefaultConfig
+	chainConfig, _, _, err := core.SetupGenesisBlock(db, config.Genesis, config.StorageMode.History)
+	if err != nil {
+		return nil, err
+	}
+	vmConfig, cacheConfig, dests := eth.BlockchainRuntimeConfig(&config)
+	return core.NewBlockChain(db, cacheConfig, chainConfig, ethash.NewFaker(), vmConfig, nil, &config.TxLookupLimit, dests)
 }

--- a/cmd/integration/state_stages.go
+++ b/cmd/integration/state_stages.go
@@ -4,14 +4,11 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/ledgerwatch/turbo-geth/consensus/ethash"
 	"github.com/ledgerwatch/turbo-geth/core"
-	"github.com/ledgerwatch/turbo-geth/core/vm"
 	"github.com/ledgerwatch/turbo-geth/eth/stagedsync"
 	"github.com/ledgerwatch/turbo-geth/eth/stagedsync/stages"
 	"github.com/ledgerwatch/turbo-geth/ethdb"
 	"github.com/ledgerwatch/turbo-geth/log"
-	"github.com/ledgerwatch/turbo-geth/params"
 	"github.com/spf13/cobra"
 )
 
@@ -48,7 +45,7 @@ func syncBySmallSteps(ctx context.Context, chaindata string) error {
 	core.UsePlainStateExecution = true
 	db := ethdb.MustOpen(chaindata)
 	defer db.Close()
-	blockchain, err := core.NewBlockChain(db, nil, params.MainnetChainConfig, ethash.NewFaker(), vm.Config{}, nil, nil, nil)
+	blockchain, err := newBlockChain(db)
 	if err != nil {
 		return err
 	}

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -217,28 +217,7 @@ func New(ctx *node.ServiceContext, config *Config) (*Ethereum, error) {
 		return nil, err
 	}
 
-	var (
-		vmConfig = vm.Config{
-			EnablePreimageRecording: config.EnablePreimageRecording,
-			EWASMInterpreter:        config.EWASMInterpreter,
-			EVMInterpreter:          config.EVMInterpreter,
-		}
-		cacheConfig = &core.CacheConfig{
-			Pruning:             config.Pruning,
-			BlocksBeforePruning: config.BlocksBeforePruning,
-			BlocksToPrune:       config.BlocksToPrune,
-			PruneTimeout:        config.PruningTimeout,
-			TrieCleanLimit:      config.TrieCleanCache,
-			TrieCleanNoPrefetch: config.NoPrefetch,
-			TrieDirtyLimit:      config.TrieDirtyCache,
-			TrieTimeLimit:       config.TrieTimeout,
-			DownloadOnly:        config.DownloadOnly,
-			NoHistory:           !config.StorageMode.History,
-			ArchiveSyncInterval: uint64(config.ArchiveSyncInterval),
-		}
-	)
-
-	dests := vm.NewDestsCache(50000)
+	vmConfig, cacheConfig, dests := BlockchainRuntimeConfig(config)
 	eth.blockchain, err = core.NewBlockChain(chainDb, cacheConfig, chainConfig, eth.engine, vmConfig, eth.shouldPreserve, &config.TxLookupLimit, dests)
 	if err != nil {
 		return nil, err
@@ -302,6 +281,30 @@ func New(ctx *node.ServiceContext, config *Config) (*Ethereum, error) {
 	}
 
 	return eth, nil
+}
+
+func BlockchainRuntimeConfig(config *Config) (vm.Config, *core.CacheConfig, *vm.DestsCache) {
+	var (
+		vmConfig = vm.Config{
+			EnablePreimageRecording: config.EnablePreimageRecording,
+			EWASMInterpreter:        config.EWASMInterpreter,
+			EVMInterpreter:          config.EVMInterpreter,
+		}
+		cacheConfig = &core.CacheConfig{
+			Pruning:             config.Pruning,
+			BlocksBeforePruning: config.BlocksBeforePruning,
+			BlocksToPrune:       config.BlocksToPrune,
+			PruneTimeout:        config.PruningTimeout,
+			TrieCleanLimit:      config.TrieCleanCache,
+			TrieCleanNoPrefetch: config.NoPrefetch,
+			TrieDirtyLimit:      config.TrieDirtyCache,
+			TrieTimeLimit:       config.TrieTimeout,
+			DownloadOnly:        config.DownloadOnly,
+			NoHistory:           !config.StorageMode.History,
+			ArchiveSyncInterval: uint64(config.ArchiveSyncInterval),
+		}
+	)
+	return vmConfig, cacheConfig, vm.NewDestsCache(50000)
 }
 
 func makeExtraData(extra []byte) []byte {


### PR DESCRIPTION
set default configs, jumpdest cache of same size
but still `ethash.NewFaker()` 