### PR TITLE
1073 eth get transaction by block number and index

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,8 @@ eth_getLogs
 eth_getStorageAt
 eth_getTransactionReceipt
 eth_getTransactionByHash
+eth_getTransactionByBlockHashAndIndex
+eth_getTransactionByBlockNumberAndIndex
 eth_sendRawTransaction
 eth_syncing
 debug_accountRange

--- a/README.md
+++ b/README.md
@@ -140,6 +140,7 @@ eth_getBalance
 eth_getLogs
 eth_getStorageAt
 eth_getTransactionReceipt
+eth_getTransactionByHash
 eth_sendRawTransaction
 eth_syncing
 debug_accountRange

--- a/cmd/rpcdaemon/commands/eth_api.go
+++ b/cmd/rpcdaemon/commands/eth_api.go
@@ -3,6 +3,7 @@ package commands
 import (
 	"context"
 	"fmt"
+	"math/big"
 
 	"github.com/ledgerwatch/turbo-geth/eth/filters"
 	"github.com/ledgerwatch/turbo-geth/turbo/adapter"
@@ -34,9 +35,9 @@ type EthAPI interface {
 	Syncing(ctx context.Context) (interface{}, error)
 	GetBlockTransactionCountByNumber(ctx context.Context, blockNr rpc.BlockNumber) (*hexutil.Uint, error)
 	GetBlockTransactionCountByHash(ctx context.Context, blockHash common.Hash) (*hexutil.Uint, error)
-	GetTransactionByHash(ctx context.Context, hash common.Hash) (map[string]interface{}, error)
-	GetTransactionByBlockHashAndIndex(ctx context.Context, blockHash common.Hash, txIndex hexutil.Uint64) (map[string]interface{}, error)
-	GetTransactionByBlockNumberAndIndex(ctx context.Context, blockNumber rpc.BlockNumber, txIndex hexutil.Uint64) (map[string]interface{}, error)
+	GetTransactionByHash(ctx context.Context, hash common.Hash) (*RPCTransaction, error)
+	GetTransactionByBlockHashAndIndex(ctx context.Context, blockHash common.Hash, txIndex hexutil.Uint64) (*RPCTransaction, error)
+	GetTransactionByBlockNumberAndIndex(ctx context.Context, blockNr rpc.BlockNumber, txIndex hexutil.Uint) (*RPCTransaction, error)
 	GetStorageAt(ctx context.Context, address common.Address, index string, blockNrOrHash rpc.BlockNumberOrHash) (string, error)
 }
 
@@ -113,105 +114,102 @@ func (api *APIImpl) GetBlockTransactionCountByHash(ctx context.Context, blockHas
 	return &n, nil
 }
 
-func (api *APIImpl) GetTransactionByHash(ctx context.Context, hash common.Hash) (map[string]interface{}, error) {
-	tx, blockHash, blockNumber, txIndex := rawdb.ReadTransaction(api.dbReader, hash)
+// RPCTransaction represents a transaction that will serialize to the RPC representation of a transaction
+// TODO(tjayrush): Copied from ./internal/ethapi/api.go - remove this comment
+type RPCTransaction struct {
+	BlockHash        *common.Hash    `json:"blockHash"`
+	BlockNumber      *hexutil.Big    `json:"blockNumber"`
+	From             common.Address  `json:"from"`
+	Gas              hexutil.Uint64  `json:"gas"`
+	GasPrice         *hexutil.Big    `json:"gasPrice"`
+	Hash             common.Hash     `json:"hash"`
+	Input            hexutil.Bytes   `json:"input"`
+	Nonce            hexutil.Uint64  `json:"nonce"`
+	To               *common.Address `json:"to"`
+	TransactionIndex *hexutil.Uint64 `json:"transactionIndex"`
+	Value            *hexutil.Big    `json:"value"`
+	V                *hexutil.Big    `json:"v"`
+	R                *hexutil.Big    `json:"r"`
+	S                *hexutil.Big    `json:"s"`
+}
 
+// newRPCTransaction returns a transaction that will serialize to the RPC
+// representation, with the given location metadata set (if available).
+// TODO(tjayrush): Copied from ./internal/ethapi/api.go - remove this comment
+func newRPCTransaction(tx *types.Transaction, blockHash common.Hash, blockNumber uint64, index uint64) *RPCTransaction {
+	var signer types.Signer = types.FrontierSigner{}
+	if tx.Protected() {
+		signer = types.NewEIP155Signer(tx.ChainID().ToBig())
+	}
+	from, _ := types.Sender(signer, tx)
+	v, r, s := tx.RawSignatureValues()
+
+	result := &RPCTransaction{
+		From:     from,
+		Gas:      hexutil.Uint64(tx.Gas()),
+		GasPrice: (*hexutil.Big)(tx.GasPrice().ToBig()),
+		Hash:     tx.Hash(),
+		Input:    hexutil.Bytes(tx.Data()),
+		Nonce:    hexutil.Uint64(tx.Nonce()),
+		To:       tx.To(),
+		Value:    (*hexutil.Big)(tx.Value().ToBig()),
+		V:        (*hexutil.Big)(v.ToBig()),
+		R:        (*hexutil.Big)(r.ToBig()),
+		S:        (*hexutil.Big)(s.ToBig()),
+	}
+	if blockHash != (common.Hash{}) {
+		result.BlockHash = &blockHash
+		result.BlockNumber = (*hexutil.Big)(new(big.Int).SetUint64(blockNumber))
+		result.TransactionIndex = (*hexutil.Uint64)(&index)
+	}
+	return result
+}
+
+// GetTransactionByHash returns the transaction for the given hash
+func (api *APIImpl) GetTransactionByHash(ctx context.Context, hash common.Hash) (*RPCTransaction, error) {
+	// https://infura.io/docs/ethereum/json-rpc/eth-getTransactionByHash
+	tx, blockHash, blockNumber, txIndex := rawdb.ReadTransaction(api.dbReader, hash)
 	if tx == nil {
 		return nil, fmt.Errorf("transaction %#x not found", hash)
 	}
-
-	from := rawdb.ReadSenders(api.dbReader, blockHash, blockNumber)[txIndex]
-
-	v, r, s := tx.RawSignatureValues()
-
-	fields := map[string]interface{}{
-		"hash":             tx.Hash(),
-		"nonce":            tx.Nonce(),
-		"blockHash":        blockHash,
-		"blockNumber":      hexutil.EncodeUint64(blockNumber),
-		"from":             from,
-		"to":               tx.To(),
-		"value":            tx.Value(),
-		"gasPrice":         tx.GasPrice(),
-		"gas":              hexutil.EncodeUint64(tx.Gas()),
-		"input":            hexutil.Encode(tx.Data()),
-		"v":                v,
-		"s":                s,
-		"r":                r,
-		"transactionIndex": txIndex,
-	}
-	return fields, nil
+	return newRPCTransaction(tx, blockHash, blockNumber, txIndex), nil
 }
 
-//TODO(tjayrush): probably using the wrong types here
-func (api *APIImpl) GetTransactionByBlockHashAndIndex(ctx context.Context, blockHash common.Hash, txIndex hexutil.Uint64) (map[string]interface{}, error) {
+// GetTransactionByBlockHashAndIndex returns the transaction for the given block hash and index.
+func (api *APIImpl) GetTransactionByBlockHashAndIndex(ctx context.Context, blockHash common.Hash, txIndex hexutil.Uint64) (*RPCTransaction, error) {
 	// https://infura.io/docs/ethereum/json-rpc/eth-getTransactionByBlockHashAndIndex
 	block := rawdb.ReadBlockByHash(api.dbReader, blockHash)
 	if block == nil {
-		return nil, fmt.Errorf("block not found: %x", blockHash)
+		return nil, fmt.Errorf("block %#x not found", blockHash)
 	}
-	nTxs := hexutil.Uint64(len(block.Transactions()))
-	if txIndex >= nTxs {
-		return nil, fmt.Errorf("index %d greater than number of txs: %d", txIndex, nTxs)
-	}
-	tx := block.Transactions()[txIndex]
 
-	from := rawdb.ReadSenders(api.dbReader, blockHash, block.NumberU64())[txIndex]
-	v, r, s := tx.RawSignatureValues()
-	fields := map[string]interface{}{
-		"hash":             tx.Hash(),
-		"nonce":            tx.Nonce(),
-		"blockHash":        blockHash,
-		"blockNumber":      hexutil.EncodeUint64(block.NumberU64()),
-		"from":             from,
-		"to":               tx.To(),
-		"value":            tx.Value(),
-		"gasPrice":         tx.GasPrice(),
-		"gas":              hexutil.EncodeUint64(tx.Gas()),
-		"input":            hexutil.Encode(tx.Data()),
-		"v":                v,
-		"s":                s,
-		"r":                r,
-		"transactionIndex": txIndex,
+	txs := block.Transactions()
+	if uint64(txIndex) >= uint64(len(txs)) {
+		return nil, fmt.Errorf("txIndex (%d) out of range (nTxs: %d)", uint64(txIndex), uint64(len(txs)))
 	}
-	return fields, nil
+
+	return newRPCTransaction(txs[txIndex], block.Hash(), block.NumberU64(), uint64(txIndex)), nil
 }
 
-//TODO(tjayrush): probably using the wrong types here
-func (api *APIImpl) GetTransactionByBlockNumberAndIndex(ctx context.Context, blockNr rpc.BlockNumber, txIndex hexutil.Uint64) (map[string]interface{}, error) {
+// GetTransactionByBlockNumberAndIndex returns the transaction for the given block number and index.
+func (api *APIImpl) GetTransactionByBlockNumberAndIndex(ctx context.Context, blockNr rpc.BlockNumber, txIndex hexutil.Uint) (*RPCTransaction, error) {
 	// https://infura.io/docs/ethereum/json-rpc/eth-getTransactionByBlockNumberAndIndex
 	blockNum, err := getBlockNumber(blockNr, api.dbReader)
 	if err != nil {
 		return nil, err
 	}
+
 	block := rawdb.ReadBlockByNumber(api.dbReader, blockNum)
 	if block == nil {
-		return nil, fmt.Errorf("block not found: %d", blockNum)
+		return nil, fmt.Errorf("block %d not found", blockNum)
 	}
-	nTxs := hexutil.Uint64(len(block.Transactions()))
-	if txIndex >= nTxs {
-		return nil, fmt.Errorf("index %d greater than number of txs: %d", txIndex, nTxs)
+
+	txs := block.Transactions()
+	if uint64(txIndex) >= uint64(len(txs)) {
+		return nil, fmt.Errorf("txIndex (%d) out of range (nTxs: %d)", uint64(txIndex), uint64(len(txs)))
 	}
-	tx := block.Transactions()[txIndex]
-	from := rawdb.ReadSenders(api.dbReader, block.Hash(), block.NumberU64())[txIndex]
-	v, r, s := tx.RawSignatureValues()
-	fields := map[string]interface{}{
-		"hash":             tx.Hash(),
-		"nonce":            tx.Nonce(),
-		"blockHash":        block.Hash(),
-		"blockNumber":      hexutil.EncodeUint64(block.NumberU64()),
-		"from":             from,
-		"to":               tx.To(),
-		"value":            tx.Value(),
-		"gasPrice":         tx.GasPrice(),
-		"gas":              hexutil.EncodeUint64(tx.Gas()),
-		"input":            hexutil.Encode(tx.Data()),
-		"v":                v,
-		"s":                s,
-		"r":                r,
-		"transactionIndex": txIndex,
-	}
-	return fields, nil
+
+	return newRPCTransaction(txs[txIndex], block.Hash(), block.NumberU64(), uint64(txIndex)), nil
 }
 
 func (api *APIImpl) GetStorageAt(ctx context.Context, address common.Address, index string, blockNrOrHash rpc.BlockNumberOrHash) (string, error) {


### PR DESCRIPTION
Fixes #1073, plus I made a slight refactor to `eth_getTransactionByHash` to use code from `./internal/ethapi/api.go`.

I also added support for `eth_getTransactionByBlockHashAndIndex` since it was so similar.

My first PR to a golang repo, so I'd greatly appreciate any feedback.

Looking for advice on how to add testing...