### PR TITLE
Ci lmdb - reduce memory usage 

### DIFF
--- a/eth/downloader/downloader_test.go
+++ b/eth/downloader/downloader_test.go
@@ -38,10 +38,12 @@ import (
 	"github.com/ledgerwatch/turbo-geth/params"
 )
 
+const OwerwriteBlockCacheItems = 256
+
 // Reduce some of the parameters to make the tester faster.
 func init() {
 	maxForkAncestry = 10000
-	blockCacheItems = 1024
+	blockCacheItems = OwerwriteBlockCacheItems
 	fsHeaderContCheck = 500 * time.Millisecond
 }
 

--- a/eth/downloader/downloader_test.go
+++ b/eth/downloader/downloader_test.go
@@ -39,14 +39,14 @@ import (
 )
 
 const OwerwriteBlockCacheItems = 1024
-const OwerwriteMaxForkAncestry = 5000
+const OwerwriteMaxForkAncestry = 3000
 
 // Reduce some of the parameters to make the tester faster.
 func init() {
 	maxForkAncestry = OwerwriteMaxForkAncestry
 	blockCacheItems = OwerwriteBlockCacheItems
 	fsHeaderSafetyNet = 256
-	fsHeaderContCheck = 500 * time.Millisecond
+	fsHeaderContCheck = 50 * time.Millisecond
 }
 
 // downloadTester is a test simulator for mocking out local block chain.
