### PR TITLE
Use the passed VMConfig

### DIFF
--- a/cmd/state/stateless/check_change_sets.go
+++ b/cmd/state/stateless/check_change_sets.go
@@ -76,7 +76,7 @@ func CheckChangeSets(genesis *core.Genesis, blockNum uint64, chaindata string, h
 			blockWriter = csw
 		}
 
-		receipts, err1 := runBlock(intraBlockState, noOpWriter, blockWriter, chainConfig, bc, block)
+		receipts, err1 := runBlock(intraBlockState, noOpWriter, blockWriter, chainConfig, bc, block, vmConfig)
 		if err1 != nil {
 			return err1
 		}

--- a/cmd/state/stateless/stateless.go
+++ b/cmd/state/stateless/stateless.go
@@ -40,11 +40,8 @@ var chartColors = []drawing.Color{
 }
 
 func runBlock(ibs *state.IntraBlockState, txnWriter state.StateWriter, blockWriter state.StateWriter,
-	chainConfig *params.ChainConfig, bcb core.ChainContext, block *types.Block,
-) (types.Receipts, error) {
+	chainConfig *params.ChainConfig, bcb core.ChainContext, block *types.Block, vmConfig vm.Config) (types.Receipts, error) {
 	header := block.Header()
-	bc := bcb.(*core.BlockChain)
-	vmConfig := *bc.GetVMConfig()
 	vmConfig.TraceJumpDest = true
 	engine := ethash.NewFullFaker()
 	gp := new(core.GasPool).AddGas(block.GasLimit())
@@ -401,7 +398,7 @@ func Stateless(
 			ibs := state.New(s)
 			ibs.SetTrace(trace)
 			s.SetBlockNr(blockNum)
-			if _, err = runBlock(ibs, s, s, chainConfig, blockProvider, block); err != nil {
+			if _, err = runBlock(ibs, s, s, chainConfig, blockProvider, block, vmConfig); err != nil {
 				fmt.Printf("Error running block %d through stateless2: %v\n", blockNum, err)
 				finalRootFail = true
 			} else if !binary {

--- a/cmd/state/stateless/stateless.go
+++ b/cmd/state/stateless/stateless.go
@@ -43,7 +43,9 @@ func runBlock(ibs *state.IntraBlockState, txnWriter state.StateWriter, blockWrit
 	chainConfig *params.ChainConfig, bcb core.ChainContext, block *types.Block,
 ) (types.Receipts, error) {
 	header := block.Header()
-	vmConfig := vm.Config{TraceJumpDest: true}
+	bc := bcb.(*core.BlockChain)
+	vmConfig := *bc.GetVMConfig()
+	vmConfig.TraceJumpDest = true
 	engine := ethash.NewFullFaker()
 	gp := new(core.GasPool).AddGas(block.GasLimit())
 	usedGas := new(uint64)


### PR DESCRIPTION
runBlock was creating a new vm.Config, ignoring the one passed inside of the core.ChainContext. This made it impossible to set a Tracer in the caller.

(let me know whether it would make more sense to add a basic Tracer to the PR)