### PR TITLE
recover_from_hashstate_stage_interruption

### DIFF
--- a/eth/stagedsync/stage_interhashes.go
+++ b/eth/stagedsync/stage_interhashes.go
@@ -32,6 +32,17 @@ func SpawnIntermediateHashesStage(s *StageState, db ethdb.Database, datadir stri
 		return nil
 	}
 
+	hashStateProgress, _, err := stages.GetStageProgress(db, stages.HashState)
+	if err != nil {
+		return err
+	}
+	if s.BlockNumber > hashStateProgress {
+		// this case means - stages.HashState was interrupted and need firstly promote stages.HashState to stages.IntermediateHashes
+		// only then can run stages.IntermediateHashes
+		s.Done()
+		return nil
+	}
+
 	hash := rawdb.ReadCanonicalHash(db, to)
 	syncHeadHeader := rawdb.ReadHeader(db, hash, to)
 	expectedRootHash := syncHeadHeader.Root
@@ -410,6 +421,17 @@ func UnwindIntermediateHashesStage(u *UnwindState, s *StageState, db ethdb.Datab
 	hash := rawdb.ReadCanonicalHash(db, u.UnwindPoint)
 	syncHeadHeader := rawdb.ReadHeader(db, hash, u.UnwindPoint)
 	expectedRootHash := syncHeadHeader.Root
+
+	hashStateProgress, _, err := stages.GetStageProgress(db, stages.HashState)
+	if err != nil {
+		return err
+	}
+	if s.BlockNumber < hashStateProgress {
+		// this case means - stages.HashState was interrupted and need firstly promote stages.HashState to stages.IntermediateHashes
+		// only then can run stages.IntermediateHashes
+		s.Done()
+		return nil
+	}
 
 	if err := unwindIntermediateHashesStageImpl(u, s, db, datadir, expectedRootHash, quit); err != nil {
 		return err


### PR DESCRIPTION
We removed "interrupted stage" concept - and now after TG restart - it starts from stage 0. 
But if interrupt HashState stage - then on start IHashes stage will show "root hash not match". 

I propose next fix: 
- IHashes will check if "progress of IHashes">="progress of HashState" - if not match, then noop.
- HashState will propagate to InterHashes stage, not to Exec stage.
- yes, HashState reading data from plainstate (which is on progress of Exec stage). But it's fine, just to handle special case. 

Example: Exec=9, IHashes=9, HashState=9, next iteration, Exec->10, IHashes->10, HashState=9 (interrupted during promotion to 10), next iteration, Exec->11, IHashes=10 noop, HashState=9 (again interrupted during promotion to 10, why not :slight_smile: ), next iteration, Exec->12, IHashes=10 noop, HashState->12, next iteration, Exec->13, IHashes->13, HashState->13