### PR TITLE
fix RegisterEthService nil panic

### DIFF
--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -1730,7 +1730,9 @@ func RegisterEthService(stack *node.Node, cfg *eth.Config) *eth.Ethereum {
 	fullNode := new(eth.Ethereum)
 	if err := stack.Register(func(ctx *node.ServiceContext) (node.Service, error) {
 		fullNodeInst, err := eth.New(ctx, cfg)
-		*fullNode = *fullNodeInst //nolint:govet
+		if err == nil {
+			*fullNode = *fullNodeInst //nolint:govet
+		}
 		return fullNode, err
 	}); err != nil {
 		Fatalf("Failed to register the Ethereum service: %v", err)


### PR DESCRIPTION
```
INFO [08-15|09:42:25.316] Allocated trie memory caches             clean=1.60GiB dirty=0.00B
INFO [08-15|09:42:25.316] Opening Database (LMDB)
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x10063dd]

goroutine 1 [running]:
github.com/ledgerwatch/turbo-geth/cmd/utils.RegisterEthService.func1(0xc000220900, 0xc0002cf530, 0xc0004ab998, 0xc0001a5800, 0x2)
        github.com/ledgerwatch/turbo-geth@/cmd/utils/flags.go:1733 +0x4d
github.com/ledgerwatch/turbo-geth/node.(*Node).Start(0xc0000e3680, 0x0, 0x0)
        github.com/ledgerwatch/turbo-geth@/node/node.go:209 +0x407
github.com/ledgerwatch/turbo-geth/cmd/utils.StartNode(0xc0000e3680)
        github.com/ledgerwatch/turbo-geth@/cmd/utils/cmd.go:69 +0x2f
main.startNode(0xc0002006e0, 0xc0000e3680)
        github.com/ledgerwatch/turbo-geth@/cmd/geth/main.go:363 +0x7e
main.geth(0xc0002006e0, 0x0, 0x0)
        github.com/ledgerwatch/turbo-geth@/cmd/geth/main.go:351 +0xc8
github.com/urfave/cli.HandleAction(0x13166c0, 0x1655808, 0xc0002006e0, 0xc0002006e0, 0x0)
        github.com/urfave/cli@v1.22.1/app.go:523 +0xbe
github.com/urfave/cli.(*App).Run(0xc00003e540, 0xc00003c1d0, 0x1, 0x1, 0x0, 0x0)
        github.com/urfave/cli@v1.22.1/app.go:285 +0x5df
main.main()
        github.com/ledgerwatch/turbo-geth@/cmd/geth/main.go:267 +0x55
```