### PR TITLE
Update stagedsync.go

### DIFF
--- a/eth/stagedsync/stagedsync.go
+++ b/eth/stagedsync/stagedsync.go
@@ -88,7 +88,7 @@ func PrepareStagedSync(
 		},
 		{
 			ID:          stages.IntermediateHashes,
-			Description: "Generate intermediate hashes and compiting state root",
+			Description: "Generate intermediate hashes and computing state root",
 			ExecFunc: func(s *StageState, u Unwinder) error {
 				return SpawnIntermediateHashesStage(s, stateDB, datadir, quitCh)
 			},


### PR DESCRIPTION
fixed a typo from `compiting` to `computing `