@@ -1024,7 +1024,7 @@ func testInvalidHeaderRollback(t *testing.T, protocol int, mode SyncMode) {
 	defer tester.peerDb.Close()
 
 	// Create a small enough block chain to download
-	targetBlocks := 3*fsHeaderSafetyNet + 256 + fsMinFullBlocks
+	targetBlocks := 2*fsHeaderSafetyNet + 256 + fsMinFullBlocks
 	chain := testChainBase.shorten(targetBlocks)
 
 	// Attempt to sync with an attacker that feeds junk during the fast sync phase.
@@ -1044,7 +1044,7 @@ func testInvalidHeaderRollback(t *testing.T, protocol int, mode SyncMode) {
 	// Attempt to sync with an attacker that feeds junk during the block import phase.
 	// This should result in both the last fsHeaderSafetyNet number of headers being
 	// rolled back, and also the pivot point being reverted to a non-block status.
-	missing = 3*fsHeaderSafetyNet + MaxHeaderFetch + 1
+	missing = 2*fsHeaderSafetyNet + MaxHeaderFetch + 1
 	blockAttackChain := chain.shorten(chain.len())
 	delete(fastAttackChain.headerm, fastAttackChain.chain[missing]) // Make sure the fast-attacker doesn't fill in
 	delete(blockAttackChain.headerm, blockAttackChain.chain[missing])

--- a/eth/downloader/downloader_test.go
+++ b/eth/downloader/downloader_test.go
@@ -38,7 +38,7 @@ import (
 	"github.com/ledgerwatch/turbo-geth/params"
 )
 
-const OwerwriteBlockCacheItems = 256
+const OwerwriteBlockCacheItems = 128
 
 // Reduce some of the parameters to make the tester faster.
 func init() {
@@ -632,8 +632,8 @@ func testForkedSync(t *testing.T, protocol int, mode SyncMode) {
 	defer tester.terminate()
 	defer tester.peerDb.Close()
 
-	chainA := testChainForkLightA.shorten(testChainBase.len() + 80)
-	chainB := testChainForkLightB.shorten(testChainBase.len() + 80)
+	chainA := testChainForkLightA.shorten(testChainBase.len() + 32)
+	chainB := testChainForkLightB.shorten(testChainBase.len() + 32)
 	tester.newPeer("fork A", protocol, chainA)
 	tester.newPeer("fork B", protocol, chainB)
 
@@ -666,8 +666,8 @@ func testHeavyForkedSync(t *testing.T, protocol int, mode SyncMode) {
 	defer tester.terminate()
 	defer tester.peerDb.Close()
 
-	chainA := testChainForkLightA.shorten(testChainBase.len() + 80)
-	chainB := testChainForkHeavy.shorten(testChainBase.len() + 80)
+	chainA := testChainForkLightA.shorten(testChainBase.len() + 32)
+	chainB := testChainForkHeavy.shorten(testChainBase.len() + 32)
 	tester.newPeer("light", protocol, chainA)
 	tester.newPeer("heavy", protocol, chainB)
 

--- a/eth/downloader/downloader_test.go
+++ b/eth/downloader/downloader_test.go
@@ -45,6 +45,7 @@ const OwerwriteMaxForkAncestry = 5000
 func init() {
 	maxForkAncestry = OwerwriteMaxForkAncestry
 	blockCacheItems = OwerwriteBlockCacheItems
+	fsHeaderSafetyNet = 256
 	fsHeaderContCheck = 500 * time.Millisecond
 }
 

--- a/eth/downloader/downloader_test.go
+++ b/eth/downloader/downloader_test.go
@@ -38,7 +38,7 @@ import (
 	"github.com/ledgerwatch/turbo-geth/params"
 )
 
-const OwerwriteBlockCacheItems = 512
+const OwerwriteBlockCacheItems = 1024
 const OwerwriteMaxForkAncestry = 5000
 
 // Reduce some of the parameters to make the tester faster.

--- a/eth/downloader/downloader_test.go
+++ b/eth/downloader/downloader_test.go
@@ -38,11 +38,12 @@ import (
 	"github.com/ledgerwatch/turbo-geth/params"
 )
 
-const OwerwriteBlockCacheItems = 128
+const OwerwriteBlockCacheItems = 512
+const OwerwriteMaxForkAncestry = 5000
 
 // Reduce some of the parameters to make the tester faster.
 func init() {
-	maxForkAncestry = 10000
+	maxForkAncestry = OwerwriteMaxForkAncestry
 	blockCacheItems = OwerwriteBlockCacheItems
 	fsHeaderContCheck = 500 * time.Millisecond
 }
@@ -632,8 +633,8 @@ func testForkedSync(t *testing.T, protocol int, mode SyncMode) {
 	defer tester.terminate()
 	defer tester.peerDb.Close()
 
-	chainA := testChainForkLightA.shorten(testChainBase.len() + 32)
-	chainB := testChainForkLightB.shorten(testChainBase.len() + 32)
+	chainA := testChainForkLightA.shorten(testChainBase.len() + 80)
+	chainB := testChainForkLightB.shorten(testChainBase.len() + 80)
 	tester.newPeer("fork A", protocol, chainA)
 	tester.newPeer("fork B", protocol, chainB)
 
@@ -666,8 +667,8 @@ func testHeavyForkedSync(t *testing.T, protocol int, mode SyncMode) {
 	defer tester.terminate()
 	defer tester.peerDb.Close()
 
-	chainA := testChainForkLightA.shorten(testChainBase.len() + 32)
-	chainB := testChainForkHeavy.shorten(testChainBase.len() + 32)
+	chainA := testChainForkLightA.shorten(testChainBase.len() + 80)
+	chainB := testChainForkHeavy.shorten(testChainBase.len() + 80)
 	tester.newPeer("light", protocol, chainA)
 	tester.newPeer("heavy", protocol, chainB)
 

--- a/eth/downloader/testchain_test.go
+++ b/eth/downloader/testchain_test.go
@@ -43,13 +43,13 @@ var (
 )
 
 // The common prefix of all test chains:
-var testChainBase = newTestChain(OwerwriteBlockCacheItems+64, testDb, testGenesis)
+var testChainBase = newTestChain(OwerwriteBlockCacheItems+200, testDb, testGenesis)
 
 // Different forks on top of the base chain:
 var testChainForkLightA, testChainForkLightB, testChainForkHeavy *testChain
 
 func TestMain(m *testing.M) {
-	var forkLen = int(maxForkAncestry/5 + 50)
+	var forkLen = OwerwriteMaxForkAncestry + 50
 	var wg sync.WaitGroup
 	wg.Add(3)
 	go func() { testChainForkLightA = testChainBase.makeFork(forkLen, false, 1); wg.Done() }()

--- a/eth/downloader/testchain_test.go
+++ b/eth/downloader/testchain_test.go
@@ -42,14 +42,8 @@ var (
 	testGenesis = core.GenesisBlockForTesting(testDb, testAddress, big.NewInt(1000000000))
 )
 
-const OwerwriteBlockCacheItems = 256
-
-func init() {
-	blockCacheItems = OwerwriteBlockCacheItems
-}
-
 // The common prefix of all test chains:
-var testChainBase = newTestChain(blockCacheItems+200, testDb, testGenesis)
+var testChainBase = newTestChain(OwerwriteBlockCacheItems+200, testDb, testGenesis)
 
 // Different forks on top of the base chain:
 var testChainForkLightA, testChainForkLightB, testChainForkHeavy *testChain

--- a/eth/downloader/testchain_test.go
+++ b/eth/downloader/testchain_test.go
@@ -42,6 +42,12 @@ var (
 	testGenesis = core.GenesisBlockForTesting(testDb, testAddress, big.NewInt(1000000000))
 )
 
+const OwerwriteBlockCacheItems = 256
+
+func init() {
+	blockCacheItems = OwerwriteBlockCacheItems
+}
+
 // The common prefix of all test chains:
 var testChainBase = newTestChain(blockCacheItems+200, testDb, testGenesis)
 

--- a/eth/downloader/testchain_test.go
+++ b/eth/downloader/testchain_test.go
@@ -43,13 +43,13 @@ var (
 )
 
 // The common prefix of all test chains:
-var testChainBase = newTestChain(OwerwriteBlockCacheItems+200, testDb, testGenesis)
+var testChainBase = newTestChain(OwerwriteBlockCacheItems+64, testDb, testGenesis)
 
 // Different forks on top of the base chain:
 var testChainForkLightA, testChainForkLightB, testChainForkHeavy *testChain
 
 func TestMain(m *testing.M) {
-	var forkLen = int(maxForkAncestry + 50)
+	var forkLen = int(maxForkAncestry/5 + 50)
 	var wg sync.WaitGroup
 	wg.Add(3)
 	go func() { testChainForkLightA = testChainBase.makeFork(forkLen, false, 1); wg.Done() }()

--- a/ethdb/kv_lmdb.go
+++ b/ethdb/kv_lmdb.go
@@ -50,7 +50,7 @@ func (opts lmdbOpts) Open() (KV, error) {
 	var logger log.Logger
 
 	if opts.inMem {
-		err = env.SetMapSize(32 << 20) // 32MB
+		err = env.SetMapSize(64 << 20) // 64MB
 		logger = log.New("lmdb", "inMem")
 		if err != nil {
 			return nil, err

--- a/ethdb/kv_lmdb.go
+++ b/ethdb/kv_lmdb.go
@@ -50,7 +50,7 @@ func (opts lmdbOpts) Open() (KV, error) {
 	var logger log.Logger
 
 	if opts.inMem {
-		err = env.SetMapSize(64 << 20) // 64MB
+		err = env.SetMapSize(32 << 20) // 32MB
 		logger = log.New("lmdb", "inMem")
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
Found problem with memory in tests: 
`eth/downloader/downloader_test.go` in init method reduce some big constants to use less memory, but `eth/downloader/testchain_test.go` reading constants values before `init` method run. 
Fixed and reduced lmdb in-mem limit from 64mb to 32mb.