### PR TITLE
lmdb transactions of unlimited size

### DIFF
--- a/common/etl/buffers.go
+++ b/common/etl/buffers.go
@@ -83,7 +83,7 @@ func (b *sortableBuffer) Get(i int) sortableBufferEntry {
 }
 
 func (b *sortableBuffer) Reset() {
-	b.entries = b.entries[:0] // keep the capacity
+	b.entries = nil
 	b.size = 0
 }
 func (b *sortableBuffer) Sort() {
@@ -150,7 +150,7 @@ func (b *appendSortableBuffer) Get(i int) sortableBufferEntry {
 	return b.sortedBuf[i]
 }
 func (b *appendSortableBuffer) Reset() {
-	b.sortedBuf = b.sortedBuf[:0]
+	b.sortedBuf = nil
 	b.entries = make(map[string][]byte)
 	b.size = 0
 }
@@ -220,7 +220,7 @@ func (b *oldestEntrySortableBuffer) Get(i int) sortableBufferEntry {
 	return b.sortedBuf[i]
 }
 func (b *oldestEntrySortableBuffer) Reset() {
-	b.sortedBuf = b.sortedBuf[:0]
+	b.sortedBuf = nil
 	b.entries = make(map[string][]byte)
 	b.size = 0
 }

--- a/common/etl/collector.go
+++ b/common/etl/collector.go
@@ -95,6 +95,7 @@ func loadFilesIntoBucket(db ethdb.Database, bucket string, providers []dataProvi
 			panic(eee)
 		}
 	}
