### PR TITLE
Fixes issue #1103

### DIFF
--- a/turbo/rpchelper/helper.go
+++ b/turbo/rpchelper/helper.go
@@ -23,8 +23,13 @@ func GetBlockNumber(blockNrOrHash rpc.BlockNumberOrHash, dbReader rawdb.Database
 			if err != nil {
 				return 0, common.Hash{}, fmt.Errorf("getting latest block number: %v", err)
 			}
-		} else if number == rpc.PendingBlockNumber || number == rpc.EarliestBlockNumber {
-			return 0, common.Hash{}, fmt.Errorf("pending and earliest blocks are not supported")
+
+		} else if number == rpc.EarliestBlockNumber {
+			blockNumber = 0
+
+		} else if number == rpc.PendingBlockNumber {
+			return 0, common.Hash{}, fmt.Errorf("pending blocks are not supported")
+
 		} else {
 			blockNumber = uint64(number.Int64())
 		}


### PR DESCRIPTION
I ran this

```
curl -X POST --data '{"jsonrpc":"2.0","method":"eth_getBalance","params":["0xa1e4380a3b1f749673e270229993ee55f35663b4", "0x0"],"id":64}' -H "Content-Type: application/json" localhost:8545
```
against all the pre-fund addresses and it now returns the same amounts as Parity for all the prefund acounts.

Fixes #1103 