### PR TITLE
Fix reproducible builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,12 +21,12 @@ docker-compose:
 	docker-compose up
 
 geth:
-	$(GOBUILD) -o $(GOBIN)/tg -ldflags "-X main.GitCommit=${GIT_COMMIT} -X main.GitDate=$(shell date +%Y.%m.%d.%H%M%S)" ./cmd/tg 
+	$(GOBUILD) -o $(GOBIN)/tg -ldflags "-X main.gitCommit=${GIT_COMMIT}" ./cmd/tg 
 	@echo "Done building."
 	@echo "Run \"$(GOBIN)/tg\" to launch turbo-geth."
 
 tg:
-	$(GOBUILD) -o $(GOBIN)/tg -ldflags "-X main.GitCommit=${GIT_COMMIT} -X main.GitDate=$(shell date +%Y.%m.%d.%H%M%S)" ./cmd/tg 
+	$(GOBUILD) -o $(GOBIN)/tg -ldflags "-X main.gitCommit=${GIT_COMMIT}" ./cmd/tg 
 	@echo "Done building."
 	@echo "Run \"$(GOBIN)/tg\" to launch turbo-geth."
 

--- a/cmd/tg/main.go
+++ b/cmd/tg/main.go
@@ -14,8 +14,7 @@ import (
 )
 
 var (
-	GitCommit string
-	GitDate   string
+	gitCommit string
 )
 
 func main() {
@@ -31,7 +30,7 @@ func runTurboGeth(ctx *cli.Context) {
 		stagedsync.DefaultUnwindOrder(),
 	)
 
-	tg := node.New(ctx, sync, node.Params{GitCommit: GitCommit, GitDate: GitDate})
+	tg := node.New(ctx, sync, node.Params{GitCommit: gitCommit})
 	err := tg.Serve()
 
 	if err != nil {

--- a/turbo/node/node.go
+++ b/turbo/node/node.go
@@ -43,7 +43,6 @@ func (tg *TurboGethNode) run() {
 }
 
 type Params struct {
-	GitDate       string
 	GitCommit     string
 	CustomBuckets dbutils.BucketsCfg
 }
@@ -75,8 +74,8 @@ func makeEthConfig(ctx *cli.Context, node *node.Node) *eth.Config {
 func makeNodeConfig(ctx *cli.Context, p Params) *node.Config {
 	nodeConfig := node.DefaultConfig
 	// see simiar changes in `cmd/geth/config.go#defaultNodeConfig`
-	if commit, date := p.GitCommit, p.GitDate; commit != "" && date != "" {
-		nodeConfig.Version = params.VersionWithCommit(commit, date)
+	if commit := p.GitCommit; commit != "" {
+		nodeConfig.Version = params.VersionWithCommit(commit, "")
 	} else {
 		nodeConfig.Version = params.Version
 	}


### PR DESCRIPTION
When making `turbo-api` I broke reproducible builds by passing the date on compile time. This commit fixes that.