### PR TITLE
DupSort of hash state

### DIFF
--- a/cmd/hack/hack.go
+++ b/cmd/hack/hack.go
@@ -1594,17 +1594,7 @@ You can think about it as Sub-Database which doesn't store any values.
 [acc2_hash]             | [acc2_value]
                         ...
 
-
 On 5M block CurrentState bucket using 5.9Gb. This layout using 2.3Gb. See dupSortState()
-
-Another feature of this layout is:
-- DupSort stores values in B+ tree
-- To delete key with multiple values - LMDB does add pages (of sub-tree) to the free list
-- Same logic used when `drop bucket`
-- LMDB doesn't deletes much. Deletion of 17GB (1 key with 1 billions values 8 bytes each) took 2sec on SSD. See deleteLargeDupSortKey()
-- It means performance of deletion contracts with huge storage is predictable
-- Means we can drop incarnations concept
-
 
 As further evolution of this idea:
 - Can add CodeHash as 2-nd value of [acc_hash] key (just use 1st byte to store type of value)

--- a/cmd/state/py/dbutils.py
+++ b/cmd/state/py/dbutils.py
@@ -5,7 +5,7 @@ PlainStateBucket = "PLAIN-CST".encode()
 PlainContractCodeBucket = "PLAIN-contractCode".encode()
 PlainAccountChangeSetBucket = "PLAIN-ACS".encode()
 PlainStorageChangeSetBucket = "PLAIN-SCS".encode()
-CurrentStateBucket = "CST".encode()
+CurrentStateBucket = "CST2".encode()
 AccountsHistoryBucket = "hAT".encode()
 StorageHistoryBucket = "hST".encode()
 CodeBucket = "CODE".encode()
@@ -45,7 +45,7 @@ CliqueBucket = "clique-".encode()
 Senders = "txSenders".encode()
 
 # cat common/dbutils/bucket.go| grep '=' | grep byte | sed 's/\[\]byte(//' | sed 's/)//' | awk '{print $3}' | grep -v '//' | grep -v '='  | tr '\n' ','
