### PR TITLE
Restore `--identity` flag

### DIFF
--- a/turbo/cli/default_flags.go
+++ b/turbo/cli/default_flags.go
@@ -53,4 +53,5 @@ var DefaultFlags = []cli.Flag{
 	utils.MetricsEnabledExpensiveFlag,
 	utils.MetricsHTTPFlag,
 	utils.MetricsPortFlag,
+	utils.IdentityFlag,
 }


### PR DESCRIPTION
@MysticRyuujin uses it to be able to see which nodes are connected to which.

It looks like it doesn't need any extra treatment, so I'm adding it back to `DefaultFlags`