+
 	batch, err := db.Begin()
 	if err != nil {
 		return err
@@ -103,9 +104,13 @@ func loadFilesIntoBucket(db ethdb.Database, bucket string, providers []dataProvi
 
 	state := &bucketState{batch, bucket, args.Quit}
 	haveSortingGuaranties := isIdentityLoadFunc(loadFunc) // user-defined loadFunc may change ordering
-	lastKey, _, err := batch.Last(bucket)
-	if err != nil {
-		return err
+	var lastKey []byte
+	if bucket != "" { // passing empty bucket name is valid case for etl when DB modification is not expected
+		var errLast error
+		lastKey, _, errLast = batch.Last(bucket)
+		if errLast != nil {
+			return errLast
+		}
 	}
 	var canUseAppend bool
 

--- a/common/etl/collector.go
+++ b/common/etl/collector.go
@@ -123,6 +123,7 @@ func loadFilesIntoBucket(db ethdb.Database, bucket string, providers []dataProvi
 		}
 		i++
 		if i%100_000 == 0 && time.Since(putTimer) > 30*time.Second {
+			putTimer = time.Now()
 			runtime.ReadMemStats(&m)
 			log.Info(
 				"Loading into bucket",

--- a/common/etl/collector.go
+++ b/common/etl/collector.go
@@ -122,7 +122,7 @@ func loadFilesIntoBucket(db ethdb.Database, bucket string, providers []dataProvi
 			canUseAppend = haveSortingGuaranties && isEndOfBucket
 		}
 		i++
-		if i%100_000 == 0 && time.Since(putTimer) > 30*time.Second {
+		if i%1_000_000 == 0 && time.Since(putTimer) > 30*time.Second {
 			putTimer = time.Now()
 			runtime.ReadMemStats(&m)
 			log.Info(

--- a/common/etl/collector.go
+++ b/common/etl/collector.go
@@ -1,10 +1,12 @@
 package etl
 
 import (
+	"bytes"
 	"container/heap"
 	"fmt"
 	"io"
 	"runtime"
+	"time"
 
 	"github.com/ledgerwatch/turbo-geth/common"
 	"github.com/ledgerwatch/turbo-geth/ethdb"
@@ -93,37 +95,57 @@ func loadFilesIntoBucket(db ethdb.Database, bucket string, providers []dataProvi
 			panic(eee)
 		}
 	}
-	batch := db.NewBatch()
-	state := &bucketState{batch, bucket, args.Quit}
+	batch, err := db.Begin()
+	if err != nil {
+		return err
+	}
+	defer batch.Rollback()
 
+	state := &bucketState{batch, bucket, args.Quit}
+	haveSortingGuaranties := isIdentityLoadFunc(loadFunc) // user-defined loadFunc may change ordering
+	lastKey, _, err := batch.Last(bucket)
+	if err != nil {
+		return err
+	}
+	var canUseAppend bool
+
+	putTimer := time.Now()
+	i := 0
 	loadNextFunc := func(originalK, k, v []byte) error {
+		if i == 0 {
+			isEndOfBucket := lastKey == nil || bytes.Compare(lastKey, k) == -1
+			canUseAppend = haveSortingGuaranties && isEndOfBucket
+		}
+		i++
+		if i%100_000 == 0 && time.Since(putTimer) > 30*time.Second {
+			runtime.ReadMemStats(&m)
+			log.Info(
+				"Loading into bucket",
+				"bucket", bucket,
+				"size", common.StorageSize(batch.BatchSize()),
+				"keys", fmt.Sprintf("%.1fM", float64(i)/1_000_000),
+				"use append", canUseAppend,
+				"current key", makeCurrentKeyStr(originalK),
+				"alloc", common.StorageSize(m.Alloc), "sys", common.StorageSize(m.Sys), "numGC", int(m.NumGC))
+		}
+
+		if canUseAppend && len(v) == 0 {
+			return nil // nothing to delete after end of bucket
+		}
 		if len(v) == 0 {
 			if err := batch.Delete(bucket, k); err != nil {
 				return err
 			}
-		} else {
-			if err := batch.Put(bucket, k, v); err != nil {
-				return err
-			}
+			return nil
 		}
-		batchSize := batch.BatchSize()
-		if batchSize > batch.IdealBatchSize() || args.loadBatchSize > 0 && batchSize > args.loadBatchSize {
-			if args.OnLoadCommit != nil {
-				if err := args.OnLoadCommit(batch, k, false); err != nil {
-					return err
-				}
-			}
-			batchSize := batch.BatchSize()
-			if _, err := batch.Commit(); err != nil {
+		if canUseAppend {
+			if err := batch.(*ethdb.TxDb).Append(bucket, k, v); err != nil {
 				return err
 			}
-			runtime.ReadMemStats(&m)
-			log.Info(
-				"Committed batch",
-				"bucket", bucket,
-				"size", common.StorageSize(batchSize),
-				"current key", makeCurrentKeyStr(originalK),
-				"alloc", common.StorageSize(m.Alloc), "sys", common.StorageSize(m.Sys), "numGC", int(m.NumGC))
+			return nil
+		}
+		if err := batch.Put(bucket, k, v); err != nil {
+			return err
 		}
 		return nil
 	}
@@ -151,15 +173,18 @@ func loadFilesIntoBucket(db ethdb.Database, bucket string, providers []dataProvi
 			return err
 		}
 	}
-	batchSize := batch.BatchSize()
+	commitTimer := time.Now()
 	if _, err := batch.Commit(); err != nil {
 		return err
 	}
+	commitTook := time.Since(commitTimer)
+
 	runtime.ReadMemStats(&m)
 	log.Debug(
 		"Committed batch",
 		"bucket", bucket,
-		"size", common.StorageSize(batchSize),
+		"commit", commitTook,
+		"size", common.StorageSize(batch.BatchSize()),
 		"current key", makeCurrentKeyStr(nil),
 		"alloc", common.StorageSize(m.Alloc), "sys", common.StorageSize(m.Sys), "numGC", int(m.NumGC))
 
@@ -172,6 +197,8 @@ func makeCurrentKeyStr(k []byte) string {
 		currentKeyStr = "final"
 	} else if len(k) < 4 {
 		currentKeyStr = fmt.Sprintf("%x", k)
+	} else if k[0] == 0 && k[1] == 0 && k[2] == 0 && k[3] == 0 && len(k) >= 8 { // if key has leading zeroes, show a bit more info
+		currentKeyStr = fmt.Sprintf("%x...", k[:8])
 	} else {
 		currentKeyStr = fmt.Sprintf("%x...", k[:4])
 	}

--- a/common/etl/etl.go
+++ b/common/etl/etl.go
@@ -155,5 +155,5 @@ var IdentityLoadFunc LoadFunc = func(k []byte, value []byte, _ State, next LoadN
 }
 
 func isIdentityLoadFunc(f LoadFunc) bool {
-	return reflect.ValueOf(IdentityLoadFunc).Pointer() == reflect.ValueOf(f).Pointer()
+	return f == nil || reflect.ValueOf(IdentityLoadFunc).Pointer() == reflect.ValueOf(f).Pointer()
 }

--- a/common/etl/etl.go
+++ b/common/etl/etl.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"io"
+	"reflect"
 	"time"
 
 	"github.com/c2h5oh/datasize"
@@ -151,4 +152,8 @@ func (s *bucketState) Stopped() error {
 // IdentityLoadFunc loads entries as they are, without transformation
 var IdentityLoadFunc LoadFunc = func(k []byte, value []byte, _ State, next LoadNextFunc) error {
 	return next(k, k, value)
+}
+
+func isIdentityLoadFunc(f LoadFunc) bool {
+	return reflect.ValueOf(IdentityLoadFunc).Pointer() == reflect.ValueOf(f).Pointer()
 }

--- a/common/etl/etl_test.go
+++ b/common/etl/etl_test.go
@@ -178,7 +178,7 @@ func TestTransformOnLoadCommitCustomBatchSize(t *testing.T) {
 	assert.Nil(t, err)
 	compareBuckets(t, db, sourceBucket, destBucket, nil)
 
-	assert.Equal(t, 21, numberOfCalls)
+	assert.Equal(t, 1, numberOfCalls)
 	assert.True(t, finalized)
 }
 

--- a/core/state/db_state_writer.go
+++ b/core/state/db_state_writer.go
@@ -256,7 +256,7 @@ func (dsw *DbStateWriter) WriteHistory() error {
 	return nil
 }
 
-func writeIndex(blocknum uint64, changes *changeset.ChangeSet, bucket string, changeDb ethdb.Database) error {
+func writeIndex(blocknum uint64, changes *changeset.ChangeSet, bucket string, changeDb ethdb.GetterPutter) error {
 	for _, change := range changes.Changes {
 		currentChunkKey := dbutils.CurrentChunkKey(change.Key)
 		indexBytes, err := changeDb.Get(bucket, currentChunkKey)

--- a/core/state/history_test.go
+++ b/core/state/history_test.go
@@ -1542,7 +1542,7 @@ func TestWalkAsOfStatePlain_WithoutIndex(t *testing.T) {
 	}
 
 	var startKey [60]byte
-	err = WalkAsOf(db.KV(), dbutils.PlainStateBucket, dbutils.StorageHistoryBucket, startKey[:], 0, 2, func(k []byte, v []byte) (b bool, e error) {
+	err = WalkAsOf(db.(ethdb.HasKV).KV(), dbutils.PlainStateBucket, dbutils.StorageHistoryBucket, startKey[:], 0, 2, func(k []byte, v []byte) (b bool, e error) {
 		err = block2.Add(common.CopyBytes(k), common.CopyBytes(v))
 		if err != nil {
 			t.Fatal(err)
@@ -1559,7 +1559,7 @@ func TestWalkAsOfStatePlain_WithoutIndex(t *testing.T) {
 		Changes: make([]changeset.Change, 0),
 	}
 
-	err = WalkAsOf(db.KV(), dbutils.PlainStateBucket, dbutils.StorageHistoryBucket, startKey[:], 0, 4, func(k []byte, v []byte) (b bool, e error) {
+	err = WalkAsOf(db.(ethdb.HasKV).KV(), dbutils.PlainStateBucket, dbutils.StorageHistoryBucket, startKey[:], 0, 4, func(k []byte, v []byte) (b bool, e error) {
 		err = block4.Add(common.CopyBytes(k), common.CopyBytes(v))
 		if err != nil {
 			t.Fatal(err)
@@ -1588,7 +1588,7 @@ func TestWalkAsOfStatePlain_WithoutIndex(t *testing.T) {
 	block6 := &changeset.ChangeSet{
 		Changes: make([]changeset.Change, 0),
 	}
-	err = WalkAsOf(db.KV(), dbutils.PlainStateBucket, dbutils.StorageHistoryBucket, startKey[:], 0, 6, func(k []byte, v []byte) (b bool, e error) {
+	err = WalkAsOf(db.(ethdb.HasKV).KV(), dbutils.PlainStateBucket, dbutils.StorageHistoryBucket, startKey[:], 0, 6, func(k []byte, v []byte) (b bool, e error) {
 		err = block6.Add(common.CopyBytes(k), common.CopyBytes(v))
 		if err != nil {
 			t.Fatal(err)

--- a/core/state/history_test.go
+++ b/core/state/history_test.go
@@ -1542,7 +1542,7 @@ func TestWalkAsOfStatePlain_WithoutIndex(t *testing.T) {
 	}
 
 	var startKey [60]byte
-	err = WalkAsOf(db.(ethdb.HasKV).KV(), dbutils.PlainStateBucket, dbutils.StorageHistoryBucket, startKey[:], 0, 2, func(k []byte, v []byte) (b bool, e error) {
+	err = WalkAsOf(db.KV(), dbutils.PlainStateBucket, dbutils.StorageHistoryBucket, startKey[:], 0, 2, func(k []byte, v []byte) (b bool, e error) {
 		err = block2.Add(common.CopyBytes(k), common.CopyBytes(v))
 		if err != nil {
 			t.Fatal(err)
@@ -1559,7 +1559,7 @@ func TestWalkAsOfStatePlain_WithoutIndex(t *testing.T) {
 		Changes: make([]changeset.Change, 0),
 	}
 
-	err = WalkAsOf(db.(ethdb.HasKV).KV(), dbutils.PlainStateBucket, dbutils.StorageHistoryBucket, startKey[:], 0, 4, func(k []byte, v []byte) (b bool, e error) {
+	err = WalkAsOf(db.KV(), dbutils.PlainStateBucket, dbutils.StorageHistoryBucket, startKey[:], 0, 4, func(k []byte, v []byte) (b bool, e error) {
 		err = block4.Add(common.CopyBytes(k), common.CopyBytes(v))
 		if err != nil {
 			t.Fatal(err)
@@ -1588,7 +1588,7 @@ func TestWalkAsOfStatePlain_WithoutIndex(t *testing.T) {
 	block6 := &changeset.ChangeSet{
 		Changes: make([]changeset.Change, 0),
 	}
-	err = WalkAsOf(db.(ethdb.HasKV).KV(), dbutils.PlainStateBucket, dbutils.StorageHistoryBucket, startKey[:], 0, 6, func(k []byte, v []byte) (b bool, e error) {
+	err = WalkAsOf(db.KV(), dbutils.PlainStateBucket, dbutils.StorageHistoryBucket, startKey[:], 0, 6, func(k []byte, v []byte) (b bool, e error) {
 		err = block6.Add(common.CopyBytes(k), common.CopyBytes(v))
 		if err != nil {
 			t.Fatal(err)

--- a/eth/stagedsync/stage_execute.go
+++ b/eth/stagedsync/stage_execute.go
@@ -73,12 +73,12 @@ func SpawnExecuteBlocksStage(s *StageState, stateDB ethdb.Database, chainConfig 
 
 		stageProgress = blockNum
 
-		blockHash := rawdb.ReadCanonicalHash(batch, blockNum)
-		block := rawdb.ReadBlock(batch, blockHash, blockNum)
+		blockHash := rawdb.ReadCanonicalHash(stateDB, blockNum)
+		block := rawdb.ReadBlock(stateDB, blockHash, blockNum)
 		if block == nil {
 			break
 		}
-		senders := rawdb.ReadSenders(batch, blockHash, blockNum)
+		senders := rawdb.ReadSenders(stateDB, blockHash, blockNum)
 		block.Body().SendersToTxs(senders)
 
 		var stateReader state.StateReader

--- a/eth/stagedsync/stage_execute.go
+++ b/eth/stagedsync/stage_execute.go
@@ -101,12 +101,9 @@ func SpawnExecuteBlocksStage(s *StageState, stateDB ethdb.Database, chainConfig 
 			if err = s.Update(batch, blockNum); err != nil {
 				return err
 			}
-			start := time.Now()
-			sz := batch.BatchSize()
 			if _, err = batch.Commit(); err != nil {
 				return err
 			}
-			log.Info("Batch committed", "in", time.Since(start), "size", common.StorageSize(sz))
 		}
 
 		if prof {

--- a/eth/stagedsync/stage_execute.go
+++ b/eth/stagedsync/stage_execute.go
@@ -59,6 +59,10 @@ func SpawnExecuteBlocksStage(s *StageState, stateDB ethdb.Database, chainConfig 
 	}
 
 	batch := stateDB.NewBatch()
+	//batch, err := stateDB.Begin()
+	//if err != nil {
+	//	return err
+	//}
 	defer batch.Rollback()
 
 	engine := chainContext.Engine()
@@ -73,12 +77,12 @@ func SpawnExecuteBlocksStage(s *StageState, stateDB ethdb.Database, chainConfig 
 
 		stageProgress = blockNum
 
-		blockHash := rawdb.ReadCanonicalHash(stateDB, blockNum)
-		block := rawdb.ReadBlock(stateDB, blockHash, blockNum)
+		blockHash := rawdb.ReadCanonicalHash(batch, blockNum)
+		block := rawdb.ReadBlock(batch, blockHash, blockNum)
 		if block == nil {
 			break
 		}
-		senders := rawdb.ReadSenders(stateDB, blockHash, blockNum)
+		senders := rawdb.ReadSenders(batch, blockHash, blockNum)
 		block.Body().SendersToTxs(senders)
 
 		var stateReader state.StateReader

--- a/eth/stagedsync/stage_execute.go
+++ b/eth/stagedsync/stage_execute.go
@@ -163,6 +163,7 @@ func UnwindExecutionStage(u *UnwindState, s *StageState, stateDB ethdb.Database,
 
 	log.Info("Unwind Execution stage", "from", s.BlockNumber, "to", u.UnwindPoint)
 	batch := stateDB.NewBatch()
+	defer batch.Rollback()
 
 	rewindFunc := ethdb.RewindDataPlain
 	stateBucket := dbutils.PlainStateBucket

--- a/ethdb/interface.go
+++ b/ethdb/interface.go
@@ -79,7 +79,8 @@ type Database interface {
 	// Entries are passed as an array:
 	// bucket0, key0, val0, bucket1, key1, val1, ...
 	MultiPut(tuples ...[]byte) (uint64, error)
-	NewBatch() DbWithPendingMutations // starts in-mem batch
+	NewBatch() DbWithPendingMutations       // starts in-mem batch
+	Begin() (DbWithPendingMutations, error) // starts db transaction
 	Last(bucket string) ([]byte, []byte, error)
 
 	// IdealBatchSize defines the size of the data batches should ideally add in one write.
@@ -91,8 +92,6 @@ type Database interface {
 	// FIXME: implement support if needed
 	Ancients() (uint64, error)
 	TruncateAncients(items uint64) error
-
-	ID() uint64
 }
 
 // MinDatabase is a minimalistic version of the Database interface.

--- a/ethdb/kv_lmdb.go
+++ b/ethdb/kv_lmdb.go
@@ -420,7 +420,7 @@ func (tx *lmdbTx) Commit(ctx context.Context) error {
 		log.Warn("fsync after commit failed: \n", err)
 	}
 	fsyncTime := time.Since(t)
-	if fsyncTime > 5*time.Second {
+	if fsyncTime > 1*time.Second {
 		log.Info("commit", "fsync", fsyncTime)
 	}
 	return nil

--- a/ethdb/kv_lmdb.go
+++ b/ethdb/kv_lmdb.go
@@ -81,8 +81,9 @@ func (opts lmdbOpts) Open() (KV, error) {
 		flags |= lmdb.Readonly
 	}
 	if opts.inMem {
+		flags |= lmdb.NoMetaSync
 	}
-	flags |= lmdb.NoSync | lmdb.NoMetaSync
+	flags |= lmdb.NoSync
 	err = env.Open(opts.path, flags, 0664)
 	if err != nil {
 		return nil, fmt.Errorf("%w, path: %s", err, opts.path)

--- a/ethdb/kv_lmdb.go
+++ b/ethdb/kv_lmdb.go
@@ -207,7 +207,7 @@ func (db *LmdbKV) DiskSize(_ context.Context) (uint64, error) {
 }
 
 func (db *LmdbKV) IdealBatchSize() int {
-	return int(1 * datasize.GB)
+	return int(2 * datasize.GB)
 }
 
 func (db *LmdbKV) Begin(ctx context.Context, parent Tx, writable bool) (Tx, error) {

--- a/ethdb/kv_lmdb.go
+++ b/ethdb/kv_lmdb.go
@@ -207,7 +207,7 @@ func (db *LmdbKV) DiskSize(_ context.Context) (uint64, error) {
 }
 
 func (db *LmdbKV) IdealBatchSize() int {
-	return 50 * 1024 * 1024 // 50 Mb
+	return int(1 * datasize.GB)
 }
 
 func (db *LmdbKV) Begin(ctx context.Context, parent Tx, writable bool) (Tx, error) {
@@ -229,7 +229,6 @@ func (db *LmdbKV) Begin(ctx context.Context, parent Tx, writable bool) (Tx, erro
 		runtime.UnlockOSThread() // unlock only in case of error. normal flow is "defer .Rollback()"
 		return nil, err
 	}
-
 	tx.RawRead = true
 	return &lmdbTx{
 		db:  db,
@@ -420,7 +419,6 @@ func (tx *lmdbTx) Rollback() {
 	}()
 	tx.closeCursors()
 	tx.tx.Abort()
-	tx.tx = nil
 }
 
 func (tx *lmdbTx) get(dbi lmdb.DBI, key []byte) ([]byte, error) {

--- a/ethdb/kv_lmdb.go
+++ b/ethdb/kv_lmdb.go
@@ -207,7 +207,7 @@ func (db *LmdbKV) DiskSize(_ context.Context) (uint64, error) {
 }
 
 func (db *LmdbKV) IdealBatchSize() int {
-	return int(2 * datasize.GB)
+	return int(512 * datasize.MB)
 }
 
 func (db *LmdbKV) Begin(ctx context.Context, parent Tx, writable bool) (Tx, error) {

--- a/ethdb/mutation.go
+++ b/ethdb/mutation.go
@@ -161,6 +161,7 @@ func (m *mutation) Commit() (uint64, error) {
 			value, _ := bt.GetStr(key)
 			m.tuples = append(m.tuples, bucketB, []byte(key), value)
 		}
+		delete(m.puts.mp, bucketStr)
 	}
 	sort.Sort(m.tuples)
 

--- a/ethdb/mutation.go
+++ b/ethdb/mutation.go
@@ -170,7 +170,7 @@ func (m *mutation) Commit() (uint64, error) {
 	}
 
 	m.puts = newPuts()
-	m.tuples = m.tuples[:0]
+	m.tuples = nil
 	return written, nil
 }
 
@@ -178,7 +178,7 @@ func (m *mutation) Rollback() {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.puts = newPuts()
-	m.tuples = m.tuples[:0]
+	m.tuples = nil
 }
 
 func (m *mutation) Keys() ([][]byte, error) {
@@ -209,6 +209,10 @@ func (m *mutation) NewBatch() DbWithPendingMutations {
 	return mm
 }
 
+func (m *mutation) Begin() (DbWithPendingMutations, error) {
+	return m.db.Begin()
+}
+
 func (m *mutation) panicOnEmptyDB() {
 	if m.db == nil {
 		panic("Not implemented")
@@ -218,10 +222,6 @@ func (m *mutation) panicOnEmptyDB() {
 func (m *mutation) MemCopy() Database {
 	m.panicOnEmptyDB()
 	return m.db
-}
-
-func (m *mutation) ID() uint64 {
-	return m.db.ID()
 }
 
 // [TURBO-GETH] Freezer support (not implemented yet)

--- a/ethdb/object_db.go
+++ b/ethdb/object_db.go
@@ -95,60 +95,8 @@ func (db *ObjectDatabase) Put(bucket string, key []byte, value []byte) error {
 
 // MultiPut - requirements: input must be sorted and without duplicates
 func (db *ObjectDatabase) MultiPut(tuples ...[]byte) (uint64, error) {
-	putTimer := time.Now()
-	count := 0
-	total := float64(len(tuples)) / 3
 	err := db.kv.Update(context.Background(), func(tx Tx) error {
-		for bucketStart := 0; bucketStart < len(tuples); {
-			bucketEnd := bucketStart
-			for ; bucketEnd < len(tuples) && bytes.Equal(tuples[bucketEnd], tuples[bucketStart]); bucketEnd += 3 {
-			}
-			c := tx.Cursor(string(tuples[bucketStart]))
-
-			// move cursor to a first element in batch
-			// if it's nil, it means all keys in batch gonna be inserted after end of bucket (batch is sorted and has no duplicates here)
-			// can apply optimisations for this case
-			firstKey, _, err := c.Seek(tuples[bucketStart+1])
-			if err != nil {
-				return err
-			}
-			isEndOfBucket := firstKey == nil
-
-			l := (bucketEnd - bucketStart) / 3
-			for i := 0; i < l; i++ {
-				k := tuples[bucketStart+3*i+1]
-				v := tuples[bucketStart+3*i+2]
-				if isEndOfBucket {
-					if v == nil {
-						// nothing to delete after end of bucket
-					} else {
-						if err := c.Append(k, v); err != nil {
-							return err
-						}
-					}
-				} else {
-					if v == nil {
-						if err := c.Delete(k); err != nil {
-							return err
-						}
-					} else {
-						if err := c.Put(k, v); err != nil {
-							return err
-						}
-					}
-				}
-
-				count++
-				if count%100_000 == 0 && time.Since(putTimer) > 30*time.Second {
-					progress := fmt.Sprintf("%.1fM/%.1fM", float64(count)/1_000_000, total/1_000_000)
-					log.Info("Write to db", "progress", progress)
-					putTimer = time.Now()
-				}
-			}
-
-			bucketStart = bucketEnd
-		}
-		return nil
+		return MultiPut(tx, tuples...)
 	})
 	if err != nil {
 		return 0, err

--- a/ethdb/object_db.go
+++ b/ethdb/object_db.go
@@ -95,6 +95,7 @@ func (db *ObjectDatabase) Put(bucket string, key []byte, value []byte) error {
 
 // MultiPut - requirements: input must be sorted and without duplicates
 func (db *ObjectDatabase) MultiPut(tuples ...[]byte) (uint64, error) {
+	var commitTimer time.Time
 	putTimer := time.Now()
 	count := 0
 	total := float64(len(tuples)) / 3
@@ -148,10 +149,15 @@ func (db *ObjectDatabase) MultiPut(tuples ...[]byte) (uint64, error) {
 
 			bucketStart = bucketEnd
 		}
+		commitTimer = time.Now()
 		return nil
 	})
 	if err != nil {
 		return 0, err
+	}
+	commitTook := time.Since(commitTimer)
+	if commitTook > 10*time.Second {
+		log.Info("Batch committed", "in", commitTook)
 	}
 	return 0, nil
 }

--- a/ethdb/object_db.go
+++ b/ethdb/object_db.go
@@ -414,7 +414,7 @@ func (db *ObjectDatabase) NewBatch() DbWithPendingMutations {
 
 func (db *ObjectDatabase) Begin() (DbWithPendingMutations, error) {
 	batch := &TxDb{db: db, cursors: map[string]*LmdbCursor{}}
-	if err := batch.begin(); err != nil {
+	if err := batch.begin(nil); err != nil {
 		panic(err)
 	}
 	return batch, nil

--- a/ethdb/object_db.go
+++ b/ethdb/object_db.go
@@ -97,6 +97,7 @@ func (db *ObjectDatabase) Put(bucket string, key []byte, value []byte) error {
 func (db *ObjectDatabase) MultiPut(tuples ...[]byte) (uint64, error) {
 	putTimer := time.Now()
 	count := 0
+	total := float64(len(tuples)) / 3
 	err := db.kv.Update(context.Background(), func(tx Tx) error {
 		for bucketStart := 0; bucketStart < len(tuples); {
 			bucketEnd := bucketStart
@@ -139,8 +140,7 @@ func (db *ObjectDatabase) MultiPut(tuples ...[]byte) (uint64, error) {
 
 				count++
 				if count%100_000 == 0 && time.Since(putTimer) > 30*time.Second {
-					total := float64(len(tuples)) / 3
-					progress := fmt.Sprintf("%.1fM/%.1fM", float64(count)/1_000_000, total/1_000_00)
+					progress := fmt.Sprintf("%.1fM/%.1fM", float64(count)/1_000_000, total/1_000_000)
 					log.Info("Write to db", "progress", progress)
 					putTimer = time.Now()
 				}

--- a/ethdb/object_db.go
+++ b/ethdb/object_db.go
@@ -95,7 +95,6 @@ func (db *ObjectDatabase) Put(bucket string, key []byte, value []byte) error {
 
 // MultiPut - requirements: input must be sorted and without duplicates
 func (db *ObjectDatabase) MultiPut(tuples ...[]byte) (uint64, error) {
-	var commitTimer time.Time
 	putTimer := time.Now()
 	count := 0
 	total := float64(len(tuples)) / 3
@@ -149,15 +148,10 @@ func (db *ObjectDatabase) MultiPut(tuples ...[]byte) (uint64, error) {
 
 			bucketStart = bucketEnd
 		}
-		commitTimer = time.Now()
 		return nil
 	})
 	if err != nil {
 		return 0, err
-	}
-	commitTook := time.Since(commitTimer)
-	if commitTook > 10*time.Second {
-		log.Info("Batch committed", "in", commitTook)
 	}
 	return 0, nil
 }

--- a/ethdb/tx_db.go
+++ b/ethdb/tx_db.go
@@ -1,0 +1,188 @@
+package ethdb
+
+import (
+	"context"
+	"fmt"
+	"github.com/c2h5oh/datasize"
+	"github.com/ledgerwatch/turbo-geth/common"
+	"github.com/ledgerwatch/turbo-geth/common/dbutils"
+)
+
+// TxDb - provides Database interface around ethdb.Tx
+// It's not thread-safe!
+// It's not usable after .Commit()/.Rollback() call
+// you can put unlimited amount of data into this class, call IdealBatchSize is unnecessary
+// Walk and MultiWalk methods - work outside of Tx object yet, will implement it later
+type TxDb struct {
+	db      Database
+	Tx      Tx
+	cursors map[string]*LmdbCursor
+	len     uint64
+}
+
+func (m *TxDb) Close() {
+	panic("don't call me")
+}
+
+func (m *TxDb) Begin() (DbWithPendingMutations, error) {
+	batch := &TxDb{db: m.db, cursors: map[string]*LmdbCursor{}}
+	if err := batch.begin(); err != nil {
+		return nil, err
+	}
+	return batch, nil
+}
+
+func (m *TxDb) Put(bucket string, key []byte, value []byte) error {
+	m.len += uint64(len(key) + len(value))
+	return m.cursors[bucket].Put(key, value)
+}
+
+func (m *TxDb) Append(bucket string, key []byte, value []byte) error {
+	m.len += uint64(len(key) + len(value))
+	return m.cursors[bucket].Append(key, value)
+}
+
+func (m *TxDb) Delete(bucket string, key []byte) error {
+	m.len += uint64(len(key))
+	return m.cursors[bucket].Delete(key)
+}
+
+func (m *TxDb) NewBatch() DbWithPendingMutations {
+	panic("don't call me")
+}
+
+func (m *TxDb) begin() error {
+	tx, err := m.db.(HasKV).KV().Begin(context.Background(), nil, true)
+	if err != nil {
+		return err
+	}
+	m.Tx = tx
+	for i := range dbutils.Buckets {
+		m.cursors[dbutils.Buckets[i]] = tx.Bucket(dbutils.Buckets[i]).Cursor().(*LmdbCursor)
+		if err := m.cursors[dbutils.Buckets[i]].initCursor(); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (m *TxDb) KV() KV {
+	if casted, ok := m.db.(HasKV); ok {
+		return casted.KV()
+	}
+	return nil
+}
+
+// Can only be called from the worker thread
+func (m *TxDb) Last(bucket string) ([]byte, []byte, error) {
+	return m.cursors[bucket].Last()
+}
+
+func (m *TxDb) Get(bucket string, key []byte) ([]byte, error) {
+	v, err := m.cursors[bucket].SeekExact(key)
+	if err != nil {
+		return nil, err
+	}
+	if v == nil {
+		return nil, ErrKeyNotFound
+	}
+	return v, nil
+}
+
+func (m *TxDb) GetIndexChunk(bucket string, key []byte, timestamp uint64) ([]byte, error) {
+	if m.db != nil {
+		return m.db.GetIndexChunk(bucket, key, timestamp)
+	}
+	return nil, ErrKeyNotFound
+}
+
+func (m *TxDb) Has(bucket string, key []byte) (bool, error) {
+	v, err := m.Get(bucket, key)
+	if err != nil {
+		return false, err
+	}
+	return v != nil, nil
+}
+
+func (m *TxDb) DiskSize(ctx context.Context) (common.StorageSize, error) {
+	if m.db == nil {
+		return 0, nil
+	}
+	sz, err := m.db.(HasStats).DiskSize(ctx)
+	if err != nil {
+		return 0, err
+	}
+	return common.StorageSize(sz), nil
+}
+
+func (m *TxDb) MultiPut(tuples ...[]byte) (uint64, error) {
+	panic("don't use me")
+}
+
+func (m *TxDb) BatchSize() int {
+	return int(m.len)
+}
+
+// IdealBatchSize defines the size of the data batches should ideally add in one write.
+func (m *TxDb) IdealBatchSize() int {
+	return int(1 * datasize.GB)
+}
+
+// WARNING: Merged mem/DB walk is not implemented
+func (m *TxDb) Walk(bucket string, startkey []byte, fixedbits int, walker func([]byte, []byte) (bool, error)) error {
+	m.panicOnEmptyDB()
+	return m.db.Walk(bucket, startkey, fixedbits, walker)
+}
+
+// WARNING: Merged mem/DB walk is not implemented
+func (m *TxDb) MultiWalk(bucket string, startkeys [][]byte, fixedbits []int, walker func(int, []byte, []byte) error) error {
+	m.panicOnEmptyDB()
+	return m.db.MultiWalk(bucket, startkeys, fixedbits, walker)
+}
+
+func (m *TxDb) Commit() (uint64, error) {
+	if m.db == nil {
+		return 0, nil
+	}
+	if m.Tx == nil {
+		return 0, fmt.Errorf("second call .Commit() on same transaction")
+	}
+	if err := m.Tx.Commit(context.Background()); err != nil {
+		return 0, err
+	}
+	m.Tx = nil
+	m.cursors = nil
+	m.len = 0
+	return 0, nil
+}
+
+func (m *TxDb) Rollback() {
+	if m.Tx == nil {
+		return
+	}
+	m.Tx.Rollback()
+	m.cursors = nil
+	m.Tx = nil
+	m.len = 0
+}
+
+func (m *TxDb) Keys() ([][]byte, error) {
+	panic("don't use me")
+}
+
+func (m *TxDb) panicOnEmptyDB() {
+	if m.db == nil {
+		panic("Not implemented")
+	}
+}
+
+// [TURBO-GETH] Freezer support (not implemented yet)
+// Ancients returns an error as we don't have a backing chain freezer.
+func (m *TxDb) Ancients() (uint64, error) {
+	return 0, errNotSupported
+}
+
+// TruncateAncients returns an error as we don't have a backing chain freezer.
+func (m *TxDb) TruncateAncients(items uint64) error {
+	return errNotSupported
+}

--- a/ethdb/tx_db.go
+++ b/ethdb/tx_db.go
@@ -75,7 +75,11 @@ func (m *TxDb) KV() KV {
 
 // Can only be called from the worker thread
 func (m *TxDb) Last(bucket string) ([]byte, []byte, error) {
-	return m.cursors[bucket].Last()
+	c, ok := m.cursors[bucket]
+	if !ok {
+		panic(fmt.Sprintf("bucket doesn't exists: '%s'", bucket))
+	}
+	return c.Last()
 }
 
 func (m *TxDb) Get(bucket string, key []byte) ([]byte, error) {

--- a/ethdb/tx_db.go
+++ b/ethdb/tx_db.go
@@ -58,7 +58,7 @@ func (m *TxDb) begin() error {
 	}
 	m.Tx = tx
 	for i := range dbutils.Buckets {
-		m.cursors[dbutils.Buckets[i]] = tx.Bucket(dbutils.Buckets[i]).Cursor().(*LmdbCursor)
+		m.cursors[dbutils.Buckets[i]] = tx.Cursor(dbutils.Buckets[i]).(*LmdbCursor)
 		if err := m.cursors[dbutils.Buckets[i]].initCursor(); err != nil {
 			return err
 		}
@@ -83,7 +83,7 @@ func (m *TxDb) Last(bucket string) ([]byte, []byte, error) {
 }
 
 func (m *TxDb) Get(bucket string, key []byte) ([]byte, error) {
-	v, err := m.cursors[bucket].SeekExact(key)
+	v, err := m.cursors[bucket].Get(key)
 	if err != nil {
 		return nil, err
 	}

--- a/ethdb/tx_db.go
+++ b/ethdb/tx_db.go
@@ -282,9 +282,6 @@ func MultiWalk(c Cursor, startkeys [][]byte, fixedbits []int, walker func(int, [
 }
 
 func (m *TxDb) Commit() (uint64, error) {
-	if m.db == nil {
-		return 0, nil
-	}
 	if m.Tx == nil {
 		return 0, fmt.Errorf("second call .Commit() on same transaction")
 	}

--- a/ethdb/tx_db.go
+++ b/ethdb/tx_db.go
@@ -27,7 +27,7 @@ func (m *TxDb) Close() {
 
 func (m *TxDb) Begin() (DbWithPendingMutations, error) {
 	batch := &TxDb{db: m.db, cursors: map[string]*LmdbCursor{}}
-	if err := batch.begin(); err != nil {
+	if err := batch.begin(m.Tx); err != nil {
 		return nil, err
 	}
 	return batch, nil
@@ -52,8 +52,8 @@ func (m *TxDb) NewBatch() DbWithPendingMutations {
 	panic("don't call me")
 }
 
-func (m *TxDb) begin() error {
-	tx, err := m.db.(HasKV).KV().Begin(context.Background(), nil, true)
+func (m *TxDb) begin(parent Tx) error {
+	tx, err := m.db.(HasKV).KV().Begin(context.Background(), parent, true)
 	if err != nil {
 		return err
 	}

--- a/trie/flatdb_sub_trie_loader.go
+++ b/trie/flatdb_sub_trie_loader.go
@@ -619,9 +619,6 @@ func (fstl *FlatDbSubTrieLoader) LoadSubTries() (SubTries, error) {
 					return err
 				}
 				counter++
-				if counter%100_000 == 0 && time.Since(t) < 30*time.Second {
-					fmt.Printf("tick\n")
-				}
 				t = fstl.logProgress(t, counter)
 			}
 			if fstl.itemPresent {

--- a/trie/flatdb_sub_trie_loader.go
+++ b/trie/flatdb_sub_trie_loader.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/binary"
 	"fmt"
+	"github.com/ledgerwatch/turbo-geth/log"
 	"io"
 	"time"
 
@@ -610,11 +611,18 @@ func (fstl *FlatDbSubTrieLoader) LoadSubTries() (SubTries, error) {
 		if err := fstl.iteration(c, ih, true /* first */); err != nil {
 			return err
 		}
+		var counter uint64
+		t := time.Now()
 		for fstl.rangeIdx < len(fstl.dbPrefixes) {
 			for !fstl.itemPresent {
 				if err := fstl.iteration(c, ih, false /* first */); err != nil {
 					return err
 				}
+				counter++
+				if counter%100_000 == 0 && time.Since(t) < 30*time.Second {
+					fmt.Printf("tick\n")
+				}
+				t = fstl.logProgress(t, counter)
 			}
 			if fstl.itemPresent {
 				if err := fstl.receiver.Receive(fstl.itemType, fstl.accountKey, fstl.storageKey, &fstl.accountValue, fstl.storageValue, fstl.hashValue, fstl.streamCutoff); err != nil {
@@ -628,6 +636,26 @@ func (fstl *FlatDbSubTrieLoader) LoadSubTries() (SubTries, error) {
 		return SubTries{}, err
 	}
 	return fstl.receiver.Result(), nil
+}
+
+func (fstl *FlatDbSubTrieLoader) logProgress(lastLogTime time.Time, counter uint64) time.Time {
+	if counter%100_000 == 0 && time.Since(lastLogTime) > 30*time.Second {
+		log.Info("Calculating Merkle root", "current key", makeCurrentKeyStr(fstl.accountKey))
+		return time.Now()
+	}
+	return lastLogTime
+}
+
+func makeCurrentKeyStr(k []byte) string {
+	var currentKeyStr string
+	if k == nil {
+		currentKeyStr = "final"
+	} else if len(k) < 4 {
+		currentKeyStr = fmt.Sprintf("%x", k)
+	} else {
+		currentKeyStr = fmt.Sprintf("%x...", k[:4])
+	}
+	return currentKeyStr
 }
 
 func (fstl *FlatDbSubTrieLoader) AttachRequestedCode(db ethdb.Getter, requests []*LoadRequestForCode) error {


### PR DESCRIPTION
- etl.loadFilesIntoBucket - does load in single transaction without mutation.go
- ethdb.ObjectDb.MultiPut - does logging progress of .Put calls every 30 sec
- "Batch committed" log message did show time of .Put calls + .Commit call. Now it shows only timing of commit (show log message only if commit took longer than 10sec). 
- some buffers are set to nil to release underlying memory pointers https://github.com/ledgerwatch/turbo-geth/pull/919
- Separate `commit` and `fsync` (see kv_lmdb.go `env.Sync(force=true)`) - it allow write logs to console more often on slow devices
- Can increase kv_lmdb.IdealBatchSize
- Interesting effect: bigger mutation size reducing commit time - probably because OS starts flushing to disk while we calling .Put and when we call .Commit already not much left to flush (we writing sorted list). 

Known problems:
- Huge mutation cause unstoppable growth of Go's process dirty memory (I fixed it in etl - https://github.com/ledgerwatch/turbo-geth/pull/919, but not fixed in mutation). 

Ideas for later check:
- we need mutation only for plain state, but using it for change sets also, maybe writing changeset to transaction (not mutation) will reduce mutation size. Will not work on this idea in current ticket. 
- Only 1 commit happening now - means `OnLoadCommit` doesn't need parameter `isDone` anymore.