### PR TITLE
[to discuss] exec blocks without ObjectDb: Mutation over TxDb

### DIFF
--- a/eth/stagedsync/stage_execute.go
+++ b/eth/stagedsync/stage_execute.go
@@ -62,14 +62,10 @@ func SpawnExecuteBlocksStage(s *StageState, stateDB ethdb.Database, chainConfig 
 	if err != nil {
 		return err
 	}
-	defer func() {
-		tx.Rollback()
-	}()
+	defer tx.Rollback()
 
 	batch := tx.NewBatch()
-	defer func() {
-		batch.Rollback()
-	}()
+	defer batch.Rollback()
 
 	engine := chainContext.Engine()
 
@@ -113,18 +109,12 @@ func SpawnExecuteBlocksStage(s *StageState, stateDB ethdb.Database, chainConfig 
 			if err = s.Update(batch, blockNum); err != nil {
 				return err
 			}
-			if _, err = batch.Commit(); err != nil {
+			if err = batch.CommitAndBegin(); err != nil {
 				return err
 			}
-			if _, err = tx.Commit(); err != nil {
+			if err = tx.CommitAndBegin(); err != nil {
 				return err
 			}
-
-			tx, err = stateDB.Begin()
-			if err != nil {
-				return err
-			}
-			batch = tx.NewBatch()
 		}
 
 		if prof {

--- a/eth/stagedsync/stage_execute.go
+++ b/eth/stagedsync/stage_execute.go
@@ -183,10 +183,7 @@ func UnwindExecutionStage(u *UnwindState, s *StageState, stateDB ethdb.Database,
 	}
 
 	log.Info("Unwind Execution stage", "from", s.BlockNumber, "to", u.UnwindPoint)
-	batch, err := stateDB.Begin()
-	if err != nil {
-		return err
-	}
+	batch := stateDB.NewBatch()
 	defer batch.Rollback()
 
 	rewindFunc := ethdb.RewindDataPlain
@@ -198,7 +195,7 @@ func UnwindExecutionStage(u *UnwindState, s *StageState, stateDB ethdb.Database,
 	writeAccountFunc := writeAccountPlain
 	recoverCodeHashFunc := recoverCodeHashPlain
 
-	accountMap, storageMap, err := rewindFunc(batch, s.BlockNumber, u.UnwindPoint)
+	accountMap, storageMap, err := rewindFunc(stateDB, s.BlockNumber, u.UnwindPoint)
 	if err != nil {
 		return fmt.Errorf("unwind Execution: getting rewind data: %v", err)
 	}
@@ -211,7 +208,7 @@ func UnwindExecutionStage(u *UnwindState, s *StageState, stateDB ethdb.Database,
 			}
 
 			// Fetch the code hash
-			recoverCodeHashFunc(&acc, batch, key)
+			recoverCodeHashFunc(&acc, stateDB, key)
 			if err = writeAccountFunc(batch, key, acc); err != nil {
 				return err
 			}

--- a/ethdb/interface.go
+++ b/ethdb/interface.go
@@ -79,7 +79,17 @@ type Database interface {
 	// Entries are passed as an array:
 	// bucket0, key0, val0, bucket1, key1, val1, ...
 	MultiPut(tuples ...[]byte) (uint64, error)
-	NewBatch() DbWithPendingMutations       // starts in-mem batch
+
+	// NewBatch - starts in-mem batch
+	//
+	// Common pattern:
+	//
+	// batch := db.NewBatch()
+	// defer batch.Rollback()
+	// ... some calculations on `batch`
+	// batch.Commit()
+	//
+	NewBatch() DbWithPendingMutations       //
 	Begin() (DbWithPendingMutations, error) // starts db transaction
 	Last(bucket string) ([]byte, []byte, error)
 
@@ -106,7 +116,33 @@ type MinDatabase interface {
 // Later they can either be committed to the database or rolled back.
 type DbWithPendingMutations interface {
 	Database
+
+	// Commit - commits transaction (or flush data into underlying db object in case of `mutation`)
+	//
+	// Common pattern:
+	//
+	// tx := db.Begin()
+	// defer tx.Rollback()
+	// ... some calculations on `tx`
+	// tx.Commit()
+	//
 	Commit() (uint64, error)
+
+	// CommitAndBegin - commits and starts new transaction inside same db object.
+	// useful for periodical commits implementation.
+	//
+	// Common pattern:
+	//
+	// tx := db.Begin()
+	// defer tx.Rollback()
+	// for {
+	// 		... some calculations on `tx`
+	//       tx.CommitAndBegin()
+	//       // defer here - is not useful, because 'tx' object is reused and first `defer` will work perfectly
+	// }
+	// tx.Commit()
+	//
+	CommitAndBegin() error
 	Rollback()
 	BatchSize() int
 }

--- a/ethdb/kv_lmdb.go
+++ b/ethdb/kv_lmdb.go
@@ -208,7 +208,7 @@ func (db *LmdbKV) DiskSize(_ context.Context) (uint64, error) {
 }
 
 func (db *LmdbKV) IdealBatchSize() int {
-	return int(5 * datasize.MB)
+	return int(512 * datasize.MB)
 }
 
 func (db *LmdbKV) Begin(ctx context.Context, parent Tx, writable bool) (Tx, error) {

--- a/ethdb/kv_lmdb.go
+++ b/ethdb/kv_lmdb.go
@@ -208,7 +208,7 @@ func (db *LmdbKV) DiskSize(_ context.Context) (uint64, error) {
 }
 
 func (db *LmdbKV) IdealBatchSize() int {
-	return int(512 * datasize.MB)
+	return int(5 * datasize.MB)
 }
 
 func (db *LmdbKV) Begin(ctx context.Context, parent Tx, writable bool) (Tx, error) {
@@ -328,7 +328,7 @@ func (db *LmdbKV) Update(ctx context.Context, f func(tx Tx) error) (err error) {
 	}
 
 	commitTook := time.Since(commitTimer)
-	if commitTook > 10*time.Second {
+	if commitTook > 20*time.Second {
 		log.Info("Batch", "commit", commitTook)
 	}
 
@@ -337,7 +337,7 @@ func (db *LmdbKV) Update(ctx context.Context, f func(tx Tx) error) (err error) {
 		log.Warn("fsync after commit failed: \n", err)
 	}
 	fsyncTook := time.Since(fsyncTimer)
-	if fsyncTook > 1*time.Second {
+	if fsyncTook > 20*time.Second {
 		log.Info("Batch", "fsync", fsyncTook)
 	}
 	return nil

--- a/ethdb/mutation.go
+++ b/ethdb/mutation.go
@@ -138,6 +138,11 @@ func (m *mutation) Delete(bucket string, key []byte) error {
 	return nil
 }
 
+func (m *mutation) CommitAndBegin() error {
+	_, err := m.Commit()
+	return err
+}
+
 func (m *mutation) Commit() (uint64, error) {
 	if metrics.Enabled {
 		if m.puts.Size() >= m.db.IdealBatchSize() {

--- a/ethdb/object_db.go
+++ b/ethdb/object_db.go
@@ -361,7 +361,7 @@ func (db *ObjectDatabase) NewBatch() DbWithPendingMutations {
 }
 
 func (db *ObjectDatabase) Begin() (DbWithPendingMutations, error) {
-	batch := &TxDb{db: db, cursors: map[string]*LmdbCursor{}}
+	batch := &TxDb{db: db}
 	if err := batch.begin(nil); err != nil {
 		panic(err)
 	}

--- a/ethdb/tx_db.go
+++ b/ethdb/tx_db.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/c2h5oh/datasize"
 	"github.com/ledgerwatch/turbo-geth/common"
 	"github.com/ledgerwatch/turbo-geth/common/dbutils"
 	"github.com/ledgerwatch/turbo-geth/log"
@@ -196,7 +195,7 @@ func (m *TxDb) BatchSize() int {
 
 // IdealBatchSize defines the size of the data batches should ideally add in one write.
 func (m *TxDb) IdealBatchSize() int {
-	return int(1 * datasize.GB)
+	return m.db.IdealBatchSize()
 }
 
 func (m *TxDb) Walk(bucket string, startkey []byte, fixedbits int, walker func([]byte, []byte) (bool, error)) error {

--- a/ethdb/tx_db.go
+++ b/ethdb/tx_db.go
@@ -29,7 +29,7 @@ func (m *TxDb) Close() {
 }
 
 func (m *TxDb) Begin() (DbWithPendingMutations, error) {
-	batch := &TxDb{db: m.db, cursors: map[string]*LmdbCursor{}}
+	batch := &TxDb{db: m.db}
 	if err := batch.begin(m.Tx); err != nil {
 		return nil, err
 	}
@@ -65,6 +65,7 @@ func (m *TxDb) begin(parent Tx) error {
 	}
 	m.Tx = tx
 	m.ParentTx = parent
+	m.cursors = make(map[string]*LmdbCursor, 16)
 	for i := range dbutils.Buckets {
 		m.cursors[dbutils.Buckets[i]] = tx.Cursor(dbutils.Buckets[i]).(*LmdbCursor)
 		if err := m.cursors[dbutils.Buckets[i]].initCursor(); err != nil {


### PR DESCRIPTION
- Usage of TxDb means don't open read transaction every time you wanna read something from db. 
- On fast disk it speeding genesis sync 21hour -> 17hours
- But it a bit increases complexity of stage_exec - now there is db.Begin, then tx.NewBatch, then both of them need periodical commit
- I need your advise - maybe we can simplify code somehow? 


