### PR TITLE
Ability to use go run for cmd/integration

### DIFF
--- a/cmd/integration/commands/flags.go
+++ b/cmd/integration/commands/flags.go
@@ -1,4 +1,4 @@
-package main
+package commands
 
 import "github.com/spf13/cobra"
 

--- a/cmd/integration/commands/refetence_db.go
+++ b/cmd/integration/commands/refetence_db.go
@@ -1,4 +1,4 @@
-package main
+package commands
 
 import (
 	"bytes"

--- a/cmd/integration/commands/reset_state.go
+++ b/cmd/integration/commands/reset_state.go
@@ -1,4 +1,4 @@
-package main
+package commands
 
 import (
 	"context"

--- a/cmd/integration/commands/root.go
+++ b/cmd/integration/commands/root.go
@@ -1,0 +1,55 @@
+package commands
+
+import (
+	"context"
+	"fmt"
+	"github.com/ledgerwatch/turbo-geth/cmd/utils"
+	"github.com/ledgerwatch/turbo-geth/internal/debug"
+	"github.com/ledgerwatch/turbo-geth/log"
+	"github.com/spf13/cobra"
+	"os"
+	"os/signal"
+	"syscall"
+)
+
+var rootCmd = &cobra.Command{
+	Use:   "integration",
+	Short: "long and heavy integration tests for turbo-geth",
+	PersistentPreRun: func(cmd *cobra.Command, args []string) {
+		if err := debug.SetupCobra(cmd); err != nil {
+			panic(err)
+		}
+	},
+	PersistentPostRun: func(cmd *cobra.Command, args []string) {
+		debug.Exit()
+	},
+}
+
+func init() {
+	utils.CobraFlags(rootCmd, append(debug.Flags, utils.MetricsEnabledFlag, utils.MetricsEnabledExpensiveFlag))
+}
+
+func rootContext() context.Context {
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		ch := make(chan os.Signal, 1)
+		signal.Notify(ch, os.Interrupt, syscall.SIGTERM)
+		defer signal.Stop(ch)
+
+		select {
+		case <-ch:
+			log.Info("Got interrupt, shutting down...")
+		case <-ctx.Done():
+		}
+
+		cancel()
+	}()
+	return ctx
+}
+
+func Execute() {
+	if err := rootCmd.ExecuteContext(rootContext()); err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+}

--- a/cmd/integration/commands/stages.go
+++ b/cmd/integration/commands/stages.go
@@ -1,4 +1,4 @@
-package main
+package commands
 
 import (
 	"context"

--- a/cmd/integration/commands/state_stages.go
+++ b/cmd/integration/commands/state_stages.go
@@ -1,4 +1,4 @@
-package main
+package commands
 
 import (
 	"bytes"

--- a/cmd/integration/main.go
+++ b/cmd/integration/main.go
@@ -1,56 +1,8 @@
 package main
 
-import (
-	"context"
-	"fmt"
-	"os"
-	"os/signal"
-	"syscall"
-
-	"github.com/ledgerwatch/turbo-geth/cmd/utils"
-	"github.com/ledgerwatch/turbo-geth/internal/debug"
-	"github.com/ledgerwatch/turbo-geth/log"
-	"github.com/spf13/cobra"
-)
-
-var rootCmd = &cobra.Command{
-	Use:   "integration",
-	Short: "long and heavy integration tests for turbo-geth",
-	PersistentPreRun: func(cmd *cobra.Command, args []string) {
-		if err := debug.SetupCobra(cmd); err != nil {
-			panic(err)
-		}
-	},
-	PersistentPostRun: func(cmd *cobra.Command, args []string) {
-		debug.Exit()
-	},
-}
-
-func init() {
-	utils.CobraFlags(rootCmd, append(debug.Flags, utils.MetricsEnabledFlag, utils.MetricsEnabledExpensiveFlag))
-}
+import "github.com/ledgerwatch/turbo-geth/cmd/integration/commands"
 
 func main() {
-	if err := rootCmd.ExecuteContext(rootContext()); err != nil {
-		fmt.Println(err)
-		os.Exit(1)
-	}
+	commands.Execute()
 }
 
-func rootContext() context.Context {
-	ctx, cancel := context.WithCancel(context.Background())
-	go func() {
-		ch := make(chan os.Signal, 1)
-		signal.Notify(ch, os.Interrupt, syscall.SIGTERM)
-		defer signal.Stop(ch)
-
-		select {
-		case <-ch:
-			log.Info("Got interrupt, shutting down...")
-		case <-ctx.Done():
-		}
-
-		cancel()
-	}()
-	return ctx
-}


### PR DESCRIPTION
Problem:
Init func runs only for main.go
Before:
```
go run ./cmd/integration/main.go --help
long and heavy integration tests for turbo-geth
```
After:
```
 go run cmd/integration/main.go --help
long and heavy integration tests for turbo-geth

Usage:
  integration [command]

Available Commands:
  compare_bucket compare bucket to the same bucket in '--reference_chaindata'
  compare_states compare state buckets to buckets in '--reference_chaindata'
  help           Help about any command
  print_stages   
...
```