### PR TITLE
Swap IH and HashState stages

### DIFF
--- a/cmd/integration/commands/stages.go
+++ b/cmd/integration/commands/stages.go
@@ -232,6 +232,7 @@ func stageIHash(ctx context.Context) error {
 		if err := stagedsync.ResetHashState(db); err != nil {
 			return err
 		}
+		return nil
 	}
 
 	stage4 := progress(stages.Execution)
@@ -255,6 +256,13 @@ func stageHashState(ctx context.Context) error {
 
 	bc, _, progress := newSync(ctx.Done(), db, nil)
 	defer bc.Stop()
+
+	if reset {
+		if err := stagedsync.ResetHashState(db); err != nil {
+			return err
+		}
+		return nil
+	}
 
 	stage5 := progress(stages.IntermediateHashes)
 	stage6 := progress(stages.HashState)

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -1730,9 +1730,10 @@ func RegisterEthService(stack *node.Node, cfg *eth.Config) *eth.Ethereum {
 	fullNode := new(eth.Ethereum)
 	if err := stack.Register(func(ctx *node.ServiceContext) (node.Service, error) {
 		fullNodeInst, err := eth.New(ctx, cfg)
-		if err == nil {
-			*fullNode = *fullNodeInst //nolint:govet
+		if err != nil {
+			return nil, err
 		}
+		*fullNode = *fullNodeInst //nolint:govet
 		return fullNode, err
 	}); err != nil {
 		Fatalf("Failed to register the Ethereum service: %v", err)

--- a/core/generate_index.go
+++ b/core/generate_index.go
@@ -32,11 +32,11 @@ type IndexGenerator struct {
 }
 
 func (ig *IndexGenerator) GenerateIndex(startBlock, endBlock uint64, changeSetBucket string, datadir string) error {
-	v, ok := changeset.Mapper[string(changeSetBucket)]
+	v, ok := changeset.Mapper[changeSetBucket]
 	if !ok {
 		return errors.New("unknown bucket type")
 	}
-	log.Debug("Index generation", "from", startBlock, "to", endBlock, "csbucket", string(changeSetBucket))
+	log.Debug("Index generation", "from", startBlock, "to", endBlock, "csbucket", changeSetBucket)
 	if endBlock < startBlock && endBlock != 0 {
 		return fmt.Errorf("generateIndex %s: endBlock %d smaller than startBlock %d", changeSetBucket, endBlock, startBlock)
 	}
@@ -59,12 +59,12 @@ func (ig *IndexGenerator) GenerateIndex(startBlock, endBlock uint64, changeSetBu
 		return err
 	}
 
-	log.Debug("Index generation successfully finished", "csbucket", string(changeSetBucket), "it took", time.Since(t))
+	log.Debug("Index generation successfully finished", "csbucket", changeSetBucket, "it took", time.Since(t))
 	return nil
 }
 
 func (ig *IndexGenerator) Truncate(timestampTo uint64, changeSetBucket string) error {
-	vv, ok := changeset.Mapper[string(changeSetBucket)]
+	vv, ok := changeset.Mapper[changeSetBucket]
 	if !ok {
 		return errors.New("unknown bucket type")
 	}
@@ -143,7 +143,7 @@ func (ig *IndexGenerator) DropIndex(bucket string) error {
 		return errors.New("imposible to drop")
 
 	}
-	log.Warn("Remove bucket", "bucket", string(bucket))
+	log.Warn("Remove bucket", "bucket", bucket)
 	return casted.ClearBuckets(bucket)
 }
 

--- a/core/generate_index.go
+++ b/core/generate_index.go
@@ -141,7 +141,6 @@ func (ig *IndexGenerator) DropIndex(bucket string) error {
 	casted, ok := ig.db.(ethdb.NonTransactional)
 	if !ok {
 		return errors.New("imposible to drop")
-
 	}
 	log.Warn("Remove bucket", "bucket", bucket)
 	return casted.ClearBuckets(bucket)

--- a/eth/stagedsync/stage_hashstate.go
+++ b/eth/stagedsync/stage_hashstate.go
@@ -235,6 +235,11 @@ func getCodeUnwindExtractFunc(db ethdb.Getter) etl.ExtractFunc {
 			if err != nil && !errors.Is(err, ethdb.ErrKeyNotFound) {
 				return fmt.Errorf("getCodeUnwindExtractFunc: %w, key=%x", err, newK)
 			}
+
+			// test
+			codeHash2, err := db.Get(dbutils.ContractCodeBucket, newK)
+			fmt.Printf("1: %x, %x, %x\n", a.CodeHash, codeHash2, codeHash)
+
 			return next(k, newK, codeHash)
 		})
 	}

--- a/eth/stagedsync/stage_hashstate.go
+++ b/eth/stagedsync/stage_hashstate.go
@@ -197,11 +197,15 @@ type Promoter struct {
 	quitCh           chan struct{}
 }
 
-func getExtractFunc(changeSetBucket string) etl.ExtractFunc {
+func getExtractPlainState(changeSetBucket string) etl.ExtractFunc {
 	walkerAdapter := changeset.Mapper[changeSetBucket].WalkerAdapter
 	return func(_, changesetBytes []byte, next etl.ExtractNextFunc) error {
 		return walkerAdapter(changesetBytes).Walk(func(k, v []byte) error {
-			return next(k, k, nil)
+			newK, err := transformPlainStateKey(k)
+			if err != nil {
+				return err
+			}
+			return next(k, newK, v)
 		})
 	}
 }

--- a/eth/stagedsync/stage_hashstate.go
+++ b/eth/stagedsync/stage_hashstate.go
@@ -31,8 +31,12 @@ func SpawnHashStateStage(s *StageState, db ethdb.Database, datadir string, quit 
 		return fmt.Errorf("hashstate: promotion backwards from %d to %d", s.BlockNumber, to)
 	}
 
-	if s.BlockNumber > 0 { // Initial hashing of the state is performed at the previous stage
-		log.Info("Promoting plain state", "from", s.BlockNumber, "to", to)
+	log.Info("Promoting plain state", "from", s.BlockNumber, "to", to)
+	if s.BlockNumber == 0 { // Initial hashing of the state is performed at the previous stage
+		if err := promoteHashedStateCleanly(s, db, datadir, quit); err != nil {
+			return err
+		}
+	} else {
 		if err := promoteHashedStateIncrementally(s, s.BlockNumber, to, db, datadir, quit); err != nil {
 			return err
 		}

--- a/eth/stagedsync/stage_interhashes.go
+++ b/eth/stagedsync/stage_interhashes.go
@@ -229,11 +229,11 @@ func (r *Receiver) storageLoad(k []byte, value []byte, _ etl.State, _ etl.LoadNe
 		return err
 	}
 	newKStr := string(newK)
-	//if len(value) > 0 {
-	//	r.storageMap[newKStr] = common.CopyBytes(value)
-	//} else {
-	//	delete(r.storageMap, newKStr)
-	//}
+	if len(value) > 0 {
+		r.storageMap[newKStr] = common.CopyBytes(value)
+	} else {
+		delete(r.storageMap, newKStr)
+	}
 	r.unfurlList = append(r.unfurlList, newKStr)
 	return nil
 }
@@ -278,11 +278,11 @@ func (p *HashPromoter) Promote(s *StageState, from, to uint64, storage bool, r *
 		changeSetBucket,
 		"",
 		p.TempDir,
-		getExtractFunc(changeSetBucket),
+		getExtractFunc2(changeSetBucket),
 		// here we avoid getting the state from changesets,
 		// we just care about the accounts that did change,
 		// so we can directly read from the PlainTextBuffer
-		getFromPlainStateAndLoad(p.db, l.LoadFunc),
+		getFromPlainStateAndLoad2(p.db, l.LoadFunc),
 		etl.TransformArgs{
 			BufferType:      etl.SortableOldestAppearedBuffer,
 			ExtractStartKey: startkey,

--- a/eth/stagedsync/stage_interhashes.go
+++ b/eth/stagedsync/stage_interhashes.go
@@ -229,11 +229,11 @@ func (r *Receiver) storageLoad(k []byte, value []byte, _ etl.State, _ etl.LoadNe
 		return err
 	}
 	newKStr := string(newK)
-	if len(value) > 0 {
-		r.storageMap[newKStr] = common.CopyBytes(value)
-	} else {
-		delete(r.storageMap, newKStr)
-	}
+	//if len(value) > 0 {
+	//	r.storageMap[newKStr] = common.CopyBytes(value)
+	//} else {
+	//	delete(r.storageMap, newKStr)
+	//}
 	r.unfurlList = append(r.unfurlList, newKStr)
 	return nil
 }
@@ -302,7 +302,7 @@ func (p *HashPromoter) Unwind(s *StageState, u *UnwindState, storage bool, r *Re
 	} else {
 		changeSetBucket = dbutils.PlainAccountChangeSetBucket
 	}
-	log.Info("Unwinding of intermediate hashes", "from", s.BlockNumber, "to", to, "csbucket", string(changeSetBucket))
+	log.Info("Unwinding of intermediate hashes", "from", s.BlockNumber, "to", to, "csbucket", changeSetBucket)
 
 	startkey := dbutils.EncodeTimestamp(to + 1)
 
@@ -373,7 +373,7 @@ func incrementIntermediateHashes(s *StageState, db ethdb.Database, to uint64, da
 	}
 	// hashCollector in the line below will collect creations of new intermediate hashes
 	r.defaultReceiver.Reset(trie.NewRetainList(0), hashCollector, false)
-	loader.SetStreamReceiver(r)
+	//loader.SetStreamReceiver(r)
 	t := time.Now()
 	subTries, err := loader.LoadSubTries()
 	if err != nil {

--- a/eth/stagedsync/stage_interhashes.go
+++ b/eth/stagedsync/stage_interhashes.go
@@ -2,7 +2,6 @@ package stagedsync
 
 import (
 	"bytes"
-	"errors"
 	"fmt"
 	"os"
 	"sort"
@@ -12,7 +11,6 @@ import (
 	"github.com/ledgerwatch/turbo-geth/common/dbutils"
 	"github.com/ledgerwatch/turbo-geth/common/etl"
 	"github.com/ledgerwatch/turbo-geth/core/rawdb"
-	"github.com/ledgerwatch/turbo-geth/core/types/accounts"
 	"github.com/ledgerwatch/turbo-geth/eth/stagedsync/stages"
 	"github.com/ledgerwatch/turbo-geth/ethdb"
 	"github.com/ledgerwatch/turbo-geth/log"
@@ -84,152 +82,6 @@ func regenerateIntermediateHashes(db ethdb.Database, datadir string, expectedRoo
 	return nil
 }
 
-type Receiver struct {
-	defaultReceiver       *trie.DefaultReceiver
-	accountMap            map[string]*accounts.Account
-	storageMap            map[string][]byte
-	removingAccount       []byte
-	currentAccountWithInc []byte
-	unfurlList            []string
-	currentIdx            int
-	quitCh                <-chan struct{}
-}
-
-func NewReceiver(quitCh <-chan struct{}) *Receiver {
-	return &Receiver{
-		defaultReceiver: trie.NewDefaultReceiver(),
-		accountMap:      make(map[string]*accounts.Account),
-		storageMap:      make(map[string][]byte),
-		quitCh:          quitCh,
-	}
-}
-
-func (r *Receiver) Receive(
-	itemType trie.StreamItem,
-	accountKey []byte,
-	storageKey []byte,
-	accountValue *accounts.Account,
-	storageValue []byte,
-	hash []byte,
-	cutoff int,
-) error {
-	if err := common.Stopped(r.quitCh); err != nil {
-		return err
-	}
-
-	storage := itemType == trie.StorageStreamItem || itemType == trie.SHashStreamItem
-	for r.currentIdx < len(r.unfurlList) {
-		ks := r.unfurlList[r.currentIdx]
-		k := []byte(ks)
-		var c int
-		switch itemType {
-		case trie.StorageStreamItem, trie.SHashStreamItem:
-			c = bytes.Compare(k, storageKey)
-		case trie.AccountStreamItem, trie.AHashStreamItem:
-			c = bytes.Compare(k, accountKey)
-		case trie.CutoffStreamItem:
-			c = -1
-		}
-		if c > 0 {
-			if storage {
-				if r.removingAccount != nil && bytes.HasPrefix(storageKey, r.removingAccount) {
-					return nil
-				}
-				if r.currentAccountWithInc == nil {
-					return nil
-				}
-				if !bytes.HasPrefix(storageKey, r.currentAccountWithInc) {
-					return nil
-				}
-			}
-			if itemType == trie.AccountStreamItem {
-				r.currentAccountWithInc = dbutils.GenerateStoragePrefix(accountKey, accountValue.Incarnation)
-			}
-			return r.defaultReceiver.Receive(itemType, accountKey, storageKey, accountValue, storageValue, hash, cutoff)
-		}
-		r.currentIdx++
-		if len(k) > common.HashLength {
-			if r.removingAccount != nil && bytes.HasPrefix(k, r.removingAccount) {
-				continue
-			}
-			if r.currentAccountWithInc == nil {
-				continue
-			}
-			if !bytes.HasPrefix(k, r.currentAccountWithInc) {
-				continue
-			}
-			v := r.storageMap[ks]
-			if len(v) > 0 {
-				if err := r.defaultReceiver.Receive(trie.StorageStreamItem, nil, k, nil, v, nil, 0); err != nil {
-					return err
-				}
-			}
-		} else {
-			v := r.accountMap[ks]
-			if v != nil {
-				if err := r.defaultReceiver.Receive(trie.AccountStreamItem, k, nil, v, nil, nil, 0); err != nil {
-					return err
-				}
-				r.removingAccount = nil
-				r.currentAccountWithInc = dbutils.GenerateStoragePrefix(k, v.Incarnation)
-			} else {
-				r.removingAccount = k
-				r.currentAccountWithInc = nil
-			}
-		}
-		if c == 0 {
-			return nil
-		}
-	}
-	// We ran out of modifications, simply pass through
-	if storage {
-		if r.removingAccount != nil && bytes.HasPrefix(storageKey, r.removingAccount) {
-			return nil
-		}
-		if r.currentAccountWithInc == nil {
-			return nil
-		}
-		if !bytes.HasPrefix(storageKey, r.currentAccountWithInc) {
-			return nil
-		}
-	}
-	r.removingAccount = nil
-	if itemType == trie.AccountStreamItem {
-		r.currentAccountWithInc = dbutils.GenerateStoragePrefix(accountKey, accountValue.Incarnation)
-	}
-	return r.defaultReceiver.Receive(itemType, accountKey, storageKey, accountValue, storageValue, hash, cutoff)
-}
-
-func (r *Receiver) Result() trie.SubTries {
-	return r.defaultReceiver.Result()
-}
-
-func (r *Receiver) accountLoad(k []byte, value []byte, _ etl.State, _ etl.LoadNextFunc) error {
-	newKStr := string(k)
-	if len(value) > 0 {
-		var a accounts.Account
-		if err := a.DecodeForStorage(value); err != nil {
-			return err
-		}
-		r.accountMap[newKStr] = &a
-	} else {
-		delete(r.accountMap, newKStr)
-	}
-	r.unfurlList = append(r.unfurlList, newKStr)
-	return nil
-}
-
-func (r *Receiver) storageLoad(k []byte, value []byte, _ etl.State, _ etl.LoadNextFunc) error {
-	newKStr := string(k)
-	if len(value) > 0 {
-		r.storageMap[newKStr] = common.CopyBytes(value)
-	} else {
-		delete(r.storageMap, newKStr)
-	}
-	r.unfurlList = append(r.unfurlList, newKStr)
-	return nil
-}
-
 type HashPromoter struct {
 	db               ethdb.Database
 	ChangeSetBufSize uint64
@@ -246,25 +98,19 @@ func NewHashPromoter(db ethdb.Database, quitCh <-chan struct{}) *HashPromoter {
 	}
 }
 
-func (p *HashPromoter) Promote(s *StageState, from, to uint64, storage bool, r *Receiver) error {
+func (p *HashPromoter) Promote(s *StageState, from, to uint64, storage bool, load etl.LoadFunc) error {
 	var changeSetBucket string
 	if storage {
 		changeSetBucket = dbutils.PlainStorageChangeSetBucket
 	} else {
 		changeSetBucket = dbutils.PlainAccountChangeSetBucket
 	}
-	log.Debug("Incremental state promotion of intermediate hashes", "from", from, "to", to, "csbucket", string(changeSetBucket))
-
-	// Can't skip stage even if it was done before interruptoin because need to fill non-persistent data structure: Receiver
+	log.Debug("Incremental state promotion of intermediate hashes", "from", from, "to", to, "csbucket", changeSetBucket)
 
 	startkey := dbutils.EncodeTimestamp(from + 1)
 
 	var l OldestAppearedLoad
-	if storage {
-		l.innerLoadFunc = r.storageLoad
-	} else {
-		l.innerLoadFunc = r.accountLoad
-	}
+	l.innerLoadFunc = load
 
 	if err := etl.Transform(
 		p.db,
@@ -284,7 +130,7 @@ func (p *HashPromoter) Promote(s *StageState, from, to uint64, storage bool, r *
 	return nil
 }
 
-func (p *HashPromoter) Unwind(s *StageState, u *UnwindState, storage bool, r *Receiver) error {
+func (p *HashPromoter) Unwind(s *StageState, u *UnwindState, storage bool, load etl.LoadFunc) error {
 	to := u.UnwindPoint
 	var changeSetBucket string
 	if storage {
@@ -296,14 +142,9 @@ func (p *HashPromoter) Unwind(s *StageState, u *UnwindState, storage bool, r *Re
 
 	startkey := dbutils.EncodeTimestamp(to + 1)
 
-	// Can't skip stage even if it was done before interruptoin because need to fill non-persistent data structure: Receiver
-
 	var l OldestAppearedLoad
-	if storage {
-		l.innerLoadFunc = r.storageLoad
-	} else {
-		l.innerLoadFunc = r.accountLoad
-	}
+	l.innerLoadFunc = load
+
 	if err := etl.Transform(
 		p.db,
 		changeSetBucket,
@@ -325,27 +166,22 @@ func (p *HashPromoter) Unwind(s *StageState, u *UnwindState, storage bool, r *Re
 func incrementIntermediateHashes(s *StageState, db ethdb.Database, to uint64, datadir string, expectedRootHash common.Hash, quit <-chan struct{}) error {
 	p := NewHashPromoter(db, quit)
 	p.TempDir = datadir
-	r := NewReceiver(quit)
-	if err := p.Promote(s, s.BlockNumber, to, false /* storage */, r); err != nil {
+	var exclude [][]byte
+	collect := func(k []byte, _ []byte, _ etl.State, _ etl.LoadNextFunc) error {
+		exclude = append(exclude, k)
+		return nil
+	}
+	if err := p.Promote(s, s.BlockNumber, to, false /* storage */, collect); err != nil {
 		return err
 	}
-	if err := p.Promote(s, s.BlockNumber, to, true /* storage */, r); err != nil {
+	if err := p.Promote(s, s.BlockNumber, to, true /* storage */, collect); err != nil {
 		return err
 	}
-	//for ks, acc := range r.accountMap {
-	//	// Fill the code hashes
-	//	if acc.Incarnation > 0 && acc.IsEmptyCodeHash() {
-	//		if codeHash, err := db.Get(dbutils.ContractCodeBucket, dbutils.GenerateStoragePrefix([]byte(ks), acc.Incarnation)); err == nil {
-	//			copy(acc.CodeHash[:], codeHash)
-	//		} else if !errors.Is(err, ethdb.ErrKeyNotFound) {
-	//			return fmt.Errorf("adjusting codeHash for ks %x, inc %d: %w", ks, acc.Incarnation, err)
-	//		}
-	//	}
-	//}
+	sort.Slice(exclude, func(i, j int) bool { return bytes.Compare(exclude[i], exclude[j]) < 0 })
+
 	unfurl := trie.NewRetainList(0)
-	sort.Strings(r.unfurlList)
-	for _, ks := range r.unfurlList {
-		unfurl.AddKey([]byte(ks))
+	for i := range exclude {
+		unfurl.AddKey(exclude[i])
 	}
 	collector := etl.NewCollector(datadir, etl.NewSortableBuffer(etl.BufferOptimalSize))
 	hashCollector := func(keyHex []byte, hash []byte) error {
@@ -361,9 +197,6 @@ func incrementIntermediateHashes(s *StageState, db ethdb.Database, to uint64, da
 	if err := loader.Reset(db, unfurl, trie.NewRetainList(0), hashCollector, [][]byte{nil}, []int{0}, false); err != nil {
 		return err
 	}
-	// hashCollector in the line below will collect creations of new intermediate hashes
-	r.defaultReceiver.Reset(trie.NewRetainList(0), hashCollector, false)
-	//loader.SetStreamReceiver(r)
 	t := time.Now()
 	subTries, err := loader.LoadSubTries()
 	if err != nil {
@@ -401,29 +234,22 @@ func UnwindIntermediateHashesStage(u *UnwindState, s *StageState, db ethdb.Datab
 func unwindIntermediateHashesStageImpl(u *UnwindState, s *StageState, db ethdb.Database, datadir string, expectedRootHash common.Hash, quit <-chan struct{}) error {
 	p := NewHashPromoter(db, quit)
 	p.TempDir = datadir
-	r := NewReceiver(quit)
-	if err := p.Unwind(s, u, false /* storage */, r); err != nil {
+	var exclude [][]byte
+	collect := func(k []byte, _ []byte, _ etl.State, _ etl.LoadNextFunc) error {
+		exclude = append(exclude, k)
+		return nil
+	}
+	if err := p.Unwind(s, u, false /* storage */, collect); err != nil {
 		return err
 	}
-	if err := p.Unwind(s, u, true /* storage */, r); err != nil {
+	if err := p.Unwind(s, u, true /* storage */, collect); err != nil {
 		return err
 	}
-	for ks, acc := range r.accountMap {
-		// Fill the code hashes
-		if acc.Incarnation > 0 && acc.IsEmptyCodeHash() {
-			if codeHash, err := db.Get(dbutils.ContractCodeBucket, dbutils.GenerateStoragePrefix([]byte(ks), acc.Incarnation)); err == nil {
-				copy(acc.CodeHash[:], codeHash)
-			} else if errors.Is(err, ethdb.ErrKeyNotFound) {
-				copy(acc.CodeHash[:], trie.EmptyCodeHash[:])
-			} else {
-				return fmt.Errorf("adjusting codeHash for ks %x, inc %d: %w", ks, acc.Incarnation, err)
-			}
-		}
-	}
-	sort.Strings(r.unfurlList)
+	sort.Slice(exclude, func(i, j int) bool { return bytes.Compare(exclude[i], exclude[j]) < 0 })
+
 	unfurl := trie.NewRetainList(0)
-	for _, ks := range r.unfurlList {
-		unfurl.AddKey([]byte(ks))
+	for i := range exclude {
+		unfurl.AddKey(exclude[i])
 	}
 	collector := etl.NewCollector(datadir, etl.NewSortableBuffer(etl.BufferOptimalSize))
 	hashCollector := func(keyHex []byte, hash []byte) error {
@@ -439,9 +265,6 @@ func unwindIntermediateHashesStageImpl(u *UnwindState, s *StageState, db ethdb.D
 	if err := loader.Reset(db, unfurl, trie.NewRetainList(0), hashCollector, [][]byte{nil}, []int{0}, false); err != nil {
 		return err
 	}
-	// hashCollector in the line below will collect creations of new intermediate hashes
-	r.defaultReceiver.Reset(trie.NewRetainList(0), hashCollector, false)
-	loader.SetStreamReceiver(r)
 	t := time.Now()
 	subTries, err := loader.LoadSubTries()
 	if err != nil {

--- a/eth/stagedsync/stage_interhashes.go
+++ b/eth/stagedsync/stage_interhashes.go
@@ -271,7 +271,7 @@ func (p *HashPromoter) Promote(s *StageState, from, to uint64, storage bool, r *
 		changeSetBucket,
 		"",
 		p.TempDir,
-		getExtractPlainState(changeSetBucket),
+		getExtractPlainStateForIH(changeSetBucket),
 		l.LoadFunc,
 		etl.TransformArgs{
 			BufferType:      etl.SortableOldestAppearedBuffer,
@@ -309,7 +309,7 @@ func (p *HashPromoter) Unwind(s *StageState, u *UnwindState, storage bool, r *Re
 		changeSetBucket,
 		"",
 		p.TempDir,
-		getExtractPlainState(changeSetBucket),
+		getExtractPlainStateForIH(changeSetBucket),
 		l.LoadFunc,
 		etl.TransformArgs{
 			BufferType:      etl.SortableOldestAppearedBuffer,

--- a/eth/stagedsync/stagedsync.go
+++ b/eth/stagedsync/stagedsync.go
@@ -167,7 +167,8 @@ func PrepareStagedSync(
 	state := NewState(stages)
 	state.unwindOrder = []*Stage{
 		// Unwinding of tx pool (reinjecting transactions into the pool needs to happen after unwinding execution)
-		stages[0], stages[1], stages[2], stages[3], stages[10], stages[4], stages[5], stages[6], stages[7], stages[8], stages[9],
+		// Unwinding of IHashes needs to happen after unwinding HashState
+		stages[0], stages[1], stages[2], stages[3], stages[10], stages[4], stages[6], stages[5], stages[7], stages[8], stages[9],
 	}
 	if err := state.LoadUnwindInfo(stateDB); err != nil {
 		return nil, err

--- a/eth/stagedsync/stagedsync.go
+++ b/eth/stagedsync/stagedsync.go
@@ -97,16 +97,6 @@ func PrepareStagedSync(
 			},
 		},
 		{
-			ID:          stages.IntermediateHashes,
-			Description: "Generate intermediate hashes and computing state root",
-			ExecFunc: func(s *StageState, u Unwinder) error {
-				return SpawnIntermediateHashesStage(s, stateDB, datadir, quitCh)
-			},
-			UnwindFunc: func(u *UnwindState, s *StageState) error {
-				return UnwindIntermediateHashesStage(u, s, stateDB, datadir, quitCh)
-			},
-		},
-		{
 			ID:          stages.HashState,
 			Description: "Hash the key in the state",
 			ExecFunc: func(s *StageState, u Unwinder) error {
@@ -114,6 +104,16 @@ func PrepareStagedSync(
 			},
 			UnwindFunc: func(u *UnwindState, s *StageState) error {
 				return UnwindHashStateStage(u, s, stateDB, datadir, quitCh)
+			},
+		},
+		{
+			ID:          stages.IntermediateHashes,
+			Description: "Generate intermediate hashes and computing state root",
+			ExecFunc: func(s *StageState, u Unwinder) error {
+				return SpawnIntermediateHashesStage(s, stateDB, datadir, quitCh)
+			},
+			UnwindFunc: func(u *UnwindState, s *StageState) error {
+				return UnwindIntermediateHashesStage(u, s, stateDB, datadir, quitCh)
 			},
 		},
 		{

--- a/eth/stagedsync/state.go
+++ b/eth/stagedsync/state.go
@@ -143,8 +143,9 @@ func (s *State) runStage(stage *Stage, db ethdb.Getter) error {
 	if err != nil {
 		return err
 	}
+	index, stage := s.CurrentStage()
 
-	message := fmt.Sprintf("Sync stage %d/%d. %v...", stage.ID+1, s.Len(), stage.Description)
+	message := fmt.Sprintf("Sync stage %d/%d. %v...", index+1, s.Len(), stage.Description)
 	log.Info(message)
 
 	err = stage.ExecFunc(stageState, s)
@@ -157,7 +158,7 @@ func (s *State) runStage(stage *Stage, db ethdb.Getter) error {
 }
 
 func (s *State) UnwindStage(unwind *UnwindState, db ethdb.GetterPutter) error {
-	log.Info("Unwinding...", "stage", unwind.Stage)
+	log.Info("Unwinding...", "stage", string(stages.DBKeys[unwind.Stage]))
 	stage, err := s.StageByID(unwind.Stage)
 	if err != nil {
 		return err


### PR DESCRIPTION
Main ideas:
- IH stage must only validate that state is correct - it must not use any hacks to override state (for example accountsMap or code hash adjust) - because it means that we store in db invalid state.
- But it means that during unwind HashState stage must go before IH, it's fine - I added to `state.unwindOrder`.
- All tweaks moved into HashState stage (it's extract part)
- IH Receiver removed

Future steps: 
- After merge of https://github.com/ledgerwatch/turbo-geth/pull/918 - I wanna try - use transaction to delete IH which now hidden by RetainList and if hashRoot match - commit all changes at once. 
