### PR TITLE
Better support for custom comparators

### DIFF
--- a/common/dbutils/bucket.go
+++ b/common/dbutils/bucket.go
@@ -1,6 +1,7 @@
 package dbutils
 
 import (
+	"bytes"
 	"sort"
 	"strings"
 
@@ -222,8 +223,20 @@ var DeprecatedBuckets = []string{
 type CustomComparator string
 
 const (
+	DefaultCmp     CustomComparator = ""
 	DupCmpSuffix32 CustomComparator = "dup_cmp_suffix32"
 )
+
+type CmpFunc func(k1, k2, v1, v2 []byte) int
+
+func DefaultCmpFunc(k1, k2, v1, v2 []byte) int { return bytes.Compare(k1, k2) }
+func DefaultDupCmpFunc(k1, k2, v1, v2 []byte) int {
+	cmp := bytes.Compare(k1, k2)
+	if cmp == 0 {
+		cmp = bytes.Compare(v1, v2)
+	}
+	return cmp
+}
 
 type BucketsCfg map[string]BucketConfigItem
 type Bucket string
@@ -261,10 +274,9 @@ var BucketsConfigs = BucketsCfg{
 		DupFromLen:                60,
 		DupToLen:                  28,
 	},
-	//IntermediateTrieHashBucket2: {
-	//	Flags:               		lmdb.DupSort,
-	//	CustomDupComparator:	 	DupCmpSuffix32,
-	//	AutoDupSortKeysConversion:  false,
+	//IntermediateTrieHashBucket: {
+	//	Flags:               lmdb.DupSort,
+	//	CustomDupComparator: DupCmpSuffix32,
 	//},
 }
 

--- a/common/etl/buffers.go
+++ b/common/etl/buffers.go
@@ -100,6 +100,7 @@ func (b *sortableBuffer) Reset() {
 	b.size = 0
 }
 func (b *sortableBuffer) Sort() {
+	defer func(t time.Time) { fmt.Printf("buffers.go:103: %s\n", time.Since(t)) }(time.Now())
 	sort.Stable(b)
 }
 

--- a/common/etl/buffers.go
+++ b/common/etl/buffers.go
@@ -1,6 +1,7 @@
 package etl
 
 import (
+	"bytes"
 	"fmt"
 	"sort"
 	"strconv"
@@ -50,7 +51,6 @@ func NewSortableBuffer(bufferOptimalSize int) *sortableBuffer {
 		entries:     make([]sortableBufferEntry, 0),
 		size:        0,
 		optimalSize: bufferOptimalSize,
-		comparator:  dbutils.DefaultCmpFunc,
 	}
 }
 
@@ -80,6 +80,9 @@ func (b *sortableBuffer) SetComparator(cmp dbutils.CmpFunc) {
 }
 
 func (b *sortableBuffer) Less(i, j int) bool {
+	if b.comparator == nil {
+		return bytes.Compare(b.entries[i].key, b.entries[j].key) < 0
+	}
 	return b.comparator(b.entries[i].key, b.entries[j].key, b.entries[i].value, b.entries[j].value) < 0
 	//return bytes.Compare(b.entries[i].key, b.entries[j].key) < 0
 }
@@ -97,7 +100,6 @@ func (b *sortableBuffer) Reset() {
 	b.size = 0
 }
 func (b *sortableBuffer) Sort() {
-	defer func(t time.Time) { fmt.Printf("buffers.go:100: %s\n", time.Since(t)) }(time.Now())
 	sort.Stable(b)
 }
 

--- a/common/etl/buffers.go
+++ b/common/etl/buffers.go
@@ -1,8 +1,10 @@
 package etl
 
 import (
+	"fmt"
 	"sort"
 	"strconv"
+	"time"
 
 	"github.com/ledgerwatch/turbo-geth/common"
 	"github.com/ledgerwatch/turbo-geth/common/dbutils"
@@ -95,6 +97,7 @@ func (b *sortableBuffer) Reset() {
 	b.size = 0
 }
 func (b *sortableBuffer) Sort() {
+	defer func(t time.Time) { fmt.Printf("buffers.go:100: %s\n", time.Since(t)) }(time.Now())
 	sort.Stable(b)
 }
 
@@ -149,6 +152,7 @@ func (b *appendSortableBuffer) Sort() {
 	for i := range b.entries {
 		b.sortedBuf = append(b.sortedBuf, sortableBufferEntry{key: []byte(i), value: b.entries[i]})
 	}
+	defer func(t time.Time) { fmt.Printf("buffers.go:155: %s\n", time.Since(t)) }(time.Now())
 	sort.Stable(b)
 }
 
@@ -225,6 +229,7 @@ func (b *oldestEntrySortableBuffer) Sort() {
 	for k, v := range b.entries {
 		b.sortedBuf = append(b.sortedBuf, sortableBufferEntry{key: []byte(k), value: v})
 	}
+	defer func(t time.Time) { fmt.Printf("buffers.go:232: %s\n", time.Since(t)) }(time.Now())
 	sort.Stable(b)
 }
 
@@ -240,6 +245,7 @@ func (b *oldestEntrySortableBuffer) Swap(i, j int) {
 func (b *oldestEntrySortableBuffer) Get(i int) sortableBufferEntry {
 	return b.sortedBuf[i]
 }
+
 func (b *oldestEntrySortableBuffer) Reset() {
 	b.sortedBuf = nil
 	b.entries = make(map[string][]byte)

--- a/ethdb/kv_abstract.go
+++ b/ethdb/kv_abstract.go
@@ -76,6 +76,10 @@ type Tx interface {
 	Rollback()                        // Rollback - abandon all the operations of the transaction instead of saving them.
 
 	BucketSize(name string) (uint64, error)
+
+	Comparator(bucket string) dbutils.CmpFunc
+	Cmp(bucket string, a, b []byte) int
+	DCmp(bucket string, a, b []byte) int
 }
 
 // Interface used for buckets migration, don't use it in usual app code
@@ -126,17 +130,23 @@ type Cursor interface {
 	// Reserve()
 
 	// PutCurrent - replace the item at the current cursor position.
+	// Warning! this method doesn't check order of keys, it means you can insert key in wrong place of bucket
 	//	The key parameter must still be provided, and must match it.
 	//	If using sorted duplicates (#MDB_DUPSORT) the data item must still
 	//	sort into the same place. This is intended to be used when the
 	//	new data is the same size as the old. Otherwise it will simply
 	//	perform a delete of the old record followed by an insert.
-	PutCurrent(key, value []byte) error
+	//
+	//PutCurrent(key, value []byte) error
+
+
 }
 
 type CursorDupSort interface {
 	Cursor
 
+	// SeekBothExact -
+	// second parameter can be nil only if searched key has no duplicates, or return error
 	SeekBothExact(key, value []byte) ([]byte, []byte, error)
 	SeekBothRange(key, value []byte) ([]byte, []byte, error)
 	FirstDup() ([]byte, error)          // FirstDup - position at first data item of current key

--- a/ethdb/kv_abstract.go
+++ b/ethdb/kv_abstract.go
@@ -139,7 +139,6 @@ type Cursor interface {
 	//
 	//PutCurrent(key, value []byte) error
 
-
 }
 
 type CursorDupSort interface {

--- a/ethdb/kv_bolt.go
+++ b/ethdb/kv_bolt.go
@@ -196,6 +196,12 @@ func (db *BoltKV) Update(ctx context.Context, f func(tx Tx) error) (err error) {
 	})
 }
 
+func (tx *boltTx) Comparator(bucket string) dbutils.CmpFunc {
+	panic("bolt doesn't support comparators")
+}
+func (tx *boltTx) Cmp(bucket string, a, b []byte) int  { panic("bolt doesn't support comparators") }
+func (tx *boltTx) DCmp(bucket string, a, b []byte) int { panic("bolt doesn't support comparators") }
+
 func (tx *boltTx) Commit(ctx context.Context) error {
 	if tx.bolt == nil {
 		return fmt.Errorf("db closed")

--- a/ethdb/kv_remote.go
+++ b/ethdb/kv_remote.go
@@ -180,6 +180,10 @@ func (db *RemoteKV) Update(ctx context.Context, f func(tx Tx) error) (err error)
 	return fmt.Errorf("remote db provider doesn't support .Update method")
 }
 
+func (tx *remoteTx) Comparator(bucket string) dbutils.CmpFunc { panic("not implemented yet") }
+func (tx *remoteTx) Cmp(bucket string, a, b []byte) int       { panic("not implemented yet") }
+func (tx *remoteTx) DCmp(bucket string, a, b []byte) int      { panic("not implemented yet") }
+
 func (tx *remoteTx) Commit(ctx context.Context) error {
 	panic("remote db is read-only")
 }

--- a/go.mod
+++ b/go.mod
@@ -47,7 +47,7 @@ require (
 	github.com/kevinburke/go-bindata v3.21.0+incompatible
 	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/ledgerwatch/bolt v1.4.6-0.20200605053542-69293d8f1d33
-	github.com/ledgerwatch/lmdb-go v1.13.1-0.20200829020305-221d50cfedab
+	github.com/ledgerwatch/lmdb-go v1.15.0
 	github.com/llgcode/draw2d v0.0.0-20180825133448-f52c8a71aff0
 	github.com/logrusorgru/aurora v2.0.3+incompatible
 	github.com/mattn/go-colorable v0.1.2

--- a/go.sum
+++ b/go.sum
@@ -227,8 +227,8 @@ github.com/kylelemons/godebug v1.1.0 h1:RPNrshWIDI6G2gRW9EHilWtl7Z6Sb1BR0xunSBf0
 github.com/kylelemons/godebug v1.1.0/go.mod h1:9/0rRGxNHcop5bhtWyNeEfOS8JIWk580+fNqagV/RAw=
 github.com/ledgerwatch/bolt v1.4.6-0.20200605053542-69293d8f1d33 h1:8e99Kuxoi+RnWCO8zD+ftp+rIuh9AYkZDRPmO8Xgp5k=
 github.com/ledgerwatch/bolt v1.4.6-0.20200605053542-69293d8f1d33/go.mod h1:4frpcWo7Gjizry2yhNN3T4FK0FrgE/AAUlHvKHC0Dao=
-github.com/ledgerwatch/lmdb-go v1.13.1-0.20200829020305-221d50cfedab h1:0GaFl88nDLj9Z8L8iE+2l0UHTEJufpyVHGYuHgRNC8k=
-github.com/ledgerwatch/lmdb-go v1.13.1-0.20200829020305-221d50cfedab/go.mod h1:NKRpCxksoTQPyxsUcBiVOe0135uqnJsnf6cElxmOL0o=
+github.com/ledgerwatch/lmdb-go v1.15.0 h1:FdT/mUQe3kG6ccPkJJX4mFxgfpJvB3C+qT+195a5PbM=
+github.com/ledgerwatch/lmdb-go v1.15.0/go.mod h1:NKRpCxksoTQPyxsUcBiVOe0135uqnJsnf6cElxmOL0o=
 github.com/leodido/go-urn v1.2.0 h1:hpXL4XnriNwQ/ABnpepYM/1vCLWNDfUNts8dX3xTG6Y=
 github.com/leodido/go-urn v1.2.0/go.mod h1:+8+nEpDfqqsY+g338gtMEUOtuK+4dEMhiQEgxpxOKII=
 github.com/llgcode/draw2d v0.0.0-20180825133448-f52c8a71aff0 h1:2vp6ESimuT8pCuZHThVyV0hlfa9oPL06HnGCL9pbUgc=


### PR DESCRIPTION
- ETL Collector - to allow set comparator 
- KV Tx - now has methods Cmp and DCmp - which are proxy to lmdb - comparing 2 byte slices by comparator of given bucket
- KV Tx - now has Comparator method - which returns func of signature `func(k1, k2, v1, v2 []byte) int` 
- method tx.Cursor - now may return different cursor classes - depends on bucket flags.
- As a side-effect: probably we can use lmdb.ReverseKeys flag (for example to experiment with PlainState)

Not solved problems:  
- db.Delete method accepting only 1 key, it's not enough to delete dupsort values, probably I will add second parameter here later.
- Mutation and ETL Buffers are based on key-value paradigm - it's not possible to express "delete value A for key B" 

