### PR TITLE
Fix `nousb` flag missing.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
   turbo-geth:
     image: turbo-geth:latest
     build: .
-    command: tg --nousb --metrics --pprof.addr="0.0.0.0" --pprof.port="6060" --private.api.addr="0.0.0.0:9090" --ipcdisable
+    command: tg --metrics --pprof.addr="0.0.0.0" --pprof.port="6060" --private.api.addr="0.0.0.0:9090" --ipcdisable
     volumes:
       - ${XDG_DATA_HOME:-~/.local/share}/turbogeth:/root/.local/share/turbogeth
     ports:

--- a/turbo/node/node.go
+++ b/turbo/node/node.go
@@ -75,6 +75,7 @@ func makeNodeConfig(ctx *cli.Context, p Params) *node.Config {
 	}
 	nodeConfig.IPCPath = "tg.ipc"
 	nodeConfig.Name = "turbo-geth"
+	nodeConfig.NoUSB = true
 
 	utils.SetNodeConfig(ctx, &nodeConfig)
 


### PR DESCRIPTION
As @AskAlexSharov noticed, we are missing the `--nousb` flag.

Since we aren't going to (so far) integrate with hardware wallets directly (maybe through Clef only or something), I hardcoded it always to be `true` in the node config.

Also, removed this flag from docker-compose.yml.