### PR TITLE
KV: to support multiple databases and multiple set of buckets

### DIFF
--- a/common/dbutils/bucket.go
+++ b/common/dbutils/bucket.go
@@ -236,8 +236,7 @@ const (
 var BucketsCfg = map[string]*BucketConfigItem{}
 
 type BucketConfigItem struct {
-	IsDupSort        bool
-	IsDupFixed       bool
+	Flags            uint
 	DBI              lmdb.DBI
 	DupToLen         int
 	DupFromLen       int
@@ -246,32 +245,31 @@ type BucketConfigItem struct {
 }
 
 type dupSortConfigEntry struct {
-	Bucket           string
-	IsDupSort        bool
-	IsDupFixed       bool
-	DupFixedSize     int
-	FromLen          int
-	ToLen            int
-	CustomComparator CustomComparator
+	Flags               uint
+	Bucket              string
+	DupFixedSize        int
+	FromLen             int
+	ToLen               int
+	CustomDupComparator CustomComparator
 }
 
 var dupSortConfig = []dupSortConfigEntry{
 	{
-		Bucket:    CurrentStateBucket,
-		IsDupSort: true,
-		ToLen:     40,
-		FromLen:   72,
+		Bucket:  CurrentStateBucket,
+		Flags:   lmdb.DupSort,
+		ToLen:   40,
+		FromLen: 72,
 	},
 	{
-		Bucket:    PlainStateBucket,
-		IsDupSort: true,
-		ToLen:     28,
-		FromLen:   60,
+		Bucket:  PlainStateBucket,
+		Flags:   lmdb.DupSort,
+		ToLen:   28,
+		FromLen: 60,
 	},
 	{
-		Bucket:           IntermediateTrieHashBucket2,
-		IsDupSort:        true,
-		CustomComparator: DupCmpSuffix32,
+		Bucket:              IntermediateTrieHashBucket2,
+		Flags:               lmdb.DupSort,
+		CustomDupComparator: DupCmpSuffix32,
 	},
 }
 
@@ -299,7 +297,7 @@ func createBucketConfig(name string) *BucketConfigItem {
 
 		cfg.DupFromLen = dupCfg.FromLen
 		cfg.DupToLen = dupCfg.ToLen
-		cfg.IsDupSort = dupCfg.IsDupSort
+		cfg.Flags = dupCfg.Flags
 	}
 
 	return cfg

--- a/common/dbutils/bucket.go
+++ b/common/dbutils/bucket.go
@@ -103,8 +103,8 @@ var (
 	StorageChangeSetBucket = "SCS"
 
 	// some_prefix_of(hash_of_address_of_account) => hash_of_subtrie
-	IntermediateTrieHashBucket  = "iTh"
-	IntermediateTrieHashBucket2 = "iTh2"
+	IntermediateTrieHashBucket = "iTh"
+	//IntermediateTrieHashBucket2 = "iTh2"
 
 	// DatabaseInfoBucket is used to store information about data layout.
 	DatabaseInfoBucket = "DBINFO"
@@ -258,10 +258,10 @@ var BucketsConfigs = BucketsCfg{
 		DupToLen:   28,
 		DupFromLen: 60,
 	},
-	IntermediateTrieHashBucket2: {
-		Flags:               lmdb.DupSort,
-		CustomDupComparator: DupCmpSuffix32,
-	},
+	//IntermediateTrieHashBucket2: {
+	//	Flags:               lmdb.DupSort,
+	//	CustomDupComparator: DupCmpSuffix32,
+	//},
 }
 
 func init() {

--- a/common/dbutils/bucket.go
+++ b/common/dbutils/bucket.go
@@ -1,10 +1,10 @@
 package dbutils
 
 import (
-	"github.com/ledgerwatch/lmdb-go/lmdb"
 	"sort"
 	"strings"
 
+	"github.com/ledgerwatch/lmdb-go/lmdb"
 	"github.com/ledgerwatch/turbo-geth/metrics"
 )
 

--- a/ethdb/kv_abstract.go
+++ b/ethdb/kv_abstract.go
@@ -3,7 +3,9 @@ package ethdb
 import (
 	"context"
 	"errors"
+
 	"github.com/ledgerwatch/turbo-geth/common"
+	"github.com/ledgerwatch/turbo-geth/common/dbutils"
 )
 
 var (
@@ -17,6 +19,7 @@ type KV interface {
 	Close()
 
 	Begin(ctx context.Context, parent Tx, writable bool) (Tx, error)
+	AllBuckets() dbutils.BucketsCfg
 }
 
 type Tx interface {

--- a/ethdb/kv_abstract_test.go
+++ b/ethdb/kv_abstract_test.go
@@ -37,7 +37,7 @@ func TestManagedTx(t *testing.T) {
 				DupFromLen: 6,
 			},
 			bucket2: {
-				Flags: lmdb.DupSort,
+				Flags: 0,
 			},
 		}
 	})

--- a/ethdb/kv_bolt.go
+++ b/ethdb/kv_bolt.go
@@ -89,7 +89,11 @@ func (opts boltOpts) Open() (KV, error) {
 		bolt:    boltDB,
 		log:     log.New("bolt_db", opts.path),
 		wg:      &sync.WaitGroup{},
-		buckets: opts.bucketsCfg(dbutils.BucketsConfigs),
+		buckets: dbutils.BucketsCfg{},
+	}
+	customBuckets := opts.bucketsCfg(dbutils.BucketsConfigs)
+	for name, cfg := range customBuckets { // copy map to avoid changing global variable
+		db.buckets[name] = cfg
 	}
 
 	if !opts.Bolt.ReadOnly {

--- a/ethdb/kv_bolt.go
+++ b/ethdb/kv_bolt.go
@@ -34,8 +34,8 @@ type boltTx struct {
 type boltBucket struct {
 	tx      *boltTx
 	bolt    *bolt.Bucket
-	id      int
 	nameLen uint
+	name    string
 }
 
 type boltCursor struct {
@@ -205,7 +205,7 @@ func (tx *boltTx) Yield() {
 }
 
 func (tx *boltTx) Bucket(name string) boltBucket {
-	b := boltBucket{tx: tx, nameLen: uint(len(name)), id: dbutils.BucketsCfg[name].ID}
+	b := boltBucket{tx: tx, nameLen: uint(len(name)), name: name}
 	b.bolt = tx.bolt.Bucket([]byte(name))
 	return b
 }
@@ -226,11 +226,11 @@ func (tx *boltTx) BucketSize(name string) (uint64, error) {
 }
 
 func (b boltBucket) Clear() error {
-	err := b.tx.bolt.DeleteBucket([]byte(dbutils.Buckets[b.id]))
+	err := b.tx.bolt.DeleteBucket([]byte(b.name))
 	if err != nil {
 		return err
 	}
-	_, err = b.tx.bolt.CreateBucket([]byte(dbutils.Buckets[b.id]), false)
+	_, err = b.tx.bolt.CreateBucket([]byte(b.name), false)
 	if err != nil {
 		return err
 	}

--- a/ethdb/kv_migrator_test.go
+++ b/ethdb/kv_migrator_test.go
@@ -15,61 +15,60 @@ func TestBucketCRUD(t *testing.T) {
 	defer kv.Close()
 
 	ctx := context.Background()
-	if err := kv.Update(ctx, func(tx Tx) error {
-		normalBucket := dbutils.Buckets[15]
-		deprecatedBucket := dbutils.DeprecatedBuckets[0]
-		migrator, ok := tx.(BucketMigrator)
-		if !ok {
-			return nil
+	tx, err := kv.Begin(ctx, nil, true)
+	require.NoError(err)
+	defer tx.Rollback()
+
+	normalBucket := dbutils.Buckets[15]
+	deprecatedBucket := dbutils.DeprecatedBuckets[0]
+	migrator, ok := tx.(BucketMigrator)
+	if !ok {
+		return
+	}
+
+	// check thad buckets have unique DBI's
+	uniquness := map[lmdb.DBI]bool{}
+	castedKv := kv.(*LmdbKV)
+	for _, bucketCfg := range castedKv.buckets {
+		if bucketCfg.DBI == NonExistingDBI {
+			continue
 		}
+		_, ok := uniquness[bucketCfg.DBI]
+		require.False(ok)
+		uniquness[bucketCfg.DBI] = true
+	}
 
-		// check thad buckets have unique DBI's
-		uniquness := map[lmdb.DBI]bool{}
-		castedKv := kv.(*LmdbKV)
-		for _, bucketCfg := range castedKv.buckets {
-			if bucketCfg.DBI == NonExistingDBI {
-				continue
-			}
-			_, ok := uniquness[bucketCfg.DBI]
-			require.False(ok)
-			uniquness[bucketCfg.DBI] = true
+	require.True(migrator.ExistsBucket(normalBucket))
+	require.True(errors.Is(migrator.DropBucket(normalBucket), ErrAttemptToDeleteNonDeprecatedBucket))
+
+	require.False(migrator.ExistsBucket(deprecatedBucket))
+	require.NoError(migrator.CreateBucket(deprecatedBucket))
+	require.True(migrator.ExistsBucket(deprecatedBucket))
+
+	require.NoError(migrator.DropBucket(deprecatedBucket))
+	require.False(migrator.ExistsBucket(deprecatedBucket))
+
+	require.NoError(migrator.CreateBucket(deprecatedBucket))
+	require.True(migrator.ExistsBucket(deprecatedBucket))
+
+	err = tx.Cursor(deprecatedBucket).Put([]byte{1}, []byte{1})
+	require.NoError(err)
+	v, err := tx.Get(deprecatedBucket, []byte{1})
+	require.NoError(err)
+	require.Equal([]byte{1}, v)
+
+	buckets, err := migrator.ExistingBuckets()
+	require.NoError(err)
+	require.True(len(buckets) > 10)
+
+	// check thad buckets have unique DBI's
+	uniquness = map[lmdb.DBI]bool{}
+	for _, bucketCfg := range castedKv.buckets {
+		if bucketCfg.DBI == NonExistingDBI {
+			continue
 		}
-
-		require.True(migrator.ExistsBucket(normalBucket))
-		require.True(errors.Is(migrator.DropBucket(normalBucket), ErrAttemptToDeleteNonDeprecatedBucket))
-
-		require.False(migrator.ExistsBucket(deprecatedBucket))
-		require.NoError(migrator.CreateBucket(deprecatedBucket))
-		require.True(migrator.ExistsBucket(deprecatedBucket))
-
-		require.NoError(migrator.DropBucket(deprecatedBucket))
-		require.False(migrator.ExistsBucket(deprecatedBucket))
-
-		require.NoError(migrator.CreateBucket(deprecatedBucket))
-		require.True(migrator.ExistsBucket(deprecatedBucket))
-
-		err := tx.Cursor(deprecatedBucket).Put([]byte{1}, []byte{1})
-		require.NoError(err)
-		v, err := tx.Get(deprecatedBucket, []byte{1})
-		require.NoError(err)
-		require.Equal([]byte{1}, v)
-
-		buckets, err := migrator.ExistingBuckets()
-		require.NoError(err)
-		require.True(len(buckets) > 10)
-
-		// check thad buckets have unique DBI's
-		uniquness = map[lmdb.DBI]bool{}
-		for _, bucketCfg := range castedKv.buckets {
-			if bucketCfg.DBI == NonExistingDBI {
-				continue
-			}
-			_, ok := uniquness[bucketCfg.DBI]
-			require.False(ok)
-			uniquness[bucketCfg.DBI] = true
-		}
-		return nil
-	}); err != nil {
-		require.NoError(err)
+		_, ok := uniquness[bucketCfg.DBI]
+		require.False(ok)
+		uniquness[bucketCfg.DBI] = true
 	}
 }

--- a/ethdb/kv_migrator_test.go
+++ b/ethdb/kv_migrator_test.go
@@ -26,13 +26,13 @@ func TestBucketCRUD(t *testing.T) {
 		// check thad buckets have unique DBI's
 		uniquness := map[lmdb.DBI]bool{}
 		castedKv := kv.(*LmdbKV)
-		for _, dbi := range castedKv.buckets {
-			if dbi == NonExistingDBI {
+		for _, bucketCfg := range castedKv.buckets {
+			if bucketCfg.DBI == NonExistingDBI {
 				continue
 			}
-			_, ok := uniquness[dbi]
+			_, ok := uniquness[bucketCfg.DBI]
 			require.False(ok)
-			uniquness[dbi] = true
+			uniquness[bucketCfg.DBI] = true
 		}
 
 		require.True(migrator.ExistsBucket(normalBucket))
@@ -60,13 +60,13 @@ func TestBucketCRUD(t *testing.T) {
 
 		// check thad buckets have unique DBI's
 		uniquness = map[lmdb.DBI]bool{}
-		for _, dbi := range castedKv.buckets {
-			if dbi == NonExistingDBI {
+		for _, bucketCfg := range castedKv.buckets {
+			if bucketCfg.DBI == NonExistingDBI {
 				continue
 			}
-			_, ok := uniquness[dbi]
+			_, ok := uniquness[bucketCfg.DBI]
 			require.False(ok)
-			uniquness[dbi] = true
+			uniquness[bucketCfg.DBI] = true
 		}
 		return nil
 	}); err != nil {

--- a/ethdb/kv_remote.go
+++ b/ethdb/kv_remote.go
@@ -114,7 +114,11 @@ func (opts remoteOpts) Open() (KV, Backend, error) {
 		remoteKV: remote.NewKVClient(conn),
 		remoteDB: remote.NewDBClient(conn),
 		log:      log.New("remote_db", opts.DialAddress),
-		buckets:  opts.bucketsCfg(dbutils.BucketsConfigs),
+		buckets:  dbutils.BucketsCfg{},
+	}
+	customBuckets := opts.bucketsCfg(dbutils.BucketsConfigs)
+	for name, cfg := range customBuckets { // copy map to avoid changing global variable
+		db.buckets[name] = cfg
 	}
 
 	eth := &RemoteBackend{

--- a/ethdb/kv_remote.go
+++ b/ethdb/kv_remote.go
@@ -4,11 +4,11 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"github.com/ledgerwatch/turbo-geth/common/dbutils"
 	"net"
 	"time"
 
 	"github.com/ledgerwatch/turbo-geth/common"
+	"github.com/ledgerwatch/turbo-geth/common/dbutils"
 	"github.com/ledgerwatch/turbo-geth/ethdb/remote"
 	"github.com/ledgerwatch/turbo-geth/log"
 	"google.golang.org/grpc"

--- a/go.mod
+++ b/go.mod
@@ -45,7 +45,7 @@ require (
 	github.com/karalabe/usb v0.0.0-20190919080040-51dc0efba356
 	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/ledgerwatch/bolt v1.4.6-0.20200605053542-69293d8f1d33
-	github.com/ledgerwatch/lmdb-go v1.13.1-0.20200828125756-548cf1dd6933
+	github.com/ledgerwatch/lmdb-go v1.13.1-0.20200829020305-221d50cfedab
 	github.com/llgcode/draw2d v0.0.0-20180825133448-f52c8a71aff0
 	github.com/logrusorgru/aurora v2.0.3+incompatible
 	github.com/mattn/go-colorable v0.1.2

--- a/go.mod
+++ b/go.mod
@@ -45,7 +45,7 @@ require (
 	github.com/karalabe/usb v0.0.0-20190919080040-51dc0efba356
 	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/ledgerwatch/bolt v1.4.6-0.20200605053542-69293d8f1d33
-	github.com/ledgerwatch/lmdb-go v1.13.0
+	github.com/ledgerwatch/lmdb-go v1.13.1-0.20200828125756-548cf1dd6933
 	github.com/llgcode/draw2d v0.0.0-20180825133448-f52c8a71aff0
 	github.com/logrusorgru/aurora v2.0.3+incompatible
 	github.com/mattn/go-colorable v0.1.2

--- a/go.sum
+++ b/go.sum
@@ -218,10 +218,6 @@ github.com/kylelemons/godebug v1.1.0 h1:RPNrshWIDI6G2gRW9EHilWtl7Z6Sb1BR0xunSBf0
 github.com/kylelemons/godebug v1.1.0/go.mod h1:9/0rRGxNHcop5bhtWyNeEfOS8JIWk580+fNqagV/RAw=
 github.com/ledgerwatch/bolt v1.4.6-0.20200605053542-69293d8f1d33 h1:8e99Kuxoi+RnWCO8zD+ftp+rIuh9AYkZDRPmO8Xgp5k=
 github.com/ledgerwatch/bolt v1.4.6-0.20200605053542-69293d8f1d33/go.mod h1:4frpcWo7Gjizry2yhNN3T4FK0FrgE/AAUlHvKHC0Dao=
-github.com/ledgerwatch/lmdb-go v1.13.0 h1:iyLPkF2i+zym+lbGMqJrrD0yMy8uCWzrO90fOBxaEtc=
-github.com/ledgerwatch/lmdb-go v1.13.0/go.mod h1:NKRpCxksoTQPyxsUcBiVOe0135uqnJsnf6cElxmOL0o=
-github.com/ledgerwatch/lmdb-go v1.13.1-0.20200828125756-548cf1dd6933 h1:7YR6rLj5BBYPvV9rZGvV1orCwQYM8X2crTxJcsS/AYs=
-github.com/ledgerwatch/lmdb-go v1.13.1-0.20200828125756-548cf1dd6933/go.mod h1:NKRpCxksoTQPyxsUcBiVOe0135uqnJsnf6cElxmOL0o=
 github.com/ledgerwatch/lmdb-go v1.13.1-0.20200829020305-221d50cfedab h1:0GaFl88nDLj9Z8L8iE+2l0UHTEJufpyVHGYuHgRNC8k=
 github.com/ledgerwatch/lmdb-go v1.13.1-0.20200829020305-221d50cfedab/go.mod h1:NKRpCxksoTQPyxsUcBiVOe0135uqnJsnf6cElxmOL0o=
 github.com/leodido/go-urn v1.2.0 h1:hpXL4XnriNwQ/ABnpepYM/1vCLWNDfUNts8dX3xTG6Y=

--- a/go.sum
+++ b/go.sum
@@ -220,6 +220,8 @@ github.com/ledgerwatch/bolt v1.4.6-0.20200605053542-69293d8f1d33 h1:8e99Kuxoi+Rn
 github.com/ledgerwatch/bolt v1.4.6-0.20200605053542-69293d8f1d33/go.mod h1:4frpcWo7Gjizry2yhNN3T4FK0FrgE/AAUlHvKHC0Dao=
 github.com/ledgerwatch/lmdb-go v1.13.0 h1:iyLPkF2i+zym+lbGMqJrrD0yMy8uCWzrO90fOBxaEtc=
 github.com/ledgerwatch/lmdb-go v1.13.0/go.mod h1:NKRpCxksoTQPyxsUcBiVOe0135uqnJsnf6cElxmOL0o=
+github.com/ledgerwatch/lmdb-go v1.13.1-0.20200828125756-548cf1dd6933 h1:7YR6rLj5BBYPvV9rZGvV1orCwQYM8X2crTxJcsS/AYs=
+github.com/ledgerwatch/lmdb-go v1.13.1-0.20200828125756-548cf1dd6933/go.mod h1:NKRpCxksoTQPyxsUcBiVOe0135uqnJsnf6cElxmOL0o=
 github.com/leodido/go-urn v1.2.0 h1:hpXL4XnriNwQ/ABnpepYM/1vCLWNDfUNts8dX3xTG6Y=
 github.com/leodido/go-urn v1.2.0/go.mod h1:+8+nEpDfqqsY+g338gtMEUOtuK+4dEMhiQEgxpxOKII=
 github.com/llgcode/draw2d v0.0.0-20180825133448-f52c8a71aff0 h1:2vp6ESimuT8pCuZHThVyV0hlfa9oPL06HnGCL9pbUgc=

--- a/go.sum
+++ b/go.sum
@@ -222,6 +222,8 @@ github.com/ledgerwatch/lmdb-go v1.13.0 h1:iyLPkF2i+zym+lbGMqJrrD0yMy8uCWzrO90fOB
 github.com/ledgerwatch/lmdb-go v1.13.0/go.mod h1:NKRpCxksoTQPyxsUcBiVOe0135uqnJsnf6cElxmOL0o=
 github.com/ledgerwatch/lmdb-go v1.13.1-0.20200828125756-548cf1dd6933 h1:7YR6rLj5BBYPvV9rZGvV1orCwQYM8X2crTxJcsS/AYs=
 github.com/ledgerwatch/lmdb-go v1.13.1-0.20200828125756-548cf1dd6933/go.mod h1:NKRpCxksoTQPyxsUcBiVOe0135uqnJsnf6cElxmOL0o=
+github.com/ledgerwatch/lmdb-go v1.13.1-0.20200829020305-221d50cfedab h1:0GaFl88nDLj9Z8L8iE+2l0UHTEJufpyVHGYuHgRNC8k=
+github.com/ledgerwatch/lmdb-go v1.13.1-0.20200829020305-221d50cfedab/go.mod h1:NKRpCxksoTQPyxsUcBiVOe0135uqnJsnf6cElxmOL0o=
 github.com/leodido/go-urn v1.2.0 h1:hpXL4XnriNwQ/ABnpepYM/1vCLWNDfUNts8dX3xTG6Y=
 github.com/leodido/go-urn v1.2.0/go.mod h1:+8+nEpDfqqsY+g338gtMEUOtuK+4dEMhiQEgxpxOKII=
 github.com/llgcode/draw2d v0.0.0-20180825133448-f52c8a71aff0 h1:2vp6ESimuT8pCuZHThVyV0hlfa9oPL06HnGCL9pbUgc=


### PR DESCRIPTION
Now I use global variables in file bucket.go to store list of buckets and their configs.
But now guys working on adding SnapshotDb - which need separated list of buckets and maybe configs will not match. 
This PR is refactoring to use bucket.go only as a Defaults settings, but defaults can be replaced before db open. 
Also defaults are immutable now. 
