### PR TITLE
Net api as a service

### DIFF
--- a/cmd/rpcdaemon/commands/daemon.go
+++ b/cmd/rpcdaemon/commands/daemon.go
@@ -139,6 +139,7 @@ func GetAPI(db ethdb.KV, eth ethdb.Backend, enabledApis []string) []rpc.API {
 	dbReader := ethdb.NewObjectDatabase(db)
 	chainContext := NewChainContext(dbReader)
 	apiImpl := NewAPI(db, dbReader, chainContext, eth)
+	netImpl := NewNetAPIImpl(eth)
 	dbgAPIImpl := NewPrivateDebugAPI(db, dbReader, chainContext)
 
 	for _, enabledAPI := range enabledApis {
@@ -155,6 +156,13 @@ func GetAPI(db ethdb.KV, eth ethdb.Backend, enabledApis []string) []rpc.API {
 				Namespace: "debug",
 				Public:    true,
 				Service:   PrivateDebugAPI(dbgAPIImpl),
+				Version:   "1.0",
+			})
+		case "net":
+			rpcAPI = append(rpcAPI, rpc.API{
+				Namespace: "net",
+				Public:    true,
+				Service:   NetAPI(netImpl),
 				Version:   "1.0",
 			})
 

--- a/cmd/rpcdaemon/commands/eth_api.go
+++ b/cmd/rpcdaemon/commands/eth_api.go
@@ -17,7 +17,6 @@ import (
 // EthAPI is a collection of functions that are exposed in the
 type EthAPI interface {
 	Coinbase(ctx context.Context) (common.Address, error)
-	NetVersion(ctx context.Context) uint64
 	BlockNumber(ctx context.Context) (hexutil.Uint64, error)
 	GetBlockByNumber(ctx context.Context, number rpc.BlockNumber, fullTx bool) (map[string]interface{}, error)
 	GetBalance(ctx context.Context, address common.Address, blockNrOrHash rpc.BlockNumberOrHash) (*hexutil.Big, error)

--- a/cmd/rpcdaemon/commands/net.go
+++ b/cmd/rpcdaemon/commands/net.go
@@ -1,0 +1,22 @@
+package commands
+
+import (
+	"context"
+
+	"github.com/ledgerwatch/turbo-geth/ethdb"
+)
+
+type NetAPI interface {
+	Version(ctx context.Context) uint64
+}
+
+type NetAPIImpl struct {
+	ethBackend ethdb.Backend
+}
+
+// NwtNetAPIImpl returns NetAPIImplImpl instance
+func NewNetAPIImpl(eth ethdb.Backend) *NetAPIImpl {
+	return &NetAPIImpl{
+		ethBackend: eth,
+	}
+}

--- a/cmd/rpcdaemon/commands/net_version.go
+++ b/cmd/rpcdaemon/commands/net_version.go
@@ -4,6 +4,6 @@ import (
 	"context"
 )
 
-func (api *APIImpl) NetVersion(_ context.Context) uint64 {
+func (api *NetAPIImpl) Version(_ context.Context) uint64 {
 	return api.ethBackend.NetVersion()
 }


### PR DESCRIPTION
Extract `net` API as a service
closes #923 