-buckets = ["PLAIN-CST", "PLAIN-contractCode", "PLAIN-ACS", "PLAIN-SCS", "CST", "hAT", "hST", "CODE", "contractCode",
+buckets = ["PLAIN-CST", "PLAIN-contractCode", "PLAIN-ACS", "PLAIN-SCS", "CST2", "hAT", "hST", "CODE", "contractCode",
            "incarnationMap", "ACS", "SCS", "iTh", "DBINFO", "DatabaseVersion", "LastHeader", "LastBlock",
            "LastFast", "TrieSync", "h", "t", "n", "H", "b", "r", "l", "B", "secure-key-", "ethereum-config-", "iB",
            "iBshead", "LastPrunedBlock", "lastAppliedMigration", "smHistory",

--- a/cmd/state/py/main.py
+++ b/cmd/state/py/main.py
@@ -24,6 +24,7 @@ env.reader_check()  # clear stale reads
 if cmd == "stats":
     data = {"name": [], "size": []}
     for bucket in dbutils.buckets:
+        print(bucket)
         b = env.open_db(bucket.encode(), create=False)
         with env.begin(write=False) as txn:
             stat = txn.stat(b)

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -1728,12 +1728,14 @@ func setDNSDiscoveryDefaults(cfg *eth.Config, genesis common.Hash) {
 // RegisterEthService adds an Ethereum client to the stack.
 func RegisterEthService(stack *node.Node, cfg *eth.Config) *eth.Ethereum {
 	fullNode := new(eth.Ethereum)
-	err := stack.Register(func(ctx *node.ServiceContext) (node.Service, error) {
+	if err := stack.Register(func(ctx *node.ServiceContext) (node.Service, error) {
 		fullNodeInst, err := eth.New(ctx, cfg)
+		if err != nil {
+			return nil, err
+		}
 		*fullNode = *fullNodeInst //nolint:govet
 		return fullNode, err
-	})
-	if err != nil {
+	}); err != nil {
 		Fatalf("Failed to register the Ethereum service: %v", err)
 	}
 	return fullNode
@@ -1745,7 +1747,9 @@ func RegisterEthStatsService(stack *node.Node, url string) {
 	if err := stack.Register(func(ctx *node.ServiceContext) (node.Service, error) {
 		// Retrieve both eth and les services
 		var ethServ *eth.Ethereum
-		ctx.Service(&ethServ)
+		if err := ctx.Service(&ethServ); err != nil {
+			return nil, err
+		}
 
 		return ethstats.New(url, ethServ)
 	}); err != nil {

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -1730,9 +1730,6 @@ func RegisterEthService(stack *node.Node, cfg *eth.Config) *eth.Ethereum {
 	fullNode := new(eth.Ethereum)
 	if err := stack.Register(func(ctx *node.ServiceContext) (node.Service, error) {
 		fullNodeInst, err := eth.New(ctx, cfg)
-		if err != nil {
-			return nil, err
-		}
 		*fullNode = *fullNodeInst //nolint:govet
 		return fullNode, err
 	}); err != nil {

--- a/common/dbutils/bucket.go
+++ b/common/dbutils/bucket.go
@@ -244,11 +244,11 @@ func init() {
 	})
 
 	for i := range Buckets {
-		BucketsCfg[string(Buckets[i])] = createBucketConfig(i, Buckets[i])
+		BucketsCfg[Buckets[i]] = createBucketConfig(i, Buckets[i])
 	}
 
 	for i := range DeprecatedBuckets {
-		BucketsCfg[string(DeprecatedBuckets[i])] = createBucketConfig(len(Buckets)+i, DeprecatedBuckets[i])
+		BucketsCfg[DeprecatedBuckets[i]] = createBucketConfig(len(Buckets)+i, DeprecatedBuckets[i])
 	}
 }
 

--- a/common/dbutils/bucket.go
+++ b/common/dbutils/bucket.go
@@ -41,7 +41,8 @@ var (
 	// Contains Storage:
 	//key - address hash + incarnation + storage key hash
 	//value - storage value(common.hash)
-	CurrentStateBucket = "CST"
+	CurrentStateBucket     = "CST2"
+	CurrentStateBucketOld1 = "CST"
 
 	//current
 	//key - key + encoded timestamp(block number)
@@ -202,6 +203,7 @@ var Buckets = []string{
 var DeprecatedBuckets = []string{
 	SyncStageProgressOld1,
 	SyncStageUnwindOld1,
+	CurrentStateBucketOld1,
 }
 
 var BucketsCfg = map[string]*BucketConfigItem{}
@@ -226,11 +228,11 @@ var dupSortConfig = []dupSortConfigEntry{
 		ToLen:   40,
 		FromLen: 72,
 	},
-	{
-		Bucket:  PlainStateBucket,
-		ToLen:   28,
-		FromLen: 60,
-	},
+	//{
+	//	Bucket:  PlainStateBucket,
+	//	ToLen:   28,
+	//	FromLen: 60,
+	//},
 }
 
 func init() {

--- a/common/dbutils/bucket.go
+++ b/common/dbutils/bucket.go
@@ -216,23 +216,26 @@ type BucketConfigItem struct {
 }
 
 type dupSortConfigEntry struct {
-	Bucket  string
-	ID      int
-	FromLen int
-	ToLen   int
+	Bucket    string
+	IsDupSort bool
+	ID        int
+	FromLen   int
+	ToLen     int
 }
 
 var dupSortConfig = []dupSortConfigEntry{
 	{
-		Bucket:  CurrentStateBucket,
-		ToLen:   40,
-		FromLen: 72,
+		Bucket:    CurrentStateBucket,
+		IsDupSort: true,
+		ToLen:     40,
+		FromLen:   72,
 	},
-	//{
-	//	Bucket:  PlainStateBucket,
-	//	ToLen:   28,
-	//	FromLen: 60,
-	//},
+	{
+		Bucket:    PlainStateBucket,
+		IsDupSort: debug.IsPlainStateDupsortEnabled(),
+		ToLen:     28,
+		FromLen:   60,
+	},
 }
 
 func init() {
@@ -259,13 +262,7 @@ func createBucketConfig(id int, name string) *BucketConfigItem {
 
 		cfg.DupFromLen = dupCfg.FromLen
 		cfg.DupToLen = dupCfg.ToLen
-
-		if dupCfg.Bucket == CurrentStateBucket {
-			cfg.IsDupsort = debug.IsHashedStateDupsortEnabled()
-		}
-		if dupCfg.Bucket == PlainStateBucket {
-			cfg.IsDupsort = debug.IsPlainStateDupsortEnabled()
-		}
+		cfg.IsDupsort = dupCfg.IsDupSort
 	}
 
 	return cfg

--- a/common/debug/experiments.go
+++ b/common/debug/experiments.go
@@ -80,15 +80,3 @@ func IsPlainStateDupsortEnabled() bool {
 	})
 	return dupsortPlain
 }
-
-var (
-	dupsortHashed    bool
-	getDupsortHashed sync.Once
-)
-
-func IsHashedStateDupsortEnabled() bool {
-	getDupsortHashed.Do(func() {
-		_, dupsortHashed = os.LookupEnv("DUPSORT_HASHED")
-	})
-	return dupsortHashed
-}

--- a/ethdb/kv_lmdb.go
+++ b/ethdb/kv_lmdb.go
@@ -262,6 +262,14 @@ type LmdbCursor struct {
 	cursor *lmdb.Cursor
 }
 
+func (db *LmdbKV) Env() *lmdb.Env {
+	return db.env
+}
+
+func (db *LmdbKV) AllDBI() map[string]lmdb.DBI {
+	return db.buckets
+}
+
 func (db *LmdbKV) View(ctx context.Context, f func(tx Tx) error) (err error) {
 	if db.env == nil {
 		return fmt.Errorf("db closed")

--- a/migrations/dupsort_hash_state.go
+++ b/migrations/dupsort_hash_state.go
@@ -12,7 +12,7 @@ var dupsortHashState = Migration{
 		if exists, err := db.(ethdb.NonTransactional).BucketExists(dbutils.CurrentStateBucketOld1); err != nil {
 			return err
 		} else if !exists {
-			return nil
+			return OnLoadCommit(db, nil, true)
 		}
 
 		if err := db.(ethdb.NonTransactional).ClearBuckets(dbutils.CurrentStateBucket); err != nil {

--- a/migrations/dupsort_hash_state.go
+++ b/migrations/dupsort_hash_state.go
@@ -1,7 +1,6 @@
 package migrations
 
 import (
-	"fmt"
 	"github.com/ledgerwatch/turbo-geth/common/dbutils"
 	"github.com/ledgerwatch/turbo-geth/common/etl"
 	"github.com/ledgerwatch/turbo-geth/ethdb"
@@ -19,12 +18,10 @@ var dupsortHashState = Migration{
 		if err := db.(ethdb.NonTransactional).ClearBuckets(dbutils.CurrentStateBucket); err != nil {
 			return err
 		}
-
 		extractFunc := func(k []byte, v []byte, next etl.ExtractNextFunc) error {
-			fmt.Printf("2 %x\n", k)
 			return next(k, k, v)
 		}
-		fmt.Printf("1\n")
+
 		if err := etl.Transform(
 			db,
 			dbutils.CurrentStateBucketOld1,

--- a/migrations/dupsort_hash_state.go
+++ b/migrations/dupsort_hash_state.go
@@ -1,0 +1,45 @@
+package migrations
+
+import (
+	"fmt"
+	"github.com/ledgerwatch/turbo-geth/common/dbutils"
+	"github.com/ledgerwatch/turbo-geth/common/etl"
+	"github.com/ledgerwatch/turbo-geth/ethdb"
+)
+
+var dupsortHashState = Migration{
+	Name: "dupsort_hash_state",
+	Up: func(db ethdb.Database, datadir string, OnLoadCommit etl.LoadCommitHandler) error {
+		if exists, err := db.(ethdb.NonTransactional).BucketExists(dbutils.CurrentStateBucketOld1); err != nil {
+			return err
+		} else if !exists {
+			return nil
+		}
+
+		if err := db.(ethdb.NonTransactional).ClearBuckets(dbutils.CurrentStateBucket); err != nil {
+			return err
+		}
+
+		extractFunc := func(k []byte, v []byte, next etl.ExtractNextFunc) error {
+			fmt.Printf("2 %x\n", k)
+			return next(k, k, v)
+		}
+		fmt.Printf("1\n")
+		if err := etl.Transform(
+			db,
+			dbutils.CurrentStateBucketOld1,
+			dbutils.CurrentStateBucket,
+			datadir,
+			extractFunc,
+			etl.IdentityLoadFunc,
+			etl.TransformArgs{OnLoadCommit: OnLoadCommit},
+		); err != nil {
+			return err
+		}
+
+		if err := db.(ethdb.NonTransactional).DropBuckets(dbutils.CurrentStateBucketOld1); err != nil {
+			return err
+		}
+		return nil
+	},
+}

--- a/migrations/dupsort_hash_state_test.go
+++ b/migrations/dupsort_hash_state_test.go
@@ -1,0 +1,55 @@
+package migrations
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/ledgerwatch/turbo-geth/common"
+	"github.com/ledgerwatch/turbo-geth/common/dbutils"
+	"github.com/ledgerwatch/turbo-geth/ethdb"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDupsortHashState(t *testing.T) {
+	require, db := require.New(t), ethdb.NewMemDatabase()
+
+	err := db.KV().Update(context.Background(), func(tx ethdb.Tx) error {
+		return tx.Bucket(dbutils.CurrentStateBucketOld1).(ethdb.BucketMigrator).Create()
+	})
+	require.NoError(err)
+
+	accKey := string(common.FromHex(fmt.Sprintf("%064x", 0)))
+	inc := string(common.FromHex("0000000000000001"))
+	storageKey := accKey + inc + accKey
+
+	err = db.Put(dbutils.CurrentStateBucketOld1, []byte(accKey), []byte{1})
+	require.NoError(err)
+	err = db.Put(dbutils.CurrentStateBucketOld1, []byte(storageKey), []byte{2})
+	require.NoError(err)
+
+	migrator := NewMigrator()
+	migrator.Migrations = []Migration{dupsortHashState}
+	err = migrator.Apply(db, "")
+	require.NoError(err)
+
+	i := 0
+	err = db.Walk(dbutils.CurrentStateBucket, nil, 0, func(k, v []byte) (bool, error) {
+		i++
+		return true, nil
+	})
+	require.NoError(err)
+	require.Equal(2, i)
+
+	v, err := db.Get(dbutils.CurrentStateBucket, []byte(accKey))
+	require.NoError(err)
+	require.Equal([]byte{1}, v)
+
+	v, err = db.Get(dbutils.CurrentStateBucket, []byte(storageKey))
+	require.NoError(err)
+	require.Equal([]byte{2}, v)
+
+	err = migrator.Apply(db, "")
+	require.NoError(err)
+
+}

--- a/migrations/dupsort_hash_state_test.go
+++ b/migrations/dupsort_hash_state_test.go
@@ -49,7 +49,4 @@ func TestDupsortHashState(t *testing.T) {
 	require.NoError(err)
 	require.Equal([]byte{2}, v)
 
-	err = migrator.Apply(db, "")
-	require.NoError(err)
-
 }

--- a/migrations/dupsort_hash_state_test.go
+++ b/migrations/dupsort_hash_state_test.go
@@ -58,7 +58,7 @@ func TestDupsortHashState(t *testing.T) {
 
 	tx, err := env.BeginTxn(nil, lmdb.Readonly)
 	require.NoError(err)
-	c, err := tx.OpenCursor(allDBI[string(dbutils.CurrentStateBucket)])
+	c, err := tx.OpenCursor(allDBI[dbutils.CurrentStateBucket])
 	require.NoError(err)
 
 	k, v, err := c.Get([]byte(accKey), nil, lmdb.Set)

--- a/migrations/migrations.go
+++ b/migrations/migrations.go
@@ -142,7 +142,7 @@ func (m *Migrator) Apply(db ethdb.Database, datadir string) error {
 		}
 
 		if !commitFuncCalled {
-			return ErrMigrationCommitNotCalled
+			return fmt.Errorf("%w: %s", ErrMigrationCommitNotCalled, v.Name)
 		}
 		log.Info("Applied migration", "name", v.Name)
 	}

--- a/migrations/migrations.go
+++ b/migrations/migrations.go
@@ -57,6 +57,7 @@ var migrations = []Migration{
 	unwindStagesToUseNamedKeys,
 	stagedsyncToUseStageBlockhashes,
 	unwindStagedsyncToUseStageBlockhashes,
+	dupsortHashState,
 }
 
 type Migration struct {


### PR DESCRIPTION
**Main idea:**

CurrentStateBucket layout which utilises DupSort feature of LMDB (store multiple values inside 1 key).
LMDB stores multiple values of 1 key in B+ tree (as keys which have no values).
It allows do Seek by values and other features of LMDB.
You can think about it as Sub-Database which doesn't store any values.

```
-------------------------------------------------------------
       key              |            value
-------------------------------------------------------------
[acc_hash]              | [acc_value]
[acc_hash]+[inc]        | [storage1_hash]+[storage1_value]
                        | [storage2_hash]+[storage2_value] // this value has no own key. it's 2nd value of [acc_hash]+[inc] key.
                        | [storage3_hash]+[storage3_value]
                        | ...
[acc_hash]+[old_inc]    | [storage1_hash]+[storage1_value]
                        | ...
[acc2_hash]             | [acc2_value]
                        ...
```

On 10.5M block CurrentState bucket of this layout using 7Gb 

**Notice:** 
- This PR touching only hashed state, not plain state - to minimize risk. But env variable "DUPSORT_PLAIN" still works.
- Implementation is fully done inside `kv_lmdb.go` but in future I plan change KV interface closer to LMDB interface and move logic to Trie Loader. (feel free to push back and force me move logic to loader now)
