### PR TITLE
Prefetch block bodies

### DIFF
--- a/eth/downloader/downloader_stagedsync.go
+++ b/eth/downloader/downloader_stagedsync.go
@@ -108,7 +108,7 @@ func (d *Downloader) SpawnBodyDownloadStage(
 	}
 	if prefetchedHashes < hashCount {
 		log.Info("Downloading block bodies", "count", hashCount-prefetchedHashes)
-		from := origin + 1
+		from := origin + 1 + uint64(prefetchedHashes)
 		d.queue.Prepare(from, d.getMode())
 		d.queue.ScheduleBodies(from, hashes[prefetchedHashes:hashCount], headers)
 		to := from + uint64(hashCount)

--- a/eth/downloader/downloader_stagedsync.go
+++ b/eth/downloader/downloader_stagedsync.go
@@ -107,7 +107,7 @@ func (d *Downloader) SpawnBodyDownloadStage(
 		}
 	}
 	if prefetchedHashes > 0 {
-		fmt.Println("downloaded until block", origin+uint64(prefetchedHashes))
+		log.Debug("Used prefetched bodies", "count", prefetchedHashes, "to", origin+uint64(prefetchedHashes))
 		return true, nil
 	}
 

--- a/eth/downloader/downloader_stagedsync.go
+++ b/eth/downloader/downloader_stagedsync.go
@@ -155,7 +155,6 @@ func (d *Downloader) processBodiesStage(to uint64) error {
 		if len(results) == 0 {
 			return nil
 		}
-		fmt.Println("queue results")
 		lastNumber, err := d.importBlockResults(results, false /* execute */)
 		if err != nil {
 			return err

--- a/eth/downloader/downloader_stagedsync.go
+++ b/eth/downloader/downloader_stagedsync.go
@@ -104,7 +104,7 @@ func (d *Downloader) SpawnBodyDownloadStage(
 		}
 	}
 	if prefetchedHashes < hashCount {
-		log.Info("downloading block bodies", "count", hashCount-prefetchedHashes)
+		log.Info("Downloading block bodies", "count", hashCount-prefetchedHashes)
 		from := origin + 1
 		d.queue.Prepare(from, d.getMode())
 		d.queue.ScheduleBodies(from, hashes[prefetchedHashes:hashCount], headers)
@@ -127,7 +127,7 @@ func (d *Downloader) SpawnBodyDownloadStage(
 			return false, err
 		}
 	} else {
-		log.Debug("everything is prefetched, nothing to download")
+		log.Debug("Everything is prefetched, nothing to download")
 	}
 	return true, nil
 }

