### PR TITLE
Use Append for changesets and receipts

### DIFF
--- a/cmd/integration/commands/reset_state.go
+++ b/cmd/integration/commands/reset_state.go
@@ -3,12 +3,13 @@ package commands
 import (
 	"context"
 	"fmt"
-	"github.com/ledgerwatch/turbo-geth/cmd/utils"
 	"os"
 	"path"
 	"sync"
 	"text/tabwriter"
 	"time"
+
+	"github.com/ledgerwatch/turbo-geth/cmd/utils"
 
 	"github.com/ledgerwatch/lmdb-go/lmdb"
 	"github.com/ledgerwatch/turbo-geth/common"
@@ -139,6 +140,7 @@ func resetExec(db *ethdb.ObjectDatabase) error {
 		dbutils.PlainAccountChangeSetBucket,
 		dbutils.PlainStorageChangeSetBucket,
 		dbutils.PlainContractCodeBucket,
+		dbutils.BlockReceiptsPrefix,
 		dbutils.IncarnationMapBucket,
 		dbutils.CodeBucket,
 	); err != nil {

--- a/core/state/plain_state_writer.go
+++ b/core/state/plain_state_writer.go
@@ -158,7 +158,7 @@ func (w *PlainStateWriter) WriteChangeSets() error {
 		return err
 	}
 	key := dbutils.EncodeTimestamp(w.blockNumber)
-	if err = db.Put(dbutils.PlainAccountChangeSetBucket, key, accountSerialised); err != nil {
+	if err = db.Append(dbutils.PlainAccountChangeSetBucket, key, accountSerialised); err != nil {
 		return err
 	}
 	storageChanges, err := w.csw.GetStorageChanges()
@@ -171,7 +171,7 @@ func (w *PlainStateWriter) WriteChangeSets() error {
 		if err != nil {
 			return err
 		}
-		if err = db.Put(dbutils.PlainStorageChangeSetBucket, key, storageSerialized); err != nil {
+		if err = db.Append(dbutils.PlainStorageChangeSetBucket, key, storageSerialized); err != nil {
 			return err
 		}
 	}

--- a/eth/stagedsync/stage_execute.go
+++ b/eth/stagedsync/stage_execute.go
@@ -244,7 +244,7 @@ func UnwindExecutionStage(u *UnwindState, s *StageState, stateDB ethdb.Database,
 		}
 	}
 
-	if err = stateDB.Walk(dbutils.PlainAccountChangeSetBucket, dbutils.EncodeBlockNumber(u.UnwindPoint+1), 0, func(k, _ []byte) (bool, error) {
+	if err = stateDB.Walk(dbutils.PlainAccountChangeSetBucket, dbutils.EncodeTimestamp(u.UnwindPoint+1), 0, func(k, _ []byte) (bool, error) {
 		if err1 := batch.Delete(dbutils.PlainAccountChangeSetBucket, common.CopyBytes(k)); err1 != nil {
 			return false, fmt.Errorf("unwind Execution: delete account changesets: %v", err1)
 		}
@@ -252,7 +252,7 @@ func UnwindExecutionStage(u *UnwindState, s *StageState, stateDB ethdb.Database,
 	}); err != nil {
 		return fmt.Errorf("unwind Execution: walking account changesets: %v", err)
 	}
-	if err = stateDB.Walk(dbutils.PlainStorageChangeSetBucket, dbutils.EncodeBlockNumber(u.UnwindPoint+1), 0, func(k, _ []byte) (bool, error) {
+	if err = stateDB.Walk(dbutils.PlainStorageChangeSetBucket, dbutils.EncodeTimestamp(u.UnwindPoint+1), 0, func(k, _ []byte) (bool, error) {
 		if err1 := batch.Delete(dbutils.PlainStorageChangeSetBucket, common.CopyBytes(k)); err1 != nil {
 			return false, fmt.Errorf("unwind Execution: delete storage changesets: %v", err1)
 		}

--- a/eth/stagedsync/stage_execute.go
+++ b/eth/stagedsync/stage_execute.go
@@ -122,7 +122,7 @@ func SpawnExecuteBlocksStage(s *StageState, stateDB ethdb.Database, chainConfig 
 				return fmt.Errorf("encode block receipts for block %d: %v", block.NumberU64(), err)
 			}
 			// Store the flattened receipt slice
-			if err = tx.Put(dbutils.BlockReceiptsPrefix, dbutils.BlockReceiptsKey(block.NumberU64(), block.Hash()), bytes); err != nil {
+			if err = tx.Append(dbutils.BlockReceiptsPrefix, dbutils.BlockReceiptsKey(block.NumberU64(), block.Hash()), bytes); err != nil {
 				return fmt.Errorf("writing receipts for block %d: %v", block.NumberU64(), err)
 			}
 		}

--- a/eth/stagedsync/stage_execute.go
+++ b/eth/stagedsync/stage_execute.go
@@ -117,12 +117,12 @@ func SpawnExecuteBlocksStage(s *StageState, stateDB ethdb.Database, chainConfig 
 			for i, receipt := range receipts {
 				storageReceipts[i] = (*types.ReceiptForStorage)(receipt)
 			}
-			bytes, err := rlp.EncodeToBytes(storageReceipts)
-			if err != nil {
-				log.Crit("Failed to encode block receipts", "err", err)
+			var bytes []byte
+			if bytes, err = rlp.EncodeToBytes(storageReceipts); err != nil {
+				return fmt.Errorf("encode block receipts for block %d: %v", block.NumberU64(), err)
 			}
 			// Store the flattened receipt slice
-			if err := tx.Append(dbutils.BlockReceiptsPrefix, dbutils.BlockReceiptsKey(block.NumberU64(), block.Hash()), bytes); err != nil {
+			if err = tx.Append(dbutils.BlockReceiptsPrefix, dbutils.BlockReceiptsKey(block.NumberU64(), block.Hash()), bytes); err != nil {
 				return fmt.Errorf("writing receipts for block %d: %v", block.NumberU64(), err)
 			}
 		}

--- a/eth/stagedsync/stage_execute.go
+++ b/eth/stagedsync/stage_execute.go
@@ -260,13 +260,15 @@ func UnwindExecutionStage(u *UnwindState, s *StageState, stateDB ethdb.Database,
 	}); err != nil {
 		return fmt.Errorf("unwind Execution: walking storage changesets: %v", err)
 	}
-	if err = stateDB.Walk(dbutils.BlockReceiptsPrefix, dbutils.EncodeBlockNumber(u.UnwindPoint+1), 0, func(k, _ []byte) (bool, error) {
-		if err1 := batch.Delete(dbutils.BlockReceiptsPrefix, common.CopyBytes(k)); err1 != nil {
-			return false, fmt.Errorf("unwind Execution: delete receipts: %v", err1)
+	if writeReceipts {
+		if err = stateDB.Walk(dbutils.BlockReceiptsPrefix, dbutils.EncodeBlockNumber(u.UnwindPoint+1), 0, func(k, _ []byte) (bool, error) {
+			if err1 := batch.Delete(dbutils.BlockReceiptsPrefix, common.CopyBytes(k)); err1 != nil {
+				return false, fmt.Errorf("unwind Execution: delete receipts: %v", err1)
+			}
+			return true, nil
+		}); err != nil {
+			return fmt.Errorf("unwind Execution: walking receipts: %v", err)
 		}
-		return true, nil
-	}); err != nil {
-		return fmt.Errorf("unwind Execution: walking receipts: %v", err)
 	}
 
 	if err = u.Done(batch); err != nil {

--- a/eth/stagedsync/stage_execute.go
+++ b/eth/stagedsync/stage_execute.go
@@ -244,7 +244,7 @@ func UnwindExecutionStage(u *UnwindState, s *StageState, stateDB ethdb.Database,
 		}
 	}
 
-	if err := stateDB.Walk(dbutils.PlainAccountChangeSetBucket, dbutils.EncodeBlockNumber(u.UnwindPoint+1), 0, func(k, _ []byte) (bool, error) {
+	if err = stateDB.Walk(dbutils.PlainAccountChangeSetBucket, dbutils.EncodeBlockNumber(u.UnwindPoint+1), 0, func(k, _ []byte) (bool, error) {
 		if err1 := batch.Delete(dbutils.PlainAccountChangeSetBucket, common.CopyBytes(k)); err1 != nil {
 			return false, fmt.Errorf("unwind Execution: delete account changesets: %v", err1)
 		}
@@ -252,7 +252,7 @@ func UnwindExecutionStage(u *UnwindState, s *StageState, stateDB ethdb.Database,
 	}); err != nil {
 		return fmt.Errorf("unwind Execution: walking account changesets: %v", err)
 	}
-	if err := stateDB.Walk(dbutils.PlainStorageChangeSetBucket, dbutils.EncodeBlockNumber(u.UnwindPoint+1), 0, func(k, _ []byte) (bool, error) {
+	if err = stateDB.Walk(dbutils.PlainStorageChangeSetBucket, dbutils.EncodeBlockNumber(u.UnwindPoint+1), 0, func(k, _ []byte) (bool, error) {
 		if err1 := batch.Delete(dbutils.PlainStorageChangeSetBucket, common.CopyBytes(k)); err1 != nil {
 			return false, fmt.Errorf("unwind Execution: delete storage changesets: %v", err1)
 		}
@@ -260,7 +260,7 @@ func UnwindExecutionStage(u *UnwindState, s *StageState, stateDB ethdb.Database,
 	}); err != nil {
 		return fmt.Errorf("unwind Execution: walking storage changesets: %v", err)
 	}
-	if err := stateDB.Walk(dbutils.BlockReceiptsPrefix, dbutils.EncodeBlockNumber(u.UnwindPoint+1), 0, func(k, _ []byte) (bool, error) {
+	if err = stateDB.Walk(dbutils.BlockReceiptsPrefix, dbutils.EncodeBlockNumber(u.UnwindPoint+1), 0, func(k, _ []byte) (bool, error) {
 		if err1 := batch.Delete(dbutils.BlockReceiptsPrefix, common.CopyBytes(k)); err1 != nil {
 			return false, fmt.Errorf("unwind Execution: delete receipts: %v", err1)
 		}

--- a/eth/stagedsync/testutil.go
+++ b/eth/stagedsync/testutil.go
@@ -130,12 +130,12 @@ func generateBlocks(t *testing.T, from uint64, numberOfBlocks uint64, stateWrite
 					t.Fatal(err)
 				}
 			}
-			if blockNumber >= from {
-				if err := blockWriter.WriteChangeSets(); err != nil {
-					t.Fatal(err)
-				}
-			}
 			testAccounts[i] = newAcc
+		}
+		if blockNumber >= from {
+			if err := blockWriter.WriteChangeSets(); err != nil {
+				t.Fatal(err)
+			}
 		}
 	}
 }

--- a/ethdb/interface.go
+++ b/ethdb/interface.go
@@ -102,6 +102,7 @@ type Database interface {
 	// FIXME: implement support if needed
 	Ancients() (uint64, error)
 	TruncateAncients(items uint64) error
+	Append(bucket string, key, value []byte) error
 }
 
 // MinDatabase is a minimalistic version of the Database interface.

--- a/ethdb/mutation.go
+++ b/ethdb/mutation.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	"github.com/c2h5oh/datasize"
-
 	"github.com/ledgerwatch/turbo-geth/common"
 	"github.com/ledgerwatch/turbo-geth/metrics"
 )

--- a/ethdb/mutation.go
+++ b/ethdb/mutation.go
@@ -3,11 +3,12 @@ package ethdb
 import (
 	"context"
 	"fmt"
-	"github.com/c2h5oh/datasize"
 	"sort"
 	"sync"
 	"sync/atomic"
 	"time"
+
+	"github.com/c2h5oh/datasize"
 
 	"github.com/ledgerwatch/turbo-geth/common"
 	"github.com/ledgerwatch/turbo-geth/metrics"
@@ -92,6 +93,14 @@ func (m *mutation) DiskSize(ctx context.Context) (common.StorageSize, error) {
 }
 
 func (m *mutation) Put(bucket string, key []byte, value []byte) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	m.puts.set(bucket, key, value)
+	return nil
+}
+
+func (m *mutation) Append(bucket string, key []byte, value []byte) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 

--- a/ethdb/object_db.go
+++ b/ethdb/object_db.go
@@ -95,6 +95,18 @@ func (db *ObjectDatabase) Put(bucket string, key []byte, value []byte) error {
 	return err
 }
 
+// Append appends a single entry to the end of the bucket.
+func (db *ObjectDatabase) Append(bucket string, key []byte, value []byte) error {
+	if metrics.Enabled {
+		defer dbPutTimer.UpdateSince(time.Now())
+	}
+
+	err := db.kv.Update(context.Background(), func(tx Tx) error {
+		return tx.Cursor(bucket).Append(key, value)
+	})
+	return err
+}
+
 // MultiPut - requirements: input must be sorted and without duplicates
 func (db *ObjectDatabase) MultiPut(tuples ...[]byte) (uint64, error) {
 	err := db.kv.Update(context.Background(), func(tx Tx) error {


### PR DESCRIPTION
I think we might have introduced performance regression by switching `Append` to `Put` for changesets and Receipts. This is to test if we did