### PR TITLE
fix stage5 interruption

### DIFF
--- a/cmd/integration/commands/stages.go
+++ b/cmd/integration/commands/stages.go
@@ -221,7 +221,7 @@ func stage4(ctx context.Context) error {
 		u := &stagedsync.UnwindState{Stage: stages.Execution, UnwindPoint: stage4.BlockNumber - unwind}
 		return stagedsync.UnwindExecutionStage(u, stage4, db)
 	}
-	return stagedsync.SpawnExecuteBlocksStage(stage4, db, chainConfig, blockchain, block, ch, blockchain.DestsCache, false, nil)
+	return stagedsync.SpawnExecuteBlocksStage(stage4, db, chainConfig, blockchain, blockchain.GetVMConfig(), block, ch, blockchain.DestsCache, false, nil)
 }
 
 func stage5(ctx context.Context) error {
@@ -351,7 +351,7 @@ func newSync(quitCh <-chan struct{}, db *ethdb.ObjectDatabase, hook stagedsync.C
 		panic(err)
 	}
 
-	st, err := stagedsync.PrepareStagedSync(nil, chainConfig, bc, db, "integration_test", ethdb.DefaultStorageMode, "", quitCh, nil, bc.DestsCache, nil, func() error { return nil }, hook)
+	st, err := stagedsync.PrepareStagedSync(nil, chainConfig, bc, bc.GetVMConfig(), db, "integration_test", ethdb.DefaultStorageMode, "", quitCh, nil, bc.DestsCache, nil, func() error { return nil }, hook)
 	if err != nil {
 		panic(err)
 	}

--- a/cmd/integration/commands/state_stages.go
+++ b/cmd/integration/commands/state_stages.go
@@ -112,7 +112,7 @@ func syncBySmallSteps(ctx context.Context, chaindata string) error {
 
 		// set block limit of execute stage
 		st.MockExecFunc(stages.Execution, func(stageState *stagedsync.StageState, unwinder stagedsync.Unwinder) error {
-			if err := stagedsync.SpawnExecuteBlocksStage(stageState, db, bc.Config(), bc, execToBlock, ch, nil, false, changeSetHook); err != nil {
+			if err := stagedsync.SpawnExecuteBlocksStage(stageState, db, bc.Config(), bc, bc.GetVMConfig(), execToBlock, ch, nil, false, changeSetHook); err != nil {
 				return fmt.Errorf("spawnExecuteBlocksStage: %w", err)
 			}
 			return nil

--- a/cmd/integration/commands/state_stages.go
+++ b/cmd/integration/commands/state_stages.go
@@ -57,11 +57,7 @@ func syncBySmallSteps(ctx context.Context, chaindata string) error {
 	core.UsePlainStateExecution = true
 	db := ethdb.MustOpen(chaindata)
 	defer db.Close()
-	chainConfig, blockchain, chainErr := newBlockChain(db)
-	if chainErr != nil {
-		return chainErr
-	}
-	defer blockchain.Stop()
+
 	ch := ctx.Done()
 
 	expectedAccountChanges := make(map[uint64][]byte)
@@ -91,14 +87,7 @@ func syncBySmallSteps(ctx context.Context, chaindata string) error {
 	bc, st, progress := newSync(ch, db, changeSetHook)
 	defer bc.Stop()
 
-	if err := st.RunInterruptedStage(db); err != nil {
-		return fmt.Errorf("runInterruptedStage: %w", err)
-	}
-	_, cs := st.CurrentStage()
-	currentStage := 0
-	if cs.ID == stages.HashState {
-		currentStage = 1
-	}
+	st.DisableStages(stages.Headers, stages.Bodies, stages.Senders, stages.TxPool)
 
 	senderStageProgress := progress(stages.Senders).BlockNumber
 
@@ -121,32 +110,16 @@ func syncBySmallSteps(ctx context.Context, chaindata string) error {
 			unwind = 0
 		}
 
-		if currentStage > 0 {
-			currentStage = 0
-			goto HashState
-		}
+		// set block limit of execute stage
+		st.MockExecFunc(stages.Execution, func(stageState *stagedsync.StageState, unwinder stagedsync.Unwinder) error {
+			if err := stagedsync.SpawnExecuteBlocksStage(stageState, db, bc.Config(), bc, execToBlock, ch, nil, false, changeSetHook); err != nil {
+				return fmt.Errorf("spawnExecuteBlocksStage: %w", err)
+			}
+			return nil
+		})
 
-		if err := stagedsync.SpawnExecuteBlocksStage(progress(stages.Execution), db, chainConfig, blockchain, execToBlock, ch, nil, false, changeSetHook); err != nil {
-			return fmt.Errorf("spawnExecuteBlocksStage: %w", err)
-		}
-
-		if err := st.RunStage(stages.IntermediateHashes, db); err != nil {
-			return fmt.Errorf("spawnIntermediateHashesStage: %w", err)
-		}
-	HashState:
-		if err := st.RunStage(stages.HashState, db); err != nil {
-			return fmt.Errorf("spawnHashStateStage: %w", err)
-		}
-
-		if err := st.RunStage(stages.AccountHistoryIndex, db); err != nil {
-			return fmt.Errorf("spawnAccountHistoryIndex: %w", err)
-		}
-		if err := st.RunStage(stages.StorageHistoryIndex, db); err != nil {
-			return fmt.Errorf("spawnStorageHistoryIndex: %w", err)
-		}
-
-		if err := st.RunStage(stages.TxLookup, db); err != nil {
-			return fmt.Errorf("spawnTxLookup: %w", err)
+		if err := st.Run(db); err != nil {
+			return err
 		}
 
 		for blockN := range expectedAccountChanges {
@@ -163,28 +136,9 @@ func syncBySmallSteps(ctx context.Context, chaindata string) error {
 
 		execStage := progress(stages.Execution)
 		to := execStage.BlockNumber - unwind
-		if err := st.UnwindStage(&stagedsync.UnwindState{Stage: stages.TxLookup, UnwindPoint: to}, db); err != nil {
-			return fmt.Errorf("unwindTxLookup: %w", err)
-		}
 
-		if err := st.UnwindStage(&stagedsync.UnwindState{Stage: stages.StorageHistoryIndex, UnwindPoint: to}, db); err != nil {
-			return fmt.Errorf("unwindStorageHistoryIndex: %w", err)
-		}
-
-		if err := st.UnwindStage(&stagedsync.UnwindState{Stage: stages.AccountHistoryIndex, UnwindPoint: to}, db); err != nil {
-			return fmt.Errorf("unwindAccountHistoryIndex: %w", err)
-		}
-
-		if err := st.UnwindStage(&stagedsync.UnwindState{Stage: stages.HashState, UnwindPoint: to}, db); err != nil {
-			return fmt.Errorf("unwindHashStateStage: %w", err)
-		}
-
-		if err := st.UnwindStage(&stagedsync.UnwindState{Stage: stages.IntermediateHashes, UnwindPoint: to}, db); err != nil {
-			return fmt.Errorf("unwindIntermediateHashesStage: %w", err)
-		}
-
-		if err := st.UnwindStage(&stagedsync.UnwindState{Stage: stages.Execution, UnwindPoint: to}, db); err != nil {
-			return fmt.Errorf("unwindExecutionStage: %w", err)
+		if err := st.UnwindTo(to, db); err != nil {
+			return err
 		}
 	}
 

--- a/eth/downloader/downloader.go
+++ b/eth/downloader/downloader.go
@@ -570,6 +570,7 @@ func (d *Downloader) syncWithPeer(p *peerConnection, hash common.Hash, blockNumb
 			d,
 			d.chainConfig,
 			d.blockchain,
+			d.blockchain.GetVMConfig(),
 			d.stateDB,
 			p.id,
 			d.storageMode,

--- a/eth/stagedsync/stage.go
+++ b/eth/stagedsync/stage.go
@@ -41,10 +41,6 @@ func (s *StageState) ExecutionAt(db ethdb.Getter) (uint64, error) {
 	return execution, err
 }
 
-func (s *StageState) WasInterrupted() bool {
-	return len(s.StageData) > 0
-}
-
 func (s *StageState) DoneAndUpdate(db ethdb.Putter, newBlockNum uint64) error {
 	err := stages.SaveStageProgress(db, s.Stage, newBlockNum, nil)
 	s.state.NextStage()

--- a/eth/stagedsync/stage_hashstate.go
+++ b/eth/stagedsync/stage_hashstate.go
@@ -56,13 +56,13 @@ func unwindHashStateStageImpl(u *UnwindState, s *StageState, stateDB ethdb.Datab
 	// and recomputes the state root from scratch
 	prom := NewPromoter(stateDB, quit)
 	prom.TempDir = datadir
-	if err := prom.Unwind(s, u, false /* storage */, false /* codes */, 0x00); err != nil {
+	if err := prom.Unwind(s, u, false /* storage */, false /* codes */); err != nil {
 		return err
 	}
-	if err := prom.Unwind(s, u, false /* storage */, true /* codes */, 0x01); err != nil {
+	if err := prom.Unwind(s, u, false /* storage */, true /* codes */); err != nil {
 		return err
 	}
-	if err := prom.Unwind(s, u, true /* storage */, false /* codes */, 0x02); err != nil {
+	if err := prom.Unwind(s, u, true /* storage */, false /* codes */); err != nil {
 		return err
 	}
 	return nil
@@ -297,7 +297,7 @@ func getFromPlainCodesAndLoad(db ethdb.Getter, loadFunc etl.LoadFunc) etl.LoadFu
 	}
 }
 
-func (p *Promoter) Promote(s *StageState, from, to uint64, storage bool, codes bool, index byte) error {
+func (p *Promoter) Promote(s *StageState, from, to uint64, storage bool, codes bool) error {
 	var changeSetBucket []byte
 	if storage {
 		changeSetBucket = dbutils.PlainStorageChangeSetBucket
@@ -331,18 +331,12 @@ func (p *Promoter) Promote(s *StageState, from, to uint64, storage bool, codes b
 		etl.TransformArgs{
 			BufferType:      etl.SortableOldestAppearedBuffer,
 			ExtractStartKey: startkey,
-			OnLoadCommit: func(putter ethdb.Putter, key []byte, isDone bool) error {
-				if isDone {
-					return s.UpdateWithStageData(putter, from, []byte{index})
-				}
-				return s.UpdateWithStageData(putter, from, append([]byte{index}, key...))
-			},
 			Quit: p.quitCh,
 		},
 	)
 }
 
-func (p *Promoter) Unwind(s *StageState, u *UnwindState, storage bool, codes bool, index byte) error {
+func (p *Promoter) Unwind(s *StageState, u *UnwindState, storage bool, codes bool) error {
 	var changeSetBucket []byte
 	if storage {
 		changeSetBucket = dbutils.PlainStorageChangeSetBucket
@@ -379,12 +373,6 @@ func (p *Promoter) Unwind(s *StageState, u *UnwindState, storage bool, codes boo
 		etl.TransformArgs{
 			BufferType:      etl.SortableOldestAppearedBuffer,
 			ExtractStartKey: startkey,
-			OnLoadCommit: func(putter ethdb.Putter, key []byte, isDone bool) error {
-				if isDone {
-					return u.UpdateWithStageData(putter, []byte{index})
-				}
-				return u.UpdateWithStageData(putter, append([]byte{index}, key...))
-			},
 			Quit: p.quitCh,
 		},
 	)
@@ -393,13 +381,13 @@ func (p *Promoter) Unwind(s *StageState, u *UnwindState, storage bool, codes boo
 func promoteHashedStateIncrementally(s *StageState, from, to uint64, db ethdb.Database, datadir string, quit <-chan struct{}) error {
 	prom := NewPromoter(db, quit)
 	prom.TempDir = datadir
-	if err := prom.Promote(s, from, to, false /* storage */, false /* codes */, 0x00); err != nil {
+	if err := prom.Promote(s, from, to, false /* storage */, false /* codes */); err != nil {
 		return err
 	}
-	if err := prom.Promote(s, from, to, false /* storage */, true /* codes */, 0x01); err != nil {
+	if err := prom.Promote(s, from, to, false /* storage */, true /* codes */); err != nil {
 		return err
 	}
-	if err := prom.Promote(s, from, to, true /* storage */, false /* codes */, 0x02); err != nil {
+	if err := prom.Promote(s, from, to, true /* storage */, false /* codes */); err != nil {
 		return err
 	}
 	return nil

--- a/eth/stagedsync/stage_senders.go
+++ b/eth/stagedsync/stage_senders.go
@@ -80,7 +80,7 @@ func SpawnRecoverSendersStage(cfg Stage3Config, s *StageState, db ethdb.Database
 		}
 	}
 
-	canonical := make([]common.Hash, to-s.BlockNumber+1)
+	canonical := make([]common.Hash, to-s.BlockNumber)
 	currentHeaderIdx := uint64(0)
 
 	if err := db.Walk(dbutils.HeaderPrefix, dbutils.EncodeBlockNumber(s.BlockNumber+1), 0, func(k, v []byte) (bool, error) {
@@ -93,7 +93,7 @@ func SpawnRecoverSendersStage(cfg Stage3Config, s *StageState, db ethdb.Database
 			return true, nil
 		}
 
-		if currentHeaderIdx > to-s.BlockNumber { // if header stage is ehead of body stage
+		if currentHeaderIdx >= to-s.BlockNumber { // if header stage is ehead of body stage
 			return false, nil
 		}
 

--- a/eth/stagedsync/stage_txpool.go
+++ b/eth/stagedsync/stage_txpool.go
@@ -45,7 +45,7 @@ func incrementalTxPoolUpdate(from, to uint64, pool *core.TxPool, db *ethdb.Objec
 	headHash := rawdb.ReadCanonicalHash(db, to)
 	headHeader := rawdb.ReadHeader(db, headHash, to)
 	pool.ResetHead(headHeader.GasLimit, to)
-	canonical := make([]common.Hash, to-from+1)
+	canonical := make([]common.Hash, to-from)
 	currentHeaderIdx := uint64(0)
 
 	if err := db.Walk(dbutils.HeaderPrefix, dbutils.EncodeBlockNumber(from+1), 0, func(k, v []byte) (bool, error) {
@@ -58,7 +58,7 @@ func incrementalTxPoolUpdate(from, to uint64, pool *core.TxPool, db *ethdb.Objec
 			return true, nil
 		}
 
-		if currentHeaderIdx > to-from { // if header stage is ehead of body stage
+		if currentHeaderIdx >= to-from { // if header stage is ahead of body stage
 			return false, nil
 		}
 
@@ -120,7 +120,7 @@ func unwindTxPoolUpdate(from, to uint64, pool *core.TxPool, db *ethdb.ObjectData
 	headHash := rawdb.ReadCanonicalHash(db, from)
 	headHeader := rawdb.ReadHeader(db, headHash, from)
 	pool.ResetHead(headHeader.GasLimit, from)
-	canonical := make([]common.Hash, to-from+1)
+	canonical := make([]common.Hash, to-from)
 	currentHeaderIdx := uint64(0)
 
 	if err := db.Walk(dbutils.HeaderPrefix, dbutils.EncodeBlockNumber(from+1), 0, func(k, v []byte) (bool, error) {
@@ -133,7 +133,7 @@ func unwindTxPoolUpdate(from, to uint64, pool *core.TxPool, db *ethdb.ObjectData
 			return true, nil
 		}
 
-		if currentHeaderIdx > to-from { // if header stage is ehead of body stage
+		if currentHeaderIdx >= to-from { // if header stage is ahead of body stage
 			return false, nil
 		}
 

--- a/eth/stagedsync/stagedsync.go
+++ b/eth/stagedsync/stagedsync.go
@@ -17,7 +17,8 @@ const prof = false // whether to profile
 func PrepareStagedSync(
 	d DownloaderGlue,
 	chainConfig *params.ChainConfig,
-	blockchain BlockChain,
+	chainContext core.ChainContext,
+	vmConfig *vm.Config,
 	stateDB *ethdb.ObjectDatabase,
 	pid string,
 	storageMode ethdb.StorageMode,
@@ -80,7 +81,7 @@ func PrepareStagedSync(
 			ID:          stages.Execution,
 			Description: "Execute blocks w/o hash checks",
 			ExecFunc: func(s *StageState, u Unwinder) error {
-				return SpawnExecuteBlocksStage(s, stateDB, chainConfig, blockchain, 0 /* limit (meaning no limit) */, quitCh, dests, storageMode.Receipts, changeSetHook)
+				return SpawnExecuteBlocksStage(s, stateDB, chainConfig, chainContext, vmConfig, 0 /* limit (meaning no limit) */, quitCh, dests, storageMode.Receipts, changeSetHook)
 			},
 			UnwindFunc: func(u *UnwindState, s *StageState) error {
 				return UnwindExecutionStage(u, s, stateDB)

--- a/eth/stagedsync/stagedsync.go
+++ b/eth/stagedsync/stagedsync.go
@@ -34,7 +34,7 @@ func PrepareStagedSync(
 	stages := []*Stage{
 		{
 			ID:          stages.Headers,
-			Description: "Downloading headers",
+			Description: "Download headers",
 			ExecFunc: func(s *StageState, u Unwinder) error {
 				return SpawnHeaderDownloadStage(s, u, d, headersFetchers)
 			},
@@ -44,7 +44,7 @@ func PrepareStagedSync(
 		},
 		{
 			ID:          stages.Bodies,
-			Description: "Downloading block bodies",
+			Description: "Download block bodies",
 			ExecFunc: func(s *StageState, u Unwinder) error {
 				return spawnBodyDownloadStage(s, u, d, pid)
 			},
@@ -54,7 +54,7 @@ func PrepareStagedSync(
 		},
 		{
 			ID:          stages.Senders,
-			Description: "Recovering senders from tx signatures",
+			Description: "Recover senders from tx signatures",
 			ExecFunc: func(s *StageState, u Unwinder) error {
 				const batchSize = 10000
 				const blockSize = 4096
@@ -78,7 +78,7 @@ func PrepareStagedSync(
 		},
 		{
 			ID:          stages.Execution,
-			Description: "Executing blocks w/o hash checks",
+			Description: "Execute blocks w/o hash checks",
 			ExecFunc: func(s *StageState, u Unwinder) error {
 				return SpawnExecuteBlocksStage(s, stateDB, chainConfig, blockchain, 0 /* limit (meaning no limit) */, quitCh, dests, storageMode.Receipts, changeSetHook)
 			},
@@ -88,7 +88,7 @@ func PrepareStagedSync(
 		},
 		{
 			ID:          stages.IntermediateHashes,
-			Description: "Generating intermediate hashes and compiting state root",
+			Description: "Generate intermediate hashes and compiting state root",
 			ExecFunc: func(s *StageState, u Unwinder) error {
 				return SpawnIntermediateHashesStage(s, stateDB, datadir, quitCh)
 			},
@@ -98,7 +98,7 @@ func PrepareStagedSync(
 		},
 		{
 			ID:          stages.HashState,
-			Description: "Hashing the key in the state",
+			Description: "Hash the key in the state",
 			ExecFunc: func(s *StageState, u Unwinder) error {
 				return SpawnHashStateStage(s, stateDB, datadir, quitCh)
 			},
@@ -108,7 +108,7 @@ func PrepareStagedSync(
 		},
 		{
 			ID:                  stages.AccountHistoryIndex,
-			Description:         "Generating account history index",
+			Description:         "Generate account history index",
 			Disabled:            !storageMode.History,
 			DisabledDescription: "Enable by adding `h` to --storage-mode",
 			ExecFunc: func(s *StageState, u Unwinder) error {
@@ -120,7 +120,7 @@ func PrepareStagedSync(
 		},
 		{
 			ID:                  stages.StorageHistoryIndex,
-			Description:         "Generating storage history index",
+			Description:         "Generate storage history index",
 			Disabled:            !storageMode.History,
 			DisabledDescription: "Enable by adding `h` to --storage-mode",
 			ExecFunc: func(s *StageState, u Unwinder) error {
@@ -132,7 +132,7 @@ func PrepareStagedSync(
 		},
 		{
 			ID:                  stages.TxLookup,
-			Description:         "Generating tx lookup index",
+			Description:         "Generate tx lookup index",
 			Disabled:            !storageMode.TxIndex,
 			DisabledDescription: "Enable by adding `t` to --storage-mode",
 			ExecFunc: func(s *StageState, u Unwinder) error {
@@ -144,7 +144,7 @@ func PrepareStagedSync(
 		},
 		{
 			ID:          stages.TxPool,
-			Description: "Starts the transaction pool",
+			Description: "Update transaction pool",
 			ExecFunc: func(s *StageState, _ Unwinder) error {
 				return spawnTxPool(s, stateDB, txPool, poolStart, quitCh)
 			},

--- a/eth/stagedsync/state.go
+++ b/eth/stagedsync/state.go
@@ -97,8 +97,7 @@ func (s *State) StageState(stage stages.SyncStage, db ethdb.Getter) (*StageState
 }
 
 func (s *State) Run(db ethdb.GetterPutter) error {
-	for !s.
-		IsDone() {
+	for !s.IsDone() {
 		if !s.unwindStack.Empty() {
 			for unwind := s.unwindStack.Pop(); unwind != nil; unwind = s.unwindStack.Pop() {
 				if err := s.UnwindStage(unwind, db); err != nil {

--- a/eth/stagedsync/state.go
+++ b/eth/stagedsync/state.go
@@ -34,6 +34,9 @@ func (s *State) GetLocalHeight(db ethdb.Getter) (uint64, error) {
 func (s *State) UnwindTo(blockNumber uint64, db ethdb.Database) error {
 	log.Info("UnwindTo", "block", blockNumber)
 	for _, stage := range s.unwindOrder {
+		if stage.Disabled {
+			continue
+		}
 		if err := s.unwindStack.Add(UnwindState{stage.ID, blockNumber, nil}, db); err != nil {
 			return err
 		}
@@ -93,73 +96,9 @@ func (s *State) StageState(stage stages.SyncStage, db ethdb.Getter) (*StageState
 	return &StageState{s, stage, blockNum, stageData}, nil
 }
 
-func (s *State) findInterruptedStage(db ethdb.Getter) (*Stage, error) {
-	for _, stage := range s.stages {
-		_, stageData, err := stages.GetStageProgress(db, stage.ID)
-		if err != nil {
-			return nil, err
-		}
-		if len(stageData) > 0 {
-			return stage, nil
-		}
-	}
-	return nil, nil
-}
-
-func (s *State) findInterruptedUnwindStage(db ethdb.Getter) (*Stage, error) {
-	for _, stage := range s.stages {
-		_, stageData, err := stages.GetStageUnwind(db, stage.ID)
-		if err != nil {
-			return nil, err
-		}
-		if len(stageData) > 0 {
-			return stage, nil
-		}
-	}
-	return nil, nil
-}
-
-func (s *State) RunInterruptedStage(db ethdb.GetterPutter) error {
-	if interruptedStage, err := s.findInterruptedStage(db); err != nil {
-		return err
-	} else if interruptedStage != nil {
-		log.Info("Run interrupted stage")
-		if err := s.runStage(interruptedStage, db); err != nil {
-			return err
-		}
-		if err := s.SetCurrentStage(interruptedStage.ID); err != nil {
-			return err
-		}
-		s.NextStage()
-		return nil
-	}
-
-	if interruptedStage, err := s.findInterruptedUnwindStage(db); err != nil {
-		return err
-	} else if interruptedStage != nil {
-		u, err := s.unwindStack.LoadFromDB(db, interruptedStage.ID)
-		if err != nil {
-			return err
-		}
-		if u == nil {
-			return nil
-		}
-		log.Info("Unwind interrupted stage")
-		if err := s.UnwindStage(u, db); err != nil {
-			return err
-		}
-		if err := s.SetCurrentStage(interruptedStage.ID); err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
 func (s *State) Run(db ethdb.GetterPutter) error {
-	if err := s.RunInterruptedStage(db); err != nil {
-		return err
-	}
-	for !s.IsDone() {
+	for !s.
+		IsDone() {
 		if !s.unwindStack.Empty() {
 			for unwind := s.unwindStack.Pop(); unwind != nil; unwind = s.unwindStack.Pop() {
 				if err := s.UnwindStage(unwind, db); err != nil {
@@ -250,4 +189,23 @@ func (s *State) UnwindStage(unwind *UnwindState, db ethdb.GetterPutter) error {
 	}
 	log.Info("Unwinding... DONE!")
 	return nil
+}
+
+func (s *State) DisableStages(ids ...stages.SyncStage) {
+	for i := range s.stages {
+		for _, id := range ids {
+			if s.stages[i].ID != id {
+				continue
+			}
+			s.stages[i].Disabled = true
+		}
+	}
+}
+
+func (s *State) MockExecFunc(id stages.SyncStage, f ExecFunc) {
+	for i := range s.stages {
+		if s.stages[i].ID == id {
+			s.stages[i].ExecFunc = f
+		}
+	}
 }

--- a/eth/stagedsync/state.go
+++ b/eth/stagedsync/state.go
@@ -127,7 +127,9 @@ func (s *State) RunInterruptedStage(db ethdb.GetterPutter) error {
 		if err := s.runStage(interruptedStage, db); err != nil {
 			return err
 		}
-		s.SetCurrentStage(interruptedStage.ID)
+		if err := s.SetCurrentStage(interruptedStage.ID); err != nil {
+			return err
+		}
 		s.NextStage()
 		return nil
 	}
@@ -146,7 +148,9 @@ func (s *State) RunInterruptedStage(db ethdb.GetterPutter) error {
 		if err := s.UnwindStage(u, db); err != nil {
 			return err
 		}
-		s.SetCurrentStage(interruptedStage.ID)
+		if err := s.SetCurrentStage(interruptedStage.ID); err != nil {
+			return err
+		}
 	}
 	return nil
 }
@@ -241,7 +245,9 @@ func (s *State) UnwindStage(unwind *UnwindState, db ethdb.GetterPutter) error {
 		return err
 	}
 
-	s.SetCurrentStage(stage.ID)
+	if err := s.SetCurrentStage(stage.ID); err != nil {
+		return err
+	}
 	log.Info("Unwinding... DONE!")
 	return nil
 }

--- a/eth/stagedsync/state_test.go
+++ b/eth/stagedsync/state_test.go
@@ -721,8 +721,8 @@ func TestStateSyncInterruptLongStage(t *testing.T) {
 
 	expectedFlow := []stages.SyncStage{
 		stages.Headers, stages.Bodies,
-		stages.Bodies, // finish the interrupted state, then restart from 0
-		stages.Headers, stages.Bodies, stages.Senders,
+		stages.Bodies, // finish the interrupted state, then continue to the next  stage
+		stages.Senders,
 	}
 	assert.Equal(t, expectedFlow, flow)
 }

--- a/eth/stagedsync/state_test.go
+++ b/eth/stagedsync/state_test.go
@@ -176,6 +176,7 @@ func TestStateErroredStage(t *testing.T) {
 		},
 	}
 	state := NewState(s)
+	state.unwindOrder = []*Stage{s[0], s[1], s[2]}
 	db := ethdb.NewMemDatabase()
 	defer db.Close()
 	err := state.Run(db)
@@ -188,7 +189,6 @@ func TestStateErroredStage(t *testing.T) {
 }
 
 func TestStateUnwindSomeStagesBehindUnwindPoint(t *testing.T) {
-	t.Skip("Disabled for unwind fixes")
 	db := ethdb.NewMemDatabase()
 	defer db.Close()
 	flow := make([]stages.SyncStage, 0)
@@ -248,8 +248,25 @@ func TestStateUnwindSomeStagesBehindUnwindPoint(t *testing.T) {
 				return u.Done(db)
 			},
 		},
+		{
+			ID:       stages.IntermediateHashes,
+			Disabled: true,
+			ExecFunc: func(s *StageState, u Unwinder) error {
+				flow = append(flow, stages.IntermediateHashes)
+				if s.BlockNumber == 0 {
+					return s.DoneAndUpdate(db, 2000)
+				}
+				s.Done()
+				return nil
+			},
+			UnwindFunc: func(u *UnwindState, s *StageState) error {
+				flow = append(flow, unwindOf(stages.IntermediateHashes))
+				return u.Done(db)
+			},
+		},
 	}
 	state := NewState(s)
+	state.unwindOrder = []*Stage{s[0], s[1], s[2], s[3]}
 	err := state.Run(db)
 	assert.NoError(t, err)
 
@@ -351,7 +368,7 @@ func TestStateUnwind(t *testing.T) {
 		},
 	}
 	state := NewState(s)
-	state.unwindOrder = []*Stage{s[0], s[1], s[2]}
+	state.unwindOrder = []*Stage{s[0], s[1], s[2], s[3]}
 	err := state.Run(db)
 	assert.NoError(t, err)
 
@@ -378,7 +395,6 @@ func TestStateUnwind(t *testing.T) {
 }
 
 func TestStateUnwindEmptyUnwinder(t *testing.T) {
-	t.Skip("Disabled for unwind fixes")
 	db := ethdb.NewMemDatabase()
 	defer db.Close()
 	flow := make([]stages.SyncStage, 0)
@@ -435,6 +451,7 @@ func TestStateUnwindEmptyUnwinder(t *testing.T) {
 		},
 	}
 	state := NewState(s)
+	state.unwindOrder = []*Stage{s[0], s[1], s[2]}
 	err := state.Run(db)
 	assert.NoError(t, err)
 
@@ -570,7 +587,6 @@ func TestStateSyncInterruptRestart(t *testing.T) {
 }
 
 func TestStateSyncInterruptLongUnwind(t *testing.T) {
-	t.Skip("Disabled for unwind fixes")
 	// interrupt a stage that is too big to fit in one batch,
 	// so the db is in inconsitent state, so we have to restart with that
 	db := ethdb.NewMemDatabase()
@@ -646,6 +662,7 @@ func TestStateSyncInterruptLongUnwind(t *testing.T) {
 		},
 	}
 	state := NewState(s)
+	state.unwindOrder = []*Stage{s[0], s[1], s[2]}
 	err := state.Run(db)
 	assert.Error(t, errInterrupted, err)
 
@@ -728,17 +745,19 @@ func TestStateSyncInterruptLongStage(t *testing.T) {
 	}
 
 	state := NewState(s)
+	state.unwindOrder = []*Stage{s[0], s[1], s[2]}
 	err := state.Run(db)
 	assert.Equal(t, errInterrupted, err)
 
 	state = NewState(s)
+	state.unwindOrder = []*Stage{s[0], s[1], s[2]}
 	err = state.Run(db)
 	assert.NoError(t, err)
 
 	expectedFlow := []stages.SyncStage{
 		stages.Headers, stages.Bodies,
-		stages.Bodies, // finish the interrupted state, then continue to the next  stage
-		stages.Senders,
+		// after restart - start from 0
+		stages.Headers, stages.Bodies, stages.Senders,
 	}
 	assert.Equal(t, expectedFlow, flow)
 }

--- a/eth/stagedsync/types.go
+++ b/eth/stagedsync/types.go
@@ -1,17 +1,5 @@
 package stagedsync
 
-import (
-	"github.com/ledgerwatch/turbo-geth/core"
-	"github.com/ledgerwatch/turbo-geth/core/types"
-	"github.com/ledgerwatch/turbo-geth/core/vm"
-)
-
-type BlockChain interface {
-	core.ChainContext
-	GetVMConfig() *vm.Config
-	GetBlockByNumber(uint64) *types.Block
-}
-
 type DownloaderGlue interface {
 	SpawnHeaderDownloadStage([]func() error, *StageState, Unwinder) error
 	SpawnBodyDownloadStage(string, *StageState, Unwinder) (bool, error)

--- a/eth/stagedsync/unwind.go
+++ b/eth/stagedsync/unwind.go
@@ -31,10 +31,6 @@ func (u *UnwindState) Skip(db ethdb.Putter) error {
 	return stages.SaveStageUnwind(db, u.Stage, 0, nil)
 }
 
-func (u *UnwindState) WasInterrupted() bool {
-	return len(u.StageData) > 0
-}
-
 type PersistentUnwindStack struct {
 	unwindStack []UnwindState
 }


### PR DESCRIPTION
### Problem:
- after "runInterruptedStage" we set state.CurrentStage to 0. It runs exec, then stage5 (but now it expecting that stage6 was run on previous iteration. 

### Solution:
Remove concepts 'interrupted stage' and 'partially executed stage' - persistent unwind stack must be enough