### PR TITLE
Release map keys and values on stage4

### DIFF
--- a/eth/stagedsync/stage_interhashes.go
+++ b/eth/stagedsync/stage_interhashes.go
@@ -224,7 +224,7 @@ func (r *Receiver) accountLoad(k []byte, value []byte, _ etl.State, _ etl.LoadNe
 		}
 		r.accountMap[newKStr] = &a
 	} else {
-		r.accountMap[newKStr] = nil
+		delete(r.accountMap, newKStr)
 	}
 	r.unfurlList = append(r.unfurlList, newKStr)
 	return nil
@@ -239,7 +239,7 @@ func (r *Receiver) storageLoad(k []byte, value []byte, _ etl.State, _ etl.LoadNe
 	if len(value) > 0 {
 		r.storageMap[newKStr] = common.CopyBytes(value)
 	} else {
-		r.storageMap[newKStr] = nil
+		delete(r.storageMap, newKStr)
 	}
 	r.unfurlList = append(r.unfurlList, newKStr)
 	return nil
@@ -362,14 +362,12 @@ func incrementIntermediateHashes(s *StageState, db ethdb.Database, from, to uint
 		return err
 	}
 	for ks, acc := range r.accountMap {
-		if acc != nil {
-			// Fill the code hashes
-			if acc.Incarnation > 0 && acc.IsEmptyCodeHash() {
-				if codeHash, err := db.Get(dbutils.ContractCodeBucket, dbutils.GenerateStoragePrefix([]byte(ks), acc.Incarnation)); err == nil {
-					copy(acc.CodeHash[:], codeHash)
-				} else if !errors.Is(err, ethdb.ErrKeyNotFound) {
-					return fmt.Errorf("adjusting codeHash for ks %x, inc %d: %w", ks, acc.Incarnation, err)
-				}
+		// Fill the code hashes
+		if acc.Incarnation > 0 && acc.IsEmptyCodeHash() {
+			if codeHash, err := db.Get(dbutils.ContractCodeBucket, dbutils.GenerateStoragePrefix([]byte(ks), acc.Incarnation)); err == nil {
+				copy(acc.CodeHash[:], codeHash)
+			} else if !errors.Is(err, ethdb.ErrKeyNotFound) {
+				return fmt.Errorf("adjusting codeHash for ks %x, inc %d: %w", ks, acc.Incarnation, err)
 			}
 		}
 	}
@@ -433,16 +431,14 @@ func unwindIntermediateHashesStageImpl(u *UnwindState, s *StageState, db ethdb.D
 		return err
 	}
 	for ks, acc := range r.accountMap {
-		if acc != nil {
-			// Fill the code hashes
-			if acc.Incarnation > 0 && acc.IsEmptyCodeHash() {
-				if codeHash, err := db.Get(dbutils.ContractCodeBucket, dbutils.GenerateStoragePrefix([]byte(ks), acc.Incarnation)); err == nil {
-					copy(acc.CodeHash[:], codeHash)
-				} else if errors.Is(err, ethdb.ErrKeyNotFound) {
-					copy(acc.CodeHash[:], trie.EmptyCodeHash[:])
-				} else {
-					return fmt.Errorf("adjusting codeHash for ks %x, inc %d: %w", ks, acc.Incarnation, err)
-				}
+		// Fill the code hashes
+		if acc.Incarnation > 0 && acc.IsEmptyCodeHash() {
+			if codeHash, err := db.Get(dbutils.ContractCodeBucket, dbutils.GenerateStoragePrefix([]byte(ks), acc.Incarnation)); err == nil {
+				copy(acc.CodeHash[:], codeHash)
+			} else if errors.Is(err, ethdb.ErrKeyNotFound) {
+				copy(acc.CodeHash[:], trie.EmptyCodeHash[:])
+			} else {
+				return fmt.Errorf("adjusting codeHash for ks %x, inc %d: %w", ks, acc.Incarnation, err)
 			}
 		}
 	}


### PR DESCRIPTION
I got this
```
fatal error: runtime: out of memory

runtime stack:
runtime.throw(0x1428fc9, 0x16)
	/snap/go/current/src/runtime/panic.go:1116 +0x72
runtime.sysMap(0xcd08000000, 0x2cc000000, 0x2475c78)
	/snap/go/current/src/runtime/mem_linux.go:169 +0xc5
runtime.(*mheap).sysAlloc(0x245ff20, 0x2ca000000, 0x245ff28, 0x165000)
	/snap/go/current/src/runtime/malloc.go:715 +0x1cd
runtime.(*mheap).grow(0x245ff20, 0x165000, 0x0)
	/snap/go/current/src/runtime/mheap.go:1286 +0x11c
runtime.(*mheap).allocSpan(0x245ff20, 0x165000, 0x7ffd78ed0000, 0x2475c88, 0x17)
	/snap/go/current/src/runtime/mheap.go:1124 +0x6a0
runtime.(*mheap).alloc.func1()
	/snap/go/current/src/runtime/mheap.go:871 +0x64
runtime.(*mheap).alloc(0x245ff20, 0x165000, 0x100, 0x168c638)
	/snap/go/current/src/runtime/mheap.go:865 +0x81
runtime.largeAlloc(0x2ca000000, 0x480001, 0xc95fd585f0)
	/snap/go/current/src/runtime/malloc.go:1152 +0x92
runtime.mallocgc.func1()
	/snap/go/current/src/runtime/malloc.go:1047 +0x46
runtime.systemstack(0x488be4)
	/snap/go/current/src/runtime/asm_amd64.s:370 +0x66
runtime.mstart()
	/snap/go/current/src/runtime/proc.go:1041

goroutine 834 [running]:
runtime.systemstack_switch()
	/snap/go/current/src/runtime/asm_amd64.s:330 fp=0xc395cee648 sp=0xc395cee640 pc=0x488ce0
runtime.mallocgc(0x2ca000000, 0x1324060, 0x74784352a462ab01, 0x9286773b23ddc557)
	/snap/go/current/src/runtime/malloc.go:1046 +0x895 fp=0xc395cee6e8 sp=0xc395cee648 pc=0x42fa15
runtime.newarray(0x1324060, 0x2200000, 0x5681cc0e2719fb18)
	/snap/go/current/src/runtime/malloc.go:1187 +0x63 fp=0xc395cee718 sp=0xc395cee6e8 pc=0x42fe53
runtime.makeBucketArray(0x1270dc0, 0xee53ae3d00000019, 0x0, 0x0, 0x48)
	/snap/go/current/src/runtime/map.go:362 +0x183 fp=0xc395cee750 sp=0xc395cee718 pc=0x430d33
runtime.hashGrow(0x1270dc0, 0xc000201920)
	/snap/go/current/src/runtime/map.go:1027 +0x89 fp=0xc395cee7a0 sp=0xc395cee750 pc=0x4328f9
runtime.mapassign_faststr(0x1270dc0, 0xc000201920, 0xc95fd9b2c0, 0x48, 0xc95fd9b2c0)
	/snap/go/current/src/runtime/map_faststr.go:272 +0x107 fp=0xc395cee808 sp=0xc395cee7a0 pc=0x436177
github.com/ledgerwatch/turbo-geth/eth/stagedsync.(*Receiver).storageLoad(0xc00047c9a0, 0xc95fd8ed00, 0x3c, 0x3c, 0x0, 0x0, 0x0, 0x16cb9e0, 0xc2801df920, 0xc0004c1340, ...)
	/mnt/sdb/go/src/github.com/ledgerwatch/sync/turbo-geth/eth/stagedsync/stage_interhashes.go:242 +0x288 fp=0xc395cee880 sp=0xc395cee808 pc=0xd330c8
github.com/ledgerwatch/turbo-geth/eth/stagedsync.(*Receiver).storageLoad-fm(0xc95fd8ed00, 0x3c, 0x3c, 0x0, 0x0, 0x0, 0x16cb9e0, 0xc2801df920, 0xc0004c1340, 0xc395cee9b8, ...)
	/mnt/sdb/go/src/github.com/ledgerwatch/sync/turbo-geth/eth/stagedsync/stage_interhashes.go:233 +0x9d fp=0xc395cee8f0 sp=0xc395cee880 pc=0xd418fd
github.com/ledgerwatch/turbo-geth/eth/stagedsync.(*OldestAppearedLoad).LoadFunc(0xc74f5c8ed0, 0xc95fd8ed00, 0x3c, 0x3c, 0x0, 0x0, 0x0, 0x16cb9e0, 0xc2801df920, 0xc0004c1340, ...)
	/mnt/sdb/go/src/github.com/ledgerwatch/sync/turbo-geth/eth/stagedsync/stage_hashstate.go:225 +0x135 fp=0xc395cee958 sp=0xc395cee8f0 pc=0xd2c4a5
github.com/ledgerwatch/turbo-geth/eth/stagedsync.(*OldestAppearedLoad).LoadFunc-fm(0xc95fd8ed00, 0x3c, 0x3c, 0x0, 0x0, 0x0, 0x16cb9e0, 0xc2801df920, 0xc0004c1340, 0x0, ...)
	/mnt/sdb/go/src/github.com/ledgerwatch/sync/turbo-geth/eth/stagedsync/stage_hashstate.go:218 +0x9d fp=0xc395cee9c8 sp=0xc395cee958 pc=0xd4182d
github.com/ledgerwatch/turbo-geth/eth/stagedsync.getFromPlainStateAndLoad.func1(0xc95fd8ed00, 0x3c, 0x3c, 0x0, 0x0, 0x0, 0x16cb9e0, 0xc2801df920, 0xc0004c1340, 0x0, ...)
	/mnt/sdb/go/src/github.com/ledgerwatch/sync/turbo-geth/eth/stagedsync/stage_hashstate.go:291 +0x131 fp=0xc395ceea68 sp=0xc395cee9c8 pc=0xd3db81
github.com/ledgerwatch/turbo-geth/common/etl.loadFilesIntoBucket(0x16f5dc0, 0xc0001db830, 0x0, 0x0, 0x0, 0xc0000db000, 0x79, 0x80, 0xc78cafe120, 0xc78cafa189, ...)
	/mnt/sdb/go/src/github.com/ledgerwatch/sync/turbo-geth/common/etl/collector.go:143 +0x485 fp=0xc395ceed58 sp=0xc395ceea68 pc=0xb427b5
github.com/ledgerwatch/turbo-geth/common/etl.(*Collector).Load(0xc74f5c8f60, 0x16f5dc0, 0xc0001db830, 0x0, 0x0, 0x0, 0xc78cafe120, 0xc78cafa189, 0x1, 0x1, ...)
	/mnt/sdb/go/src/github.com/ledgerwatch/sync/turbo-geth/common/etl/collector.go:79 +0x118 fp=0xc395ceee50 sp=0xc395ceed58 pc=0xb42258
github.com/ledgerwatch/turbo-geth/common/etl.Transform(0x16f5dc0, 0xc0001db830, 0x21e7d48, 0x9, 0x9, 0x0, 0x0, 0x0, 0xc00029f5c0, 0x16, ...)
	/mnt/sdb/go/src/github.com/ledgerwatch/sync/turbo-geth/common/etl/etl.go:94 +0x3c5 fp=0xc395ceef98 sp=0xc395ceee50 pc=0xb44885
github.com/ledgerwatch/turbo-geth/eth/stagedsync.(*HashPromoter).Promote(0xc000201890, 0xc000201770, 0x1, 0x9fc300, 0xc000370201, 0xc00047c9a0, 0x0, 0x0)
	/mnt/sdb/go/src/github.com/ledgerwatch/sync/turbo-geth/eth/stagedsync/stage_interhashes.go:283 +0x501 fp=0xc395cef1c8 sp=0xc395ceef98 pc=0xd33741
github.com/ledgerwatch/turbo-geth/eth/stagedsync.incrementIntermediateHashes(0xc000201770, 0x16f5dc0, 0xc0001db830, 0x1, 0x9fc300, 0xc00029f5c0, 0x16, 0x212c30960e6e6f1d, 0x210626e65bf4f6ed, 0xb001f9ad5adb65c6, ...)
	/mnt/sdb/go/src/github.com/ledgerwatch/sync/turbo-geth/eth/stagedsync/stage_interhashes.go:361 +0x2d0 fp=0xc395cef5a8 sp=0xc395cef1c8 pc=0xd34130
github.com/ledgerwatch/turbo-geth/eth/stagedsync.updateIntermediateHashes(0xc000201770, 0x16f5dc0, 0xc0001db830, 0x1, 0x9fc300, 0xc00029f5c0, 0x16, 0xc0000aa840, 0x0, 0x0)
	/mnt/sdb/go/src/github.com/ledgerwatch/sync/turbo-geth/eth/stagedsync/stage_interhashes.go:57 +0x232 fp=0xc395cef668 sp=0xc395cef5a8 pc=0xd313a2
github.com/ledgerwatch/turbo-geth/eth/stagedsync.SpawnIntermediateHashesStage(0xc000201770, 0x16f5dc0, 0xc0001db830, 0xc00029f5c0, 0x16, 0xc0000aa840, 0xd3b590, 0x1d72ec8)
	/mnt/sdb/go/src/github.com/ledgerwatch/sync/turbo-geth/eth/stagedsync/stage_interhashes.go:44 +0x23e fp=0xc395cef738 sp=0xc395cef668 pc=0xd30f5e
github.com/ledgerwatch/turbo-geth/eth/stagedsync.PrepareStagedSync.func9(0xc000201770, 0x16ba400, 0xc000201680, 0x3, 0x0)
	/mnt/sdb/go/src/github.com/ledgerwatch/sync/turbo-geth/eth/stagedsync/stagedsync.go:120 +0x6d fp=0xc395cef790 sp=0xc395cef738 pc=0xd40cfd
github.com/ledgerwatch/turbo-geth/eth/stagedsync.(*State).runStage(0xc000201680, 0xc000298e00, 0x7fcb88177040, 0xc0001db830, 0xc0001db830, 0x0)
	/mnt/sdb/go/src/github.com/ledgerwatch/sync/turbo-geth/eth/stagedsync/state.go:202 +0x204 fp=0xc395cef848 sp=0xc395cef790 pc=0xd3b794
github.com/ledgerwatch/turbo-geth/eth/stagedsync.(*State).RunInterruptedStage(0xc000201680, 0x7fcb88177080, 0xc0001db830, 0x11473d9, 0x9e3850)
	/mnt/sdb/go/src/github.com/ledgerwatch/sync/turbo-geth/eth/stagedsync/state.go:125 +0x25b fp=0xc395cef8a8 sp=0xc395cef848 pc=0xd3aefb
github.com/ledgerwatch/turbo-geth/eth/stagedsync.(*State).Run(0xc000201680, 0x7fcb88177080, 0xc0001db830, 0x7fcb88177080, 0xc0001db830)
	/mnt/sdb/go/src/github.com/ledgerwatch/sync/turbo-geth/eth/stagedsync/state.go:148 +0x5a fp=0xc395cef980 sp=0xc395cef8a8 pc=0xd3afba
github.com/ledgerwatch/turbo-geth/eth/downloader.(*Downloader).syncWithPeer(0xc00000c3c0, 0xc0000ada40, 0x90d37a06143e1cf2, 0x88b7ea53f9f256aa, 0x2449f2492a02105c, 0x23f6ec231c1a7de, 0xc0000a8400, 0x16d8fa0, 0xc0000b0000, 0xc0002945d0, ...)
	/mnt/sdb/go/src/github.com/ledgerwatch/sync/turbo-geth/eth/downloader/downloader.go:586 +0xb07 fp=0xc395cefc78 sp=0xc395cef980 pc=0xd44e37
github.com/ledgerwatch/turbo-geth/eth/downloader.(*Downloader).synchronise(0xc00000c3c0, 0xc0002d45d0, 0x10, 0x90d37a06143e1cf2, 0x88b7ea53f9f256aa, 0x2449f2492a02105c, 0x23f6ec231c1a7de, 0xc0000a8400, 0x3, 0x16d8fa0, ...)
	/mnt/sdb/go/src/github.com/ledgerwatch/sync/turbo-geth/eth/downloader/downloader.go:458 +0x3a8 fp=0xc395cefd50 sp=0xc395cefc78 pc=0xd44118
github.com/ledgerwatch/turbo-geth/eth/downloader.(*Downloader).Synchronise(0xc00000c3c0, 0xc0002d45d0, 0x10, 0x90d37a06143e1cf2, 0x88b7ea53f9f256aa, 0x2449f2492a02105c, 0x23f6ec231c1a7de, 0xc0000a8400, 0x3, 0x16d8fa0, ...)
	/mnt/sdb/go/src/github.com/ledgerwatch/sync/turbo-geth/eth/downloader/downloader.go:355 +0xb8 fp=0xc395cefec0 sp=0xc395cefd50 pc=0xd43558
github.com/ledgerwatch/turbo-geth/eth.(*ProtocolManager).doSync(0xc0002a6900, 0xc000532200, 0x14f7e10, 0xc00001c380)
	/mnt/sdb/go/src/github.com/ledgerwatch/sync/turbo-geth/eth/sync.go:322 +0x1b9 fp=0xc395ceff90 sp=0xc395cefec0 pc=0xe5e6f9
github.com/ledgerwatch/turbo-geth/eth.(*chainSyncer).startSync.func1(0xc0001da600, 0xc000532200)
	/mnt/sdb/go/src/github.com/ledgerwatch/sync/turbo-geth/eth/sync.go:294 +0x38 fp=0xc395ceffd0 sp=0xc395ceff90 pc=0xe646a8
runtime.goexit()
	/snap/go/current/src/runtime/asm_amd64.s:1373 +0x1 fp=0xc395ceffd8 sp=0xc395ceffd0 pc=0x48adf1
created by github.com/ledgerwatch/turbo-geth/eth.(*chainSyncer).startSync
	/mnt/sdb/go/src/github.com/ledgerwatch/sync/turbo-geth/eth/sync.go:294 +0x7a
```

We can delete map keys instead of setting them to `nil` and keeping map cell in memory.