### PR TITLE
Disable ipc RPC

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Usage:
 See more detailed [overview of functionality and current limitations](https://ledgerwatch.github.io/turbo_geth_release.html).
 It is being updated on recurring basis.
 
-#### 1. More Efficient State Storage
+#### More Efficient State Storage
 
 **Flat KV storage.** Turbo-Geth uses a key-value database and storing accounts and storage in
 a simple way. **See our detailed DB walkthrough [here](./docs/programmers_guide/db_walkthrough.MD).**
@@ -42,7 +42,7 @@ DB inserts sometimes are orders of magnitude quicker.
 accounts and the storage.
 
 
-#### 2. Faster Initial Sync
+#### Faster Initial Sync
 
 Turbo-Geth uses a rearchitected full sync algorithm from
 [Go-Ethereum](https://github.com/ethereum/go-ethereum) that is split into
@@ -68,7 +68,7 @@ Examples of stages are:
 
 * And more...
 
-#### 3. JSON-RPC daemon
+#### JSON-RPC daemon
 
 In turbo-geth RPC calls are extracted out of the main binary into a separate daemon.
 This daemon can use both local or remote DBs. That means, that this RPC daemon
@@ -113,7 +113,7 @@ debug_getModifiedAccountsByNumber
 debug_getModifiedAccountsByHash
 ```
 
-#### 4. REST API Daemon
+#### REST API Daemon
 
 Apart from JSON-RPC daemon, Turbo-Geth also contains REST API daemon. It uses
 turbo-geth remote DB functionality. [Docs](./cmd/rpcdaemon/Readme.md)
@@ -137,7 +137,7 @@ GET /api/v1/accounts/<accountAddress>
 GET /api/v1/storage/?prefix=PREFIX
 ```
 
-#### 5. Run all components by docker-compose
+#### Or run all components by docker-compose
 
 Next command starts: turbo-geth on port 30303, rpcdaemon 8545, restapi 8080, debug-web-ui 3001, prometheus 9090, grafana 3000
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
   turbo-geth:
     image: turbo-geth:latest
     build: .
-    command: tg --nousb --metrics --pprof.addr="0.0.0.0" --pprof.port="6060" --private.api.addr="0.0.0.0:9090"
+    command: tg --nousb --metrics --pprof.addr="0.0.0.0" --pprof.port="6060" --private.api.addr="0.0.0.0:9090" --ipcdisable
     volumes:
       - ${XDG_DATA_HOME:-~}/turbogeth:/root/.turbogeth/
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ services:
     build: .
     command: tg --nousb --metrics --pprof.addr="0.0.0.0" --pprof.port="6060" --private.api.addr="0.0.0.0:9090" --ipcdisable
     volumes:
-      - ${XDG_DATA_HOME:-~}/turbogeth:/root/.turbogeth/
+      - ${XDG_DATA_HOME:-~/.local/share}/turbogeth:/root/.turbogeth/
     ports:
       - 30303:30303
 
@@ -18,7 +18,7 @@ services:
       - 9090:9090
     volumes:
       - ./cmd/prometheus/prometheus.yml:/etc/prometheus/prometheus.yml
-      - ${XDG_DATA_HOME:-./cmd/prometheus}/tg-prometheus:/prometheus
+      - ${XDG_DATA_HOME:-~/.local/share}/tg-prometheus:/prometheus
 
   grafana:
     image: grafana/grafana:7.1.1
@@ -28,7 +28,7 @@ services:
       - ./cmd/prometheus/grafana.ini:/etc/grafana/grafana.ini
       - ./cmd/prometheus/datasources:/etc/grafana/provisioning/datasources
       - ./cmd/prometheus/dashboards:/etc/grafana/provisioning/dashboards
-      - ${XDG_DATA_HOME:-./cmd/prometheus}/tg-grafana:/var/lib/grafana
+      - ${XDG_DATA_HOME:-~/.local/share}/tg-grafana:/var/lib/grafana
 
   restapi:
     image: turbo-geth:latest


### PR DESCRIPTION
As of feedback gotten here: https://github.com/ledgerwatch/turbo-geth/issues/832#issuecomment-667532694
- Disable ipc RPC
- Make Readme less confusing - people thought points are depend on each-other (for example need to build restapi before build docker).