### PR TITLE
Use datadir for temp files when generating indexes

### DIFF
--- a/cmd/state/generate/regenerate_index.go
+++ b/cmd/state/generate/regenerate_index.go
@@ -2,10 +2,11 @@ package generate
 
 import (
 	"errors"
-	"github.com/ledgerwatch/turbo-geth/common/changeset"
 	"os"
 	"os/signal"
 	"time"
+
+	"github.com/ledgerwatch/turbo-geth/common/changeset"
 
 	"github.com/ledgerwatch/turbo-geth/core"
 	"github.com/ledgerwatch/turbo-geth/eth/stagedsync/stages"
@@ -41,7 +42,7 @@ func RegenerateIndex(chaindata string, csBucket []byte) error {
 	}
 	startTime := time.Now()
 	log.Info("Index generation started", "start time", startTime)
-	err = ig.GenerateIndex(0, lastExecutedBlock, csBucket)
+	err = ig.GenerateIndex(0, lastExecutedBlock, csBucket, os.TempDir())
 	if err != nil {
 		return err
 	}

--- a/core/generate_index.go
+++ b/core/generate_index.go
@@ -32,7 +32,7 @@ type IndexGenerator struct {
 	quitCh           <-chan struct{}
 }
 
-func (ig *IndexGenerator) GenerateIndex(startBlock, endBlock uint64, changeSetBucket []byte) error {
+func (ig *IndexGenerator) GenerateIndex(startBlock, endBlock uint64, changeSetBucket []byte, datadir string) error {
 	v, ok := changeset.Mapper[string(changeSetBucket)]
 	if !ok {
 		return errors.New("unknown bucket type")
@@ -44,7 +44,7 @@ func (ig *IndexGenerator) GenerateIndex(startBlock, endBlock uint64, changeSetBu
 	t := time.Now()
 	err := etl.Transform(ig.db, changeSetBucket,
 		v.IndexBucket,
-		os.TempDir(),
+		datadir,
 		getExtractFunc(v.WalkerAdapter),
 		loadFunc,
 		etl.TransformArgs{

--- a/core/generate_index_test.go
+++ b/core/generate_index_test.go
@@ -4,12 +4,13 @@ import (
 	"bytes"
 	"encoding/binary"
 	"fmt"
-	"github.com/ledgerwatch/turbo-geth/common/changeset"
 	"os"
 	"reflect"
 	"sort"
 	"strconv"
 	"testing"
+
+	"github.com/ledgerwatch/turbo-geth/common/changeset"
 
 	"github.com/ledgerwatch/turbo-geth/common"
 	"github.com/ledgerwatch/turbo-geth/common/dbutils"
@@ -33,7 +34,7 @@ func TestIndexGenerator_GenerateIndex_SimpleCase(t *testing.T) {
 			addrs, expecedIndexes := generateTestData(t, db, csBucket, blocksNum)
 
 			ig.ChangeSetBufSize = 16 * 1024
-			err := ig.GenerateIndex(0, uint64(blocksNum), csBucket)
+			err := ig.GenerateIndex(0, uint64(blocksNum), csBucket, "")
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -69,7 +70,7 @@ func TestIndexGenerator_Truncate(t *testing.T) {
 		mp := changeset.Mapper[string(csbucket)]
 		indexBucket := mp.IndexBucket
 		ig := NewIndexGenerator(db, make(chan struct{}))
-		err := ig.GenerateIndex(0, uint64(2100), csbucket)
+		err := ig.GenerateIndex(0, uint64(2100), csbucket, "")
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/eth/stagedsync/stage_indexes.go
+++ b/eth/stagedsync/stage_indexes.go
@@ -26,7 +26,7 @@ func SpawnAccountHistoryIndex(s *StageState, db ethdb.Database, datadir string, 
 	ig := core.NewIndexGenerator(db, quitCh)
 	ig.TempDir = datadir
 
-	if err := ig.GenerateIndex(blockNum, endBlock, dbutils.PlainAccountChangeSetBucket); err != nil {
+	if err := ig.GenerateIndex(blockNum, endBlock, dbutils.PlainAccountChangeSetBucket, datadir); err != nil {
 		return fmt.Errorf("account history index: fail to generate index: %w", err)
 	}
 
@@ -49,7 +49,7 @@ func SpawnStorageHistoryIndex(s *StageState, db ethdb.Database, datadir string, 
 	}
 	ig := core.NewIndexGenerator(db, quitCh)
 	ig.TempDir = datadir
-	if err := ig.GenerateIndex(blockNum, endBlock, dbutils.PlainStorageChangeSetBucket); err != nil {
+	if err := ig.GenerateIndex(blockNum, endBlock, dbutils.PlainStorageChangeSetBucket, datadir); err != nil {
 		return fmt.Errorf("storage history index: fail to generate index: %w", err)
 	}
 


### PR DESCRIPTION
All temp files for all stages are supposed to be in the datadir. Indexes generation had a bug where it used the actual temp dir and that could unexpectedly fill the whole partition, especially if someone syncs on the external drives.