--- a/eth/downloader/downloader_stagedsync.go
+++ b/eth/downloader/downloader_stagedsync.go
@@ -97,7 +97,10 @@ func (d *Downloader) SpawnBodyDownloadStage(
 		if block := prefetchedBlocks.Pop(h); block != nil {
 			fr := fetchResultFromBlock(block)
 			execute := false
-			d.importBlockResults([]*fetchResult{fr}, execute)
+			_, err := d.importBlockResults([]*fetchResult{fr}, execute)
+			if err != nil {
+				return false, err
+			}
 			prefetchedHashes++
 		} else {
 			break

--- a/eth/downloader/downloader_stagedsync_test.go
+++ b/eth/downloader/downloader_stagedsync_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/ledgerwatch/turbo-geth/core/state"
 	"github.com/ledgerwatch/turbo-geth/core/types"
 	"github.com/ledgerwatch/turbo-geth/core/vm"
+	"github.com/ledgerwatch/turbo-geth/eth/stagedsync"
 	"github.com/ledgerwatch/turbo-geth/ethdb"
 	"github.com/ledgerwatch/turbo-geth/event"
 	"github.com/ledgerwatch/turbo-geth/log"
@@ -41,6 +42,7 @@ func newStagedSyncTester() (*stagedSyncTester, func()) {
 	rawdb.WriteTd(tester.db, tester.genesis.Hash(), tester.genesis.NumberU64(), tester.genesis.Difficulty())
 	rawdb.WriteBlock(context.Background(), tester.db, testGenesis)
 	tester.downloader = New(uint64(StagedSync), tester.db, new(event.TypeMux), params.TestChainConfig, tester, nil, tester.dropPeer, ethdb.DefaultStorageMode)
+	tester.downloader.SetStagedSync(stagedsync.New())
 	clear := func() {
 		tester.db.Close()
 	}

--- a/eth/handler.go
+++ b/eth/handler.go
@@ -859,7 +859,7 @@ func (pm *ProtocolManager) handleMsg(p *peer) error {
 				return err
 			}
 		} else {
-			log.Debug("adding block to staged sync prefetch",
+			log.Debug("Adding block to staged sync prefetch",
 				"number", request.Block.NumberU64,
 				"hash", request.Block.Hash().Hex(),
 			)

--- a/eth/handler.go
+++ b/eth/handler.go
@@ -858,6 +858,9 @@ func (pm *ProtocolManager) handleMsg(p *peer) error {
 			if err := pm.blockFetcher.Enqueue(p.id, request.Block); err != nil {
 				return err
 			}
+		} else {
+			fmt.Println("IGORM: adding block to prefetch", request.Block.NumberU64(), request.Block.Hash().Hex())
+			pm.stagedSync.PrefetchedBlocks.Add(request.Block)
 		}
 
 		// Assuming the block is importable by the peer, but possibly not yet done so,

--- a/eth/handler.go
+++ b/eth/handler.go
@@ -859,7 +859,10 @@ func (pm *ProtocolManager) handleMsg(p *peer) error {
 				return err
 			}
 		} else {
-			fmt.Println("IGORM: adding block to prefetch", request.Block.NumberU64(), request.Block.Hash().Hex())
+			log.Debug("adding block to staged sync prefetch",
+				"number", request.Block.NumberU64,
+				"hash", request.Block.Hash().Hex(),
+			)
 			pm.stagedSync.PrefetchedBlocks.Add(request.Block)
 		}
 

--- a/eth/stagedsync/prefetched_blocks.go
+++ b/eth/stagedsync/prefetched_blocks.go
@@ -12,7 +12,7 @@ type PrefetchedBlocks struct {
 }
 
 func NewPrefetchedBlocks() *PrefetchedBlocks {
-	cache, err := lru.New(10000)
+	cache, err := lru.New(1000)
 	if err != nil {
 		panic("error creating prefetching cache for blocks")
 	}

--- a/eth/stagedsync/prefetched_blocks.go
+++ b/eth/stagedsync/prefetched_blocks.go
@@ -1,0 +1,35 @@
+package stagedsync
+
+import (
+	"fmt"
+	"sync"
+
+	"github.com/ledgerwatch/turbo-geth/common"
+	"github.com/ledgerwatch/turbo-geth/core/types"
+)
+
+type PrefetchedBlocks struct {
+	blocks *sync.Map
+}
+
+func NewPrefetchedBlocks() *PrefetchedBlocks {
+	return &PrefetchedBlocks{blocks: &sync.Map{}}
+}
+
+func (pb *PrefetchedBlocks) GetBlockByHash(hash common.Hash) *types.Block {
+	fmt.Println("PrefetchedBlocks.GetBlockByHash", hash.Hex())
+	if val, ok := pb.blocks.Load(hash); ok && val != nil {
+		if block, ok := val.(*types.Block); ok {
+			return block
+		}
+	}
+	return nil
+}
+
+func (pb *PrefetchedBlocks) Add(b *types.Block) {
+	if b == nil {
+		return
+	}
+	hash := b.Hash()
+	pb.blocks.Store(hash, b)
+}

--- a/eth/stagedsync/stage_bodies.go
+++ b/eth/stagedsync/stage_bodies.go
@@ -6,8 +6,8 @@ import (
 	"github.com/ledgerwatch/turbo-geth/ethdb"
 )
 
-func spawnBodyDownloadStage(s *StageState, u Unwinder, d DownloaderGlue, pid string) error {
-	cont, err := d.SpawnBodyDownloadStage(pid, s, u)
+func spawnBodyDownloadStage(s *StageState, u Unwinder, d DownloaderGlue, pid string, pb *PrefetchedBlocks) error {
+	cont, err := d.SpawnBodyDownloadStage(pid, s, u, pb)
 	if err != nil {
 		return err
 	}

--- a/eth/stagedsync/stagedsync.go
+++ b/eth/stagedsync/stagedsync.go
@@ -15,13 +15,16 @@ import (
 const prof = false // whether to profile
 
 type StagedSync struct {
+	PrefetchedBlocks *PrefetchedBlocks
 }
 
 func New() *StagedSync {
-	return &StagedSync{}
+	return &StagedSync{
+		PrefetchedBlocks: NewPrefetchedBlocks(),
+	}
 }
 
-func (*StagedSync) Prepare(
+func (stagedSync *StagedSync) Prepare(
 	d DownloaderGlue,
 	chainConfig *params.ChainConfig,
 	chainContext core.ChainContext,
@@ -64,7 +67,7 @@ func (*StagedSync) Prepare(
 			ID:          stages.Bodies,
 			Description: "Download block bodies",
 			ExecFunc: func(s *StageState, u Unwinder) error {
-				return spawnBodyDownloadStage(s, u, d, pid)
+				return spawnBodyDownloadStage(s, u, d, pid, stagedSync.PrefetchedBlocks)
 			},
 			UnwindFunc: func(u *UnwindState, s *StageState) error {
 				return unwindBodyDownloadStage(u, db)

--- a/eth/stagedsync/types.go
+++ b/eth/stagedsync/types.go
@@ -2,5 +2,5 @@ package stagedsync
 
 type DownloaderGlue interface {
 	SpawnHeaderDownloadStage([]func() error, *StageState, Unwinder) error
-	SpawnBodyDownloadStage(string, *StageState, Unwinder) (bool, error)
+	SpawnBodyDownloadStage(string, *StageState, Unwinder, *PrefetchedBlocks) (bool, error)
 }


### PR DESCRIPTION
When there is a broadcast about a new block, we add this to a fixed-size `lru` cache, so it could be used on stage 3.

It is a very simple and naive implementation and affects only block bodies at the moment.

It also does not affect the case when the block body is broadcasted before it is actually downloaded that might be fixed in the following PRs.