### PR TITLE
[to discuss] Normal form of topics

### DIFF
--- a/accounts/abi/bind/backends/simulated.go
+++ b/accounts/abi/bind/backends/simulated.go
@@ -508,7 +508,7 @@ func (b *SimulatedBackend) EstimateGas(ctx context.Context, call ethereum.CallMs
 
 	// Determine the lowest and highest possible gas limits to binary search in between
 	var (
-		lo  uint64 = params.TxGas - 1
+		lo  = params.TxGas - 1
 		hi  uint64
 		cap uint64
 	)
@@ -828,7 +828,7 @@ func (fb *filterBackend) GetReceipts(_ context.Context, hash common.Hash) (types
 	if number == nil {
 		return nil, nil
 	}
-	return rawdb.ReadReceipts(fb.db, hash, *number), nil
+	return rawdb.ReadReceipts(fb.db, *number), nil
 }
 
 func (fb *filterBackend) GetLogs(_ context.Context, hash common.Hash) ([][]*types.Log, error) {
@@ -836,7 +836,7 @@ func (fb *filterBackend) GetLogs(_ context.Context, hash common.Hash) ([][]*type
 	if number == nil {
 		return nil, nil
 	}
-	receipts := rawdb.ReadReceipts(fb.db, hash, *number)
+	receipts := rawdb.ReadReceipts(fb.db, *number)
 	if receipts == nil {
 		return nil, nil
 	}

--- a/cmd/integration/commands/reset_state.go
+++ b/cmd/integration/commands/reset_state.go
@@ -149,7 +149,7 @@ func resetExec(db *ethdb.ObjectDatabase) error {
 		dbutils.PlainAccountChangeSetBucket,
 		dbutils.PlainStorageChangeSetBucket,
 		dbutils.PlainContractCodeBucket,
-		dbutils.BlockReceiptsPrefix,
+		dbutils.BlockReceipts,
 		dbutils.IncarnationMapBucket,
 		dbutils.CodeBucket,
 	); err != nil {

--- a/cmd/pics/state.go
+++ b/cmd/pics/state.go
@@ -116,7 +116,7 @@ func keyTape(t *trie.Trie, number int) error {
 }
 
 var bucketLabels = map[string]string{
-	dbutils.BlockReceiptsPrefix:   "Receipts",
+	dbutils.BlockReceipts:         "Receipts",
 	dbutils.AccountsHistoryBucket: "History Of Accounts",
 	dbutils.HeaderPrefix:          "Headers",
 	//dbutils.ConfigPrefix:                "Config",

--- a/cmd/rpcdaemon/commands/get_receipts.go
+++ b/cmd/rpcdaemon/commands/get_receipts.go
@@ -2,6 +2,7 @@ package commands
 
 import (
 	"context"
+	"encoding/binary"
 	"fmt"
 	"math/big"
 
@@ -21,7 +22,7 @@ import (
 )
 
 func getReceipts(ctx context.Context, tx rawdb.DatabaseReader, kv ethdb.KV, number uint64, hash common.Hash) (types.Receipts, error) {
-	if cached := rawdb.ReadReceipts(tx, hash, number); cached != nil {
+	if cached := rawdb.ReadReceipts(tx, number); cached != nil {
 		return cached, nil
 	}
 
@@ -55,7 +56,13 @@ func getReceipts(ctx context.Context, tx rawdb.DatabaseReader, kv ethdb.KV, numb
 // GetLogsByHash non-standard RPC that returns all logs in a block
 // TODO(tjayrush): Since this is non-standard we could rename it to GetLogsByBlockHash to be more consistent and avoid confusion
 func (api *APIImpl) GetLogsByHash(ctx context.Context, hash common.Hash) ([][]*types.Log, error) {
-	number := rawdb.ReadHeaderNumber(api.dbReader, hash)
+	tx, err := api.dbReader.Begin(context.Background())
+	if err != nil {
+		return nil, err
+	}
+	defer tx.Rollback()
+
+	number := rawdb.ReadHeaderNumber(tx, hash)
 	if number == nil {
 		return nil, fmt.Errorf("block not found: %x", hash)
 	}
@@ -66,6 +73,13 @@ func (api *APIImpl) GetLogsByHash(ctx context.Context, hash common.Hash) ([][]*t
 	}
 	logs := make([][]*types.Log, len(receipts))
 	for i, receipt := range receipts {
+		for _, l := range receipt.Logs {
+			l.Topics, err = rawdb.ReadTopics(tx, l.TopicIds)
+			if err != nil {
+				return nil, err
+			}
+		}
+
 		logs[i] = receipt.Logs
 	}
 	return logs, nil
@@ -109,7 +123,12 @@ func (api *APIImpl) GetLogs(ctx context.Context, crit filters.FilterCriteria) ([
 	blockNumbers := gocroaring.New()
 	blockNumbers.AddRange(begin, end+1) // [min,max)
 
-	topicsBitmap, err := getTopicsBitmap(tx.(ethdb.HasTx).Tx().Cursor(dbutils.LogTopicIndex), crit.Topics)
+	critTopicIds, err := topicsToIds(tx, crit.Topics)
+	if err != nil {
+		return returnLogs(logs), err
+	}
+
+	topicsBitmap, err := getTopicsBitmap(tx.(ethdb.HasTx).Tx().Cursor(dbutils.LogTopicIndex), critTopicIds)
 	if err != nil {
 		return nil, err
 	}
@@ -124,9 +143,9 @@ func (api *APIImpl) GetLogs(ctx context.Context, crit filters.FilterCriteria) ([
 	logAddrIndex := tx.(ethdb.HasTx).Tx().Cursor(dbutils.LogAddressIndex)
 	var addrBitmap *gocroaring.Bitmap
 	for _, addr := range crit.Addresses {
-		m, err := bitmapdb.Get(logAddrIndex, addr[:])
-		if err != nil {
-			return nil, err
+		m, errGet := bitmapdb.Get(logAddrIndex, addr[:])
+		if errGet != nil {
+			return nil, errGet
 		}
 		if addrBitmap == nil {
 			addrBitmap = m
@@ -152,16 +171,24 @@ func (api *APIImpl) GetLogs(ctx context.Context, crit filters.FilterCriteria) ([
 		if blockHash == (common.Hash{}) {
 			return returnLogs(logs), fmt.Errorf("block not found %d", uint64(blockNToMatch))
 		}
-		receipts, err := getReceipts(ctx, tx, api.db, uint64(blockNToMatch), blockHash)
-		if err != nil {
-			return returnLogs(logs), err
+
+		receipts, errGet := getReceipts(ctx, tx, api.db, uint64(blockNToMatch), blockHash)
+		if errGet != nil {
+			return returnLogs(logs), errGet
 		}
 		unfiltered := make([]*types.Log, 0, len(receipts))
 		for _, receipt := range receipts {
 			unfiltered = append(unfiltered, receipt.Logs...)
 		}
-		unfiltered = filterLogs(unfiltered, nil, nil, crit.Addresses, crit.Topics)
+		unfiltered = filterLogs(unfiltered, nil, nil, crit.Addresses, critTopicIds)
 		logs = append(logs, unfiltered...)
+	}
+
+	for _, l := range logs {
+		l.Topics, err = rawdb.ReadTopics(tx, l.TopicIds)
+		if err != nil {
+			return returnLogs(logs), err
+		}
 	}
 
 	return returnLogs(logs), nil
@@ -178,12 +205,14 @@ func (api *APIImpl) GetLogs(ctx context.Context, crit filters.FilterCriteria) ([
 // {{}, {B}}          matches any topic in first position AND B in second position
 // {{A}, {B}}         matches topic A in first position AND B in second position
 // {{A, B}, {C, D}}   matches topic (A OR B) in first position AND (C OR D) in second position
-func getTopicsBitmap(c ethdb.Cursor, topics [][]common.Hash) (*gocroaring.Bitmap, error) {
+func getTopicsBitmap(c ethdb.Cursor, topics [][]uint32) (*gocroaring.Bitmap, error) {
+	idBytes := make([]byte, 4)
 	var result *gocroaring.Bitmap
 	for _, sub := range topics {
 		var bitmapForORing *gocroaring.Bitmap
 		for _, topic := range sub {
-			m, err := bitmapdb.Get(c, topic[:])
+			binary.BigEndian.PutUint32(idBytes, topic)
+			m, err := bitmapdb.Get(c, idBytes)
 			if err != nil {
 				return nil, err
 			}
@@ -205,14 +234,35 @@ func getTopicsBitmap(c ethdb.Cursor, topics [][]common.Hash) (*gocroaring.Bitmap
 	return result, nil
 }
 
+func topicsToIds(db rawdb.DatabaseReader, topics [][]common.Hash) ([][]uint32, error) {
+	ids := make([][]uint32, len(topics))
+	for i, sub := range topics {
+		ids[i] = make([]uint32, len(sub))
+		for j, topic := range sub {
+			var err error
+			ids[i][j], err = rawdb.ReadTopicId(db, topic)
+			if err != nil {
+				return nil, err
+			}
+		}
+	}
+	return ids, nil
+}
+
 func (api *APIImpl) GetTransactionReceipt(ctx context.Context, hash common.Hash) (map[string]interface{}, error) {
+	tx, err := api.dbReader.Begin(context.Background())
+	if err != nil {
+		return nil, err
+	}
+	defer tx.Rollback()
+
 	// Retrieve the transaction and assemble its EVM context
-	tx, blockHash, blockNumber, txIndex := rawdb.ReadTransaction(api.dbReader, hash)
+	txn, blockHash, blockNumber, txIndex := rawdb.ReadTransaction(tx, hash)
 	if tx == nil {
 		return nil, fmt.Errorf("transaction %#x not found", hash)
 	}
 
-	receipts, err := getReceipts(ctx, api.dbReader, api.db, blockNumber, blockHash)
+	receipts, err := getReceipts(ctx, tx, api.db, blockNumber, blockHash)
 	if err != nil {
 		return nil, fmt.Errorf("getReceipts error: %v", err)
 	}
@@ -222,14 +272,18 @@ func (api *APIImpl) GetTransactionReceipt(ctx context.Context, hash common.Hash)
 	receipt := receipts[txIndex]
 
 	var signer types.Signer = types.FrontierSigner{}
-	if tx.Protected() {
-		signer = types.NewEIP155Signer(tx.ChainID().ToBig())
+	if txn.Protected() {
+		signer = types.NewEIP155Signer(txn.ChainID().ToBig())
 	}
-	from, _ := types.Sender(signer, tx)
+	from, _ := types.Sender(signer, txn)
 
 	// Fill in the derived information in the logs
 	if receipt.Logs != nil {
 		for _, log := range receipt.Logs {
+			log.Topics, err = rawdb.ReadTopics(tx, log.TopicIds)
+			if err != nil {
+				return nil, err
+			}
 			log.BlockNumber = blockNumber
 			log.TxHash = hash
 			log.TxIndex = uint(txIndex)
@@ -244,7 +298,7 @@ func (api *APIImpl) GetTransactionReceipt(ctx context.Context, hash common.Hash)
 		"transactionHash":   hash,
 		"transactionIndex":  hexutil.Uint64(txIndex),
 		"from":              from,
-		"to":                tx.To(),
+		"to":                txn.To(),
 		"gasUsed":           hexutil.Uint64(receipt.GasUsed),
 		"cumulativeGasUsed": hexutil.Uint64(receipt.CumulativeGasUsed),
 		"contractAddress":   nil,
@@ -279,7 +333,7 @@ func includes(addresses []common.Address, a common.Address) bool {
 }
 
 // filterLogs creates a slice of logs matching the given criteria.
-func filterLogs(logs []*types.Log, fromBlock, toBlock *big.Int, addresses []common.Address, topics [][]common.Hash) []*types.Log {
+func filterLogs(logs []*types.Log, fromBlock, toBlock *big.Int, addresses []common.Address, topics [][]uint32) []*types.Log {
 	var ret []*types.Log
 Logs:
 	for _, log := range logs {
@@ -294,13 +348,13 @@ Logs:
 			continue
 		}
 		// If the to filtered topics is greater than the amount of topics in logs, skip.
-		if len(topics) > len(log.Topics) {
+		if len(topics) > len(log.TopicIds) {
 			continue Logs
 		}
 		for i, sub := range topics {
 			match := len(sub) == 0 // empty rule set == wildcard
 			for _, topic := range sub {
-				if log.Topics[i] == topic {
+				if log.TopicIds[i] == topic {
 					match = true
 					break
 				}

--- a/cmd/state/stateless/check_change_sets.go
+++ b/cmd/state/stateless/check_change_sets.go
@@ -88,7 +88,7 @@ func CheckChangeSets(genesis *core.Genesis, blockNum uint64, chaindata string, h
 			}
 		}
 		if writeReceipts {
-			rawdb.WriteReceipts(batch, block.Hash(), block.NumberU64(), receipts)
+			rawdb.WriteReceipts(batch, block.NumberU64(), receipts)
 			if batch.BatchSize() >= batch.IdealBatchSize() {
 				log.Info("Committing receipts", "up to block", block.NumberU64(), "batch size", common.StorageSize(batch.BatchSize()))
 				if err := batch.CommitAndBegin(context.Background()); err != nil {

--- a/common/dbutils/bucket.go
+++ b/common/dbutils/bucket.go
@@ -111,8 +111,12 @@ var (
 	HeaderHashSuffix   = []byte("n") // headerPrefix + num (uint64 big endian) + headerHashSuffix -> hash
 	HeaderNumberPrefix = "H"         // headerNumberPrefix + hash -> num (uint64 big endian)
 
-	BlockBodyPrefix     = "b" // blockBodyPrefix + num (uint64 big endian) + hash -> block body
-	BlockReceiptsPrefix = "r" // blockReceiptsPrefix + num (uint64 big endian) + hash -> block receipts
+	BlockBodyPrefix         = "b"  // blockBodyPrefix + num (uint64 big endian) + hash -> block body
+	BlockReceipts           = "r2" // blockNum_u64 -> block receipts rlp
+	BlockReceiptsPrefixOld1 = "r"  // blockReceiptsPrefix + num (uint64 big endian) + hash -> block receipts
+
+	LogId2Topic = "log_id_topic" // num (uint32 big endian) -> 32 bytes topic
+	LogTopic2Id = "log_topic_id" // 32 bytes topic -> num (uint32 big endian)
 
 	// Stores bitmap indices - in which block numbers saw logs of given 'address' or 'topic'
 	// [addr or topic] + [2 bytes inverted shard number] -> bitmap(blockN)
@@ -162,6 +166,8 @@ var (
 	// it stores stages progress to understand in which context was executed migration
 	// in case of bug-report developer can ask content of this bucket
 	Migrations = "migrations"
+
+	Counters = "counters"
 )
 
 // Keys
@@ -201,7 +207,7 @@ var Buckets = []string{
 	HeaderPrefix,
 	HeaderNumberPrefix,
 	BlockBodyPrefix,
-	BlockReceiptsPrefix,
+	BlockReceipts,
 	TxLookupPrefix,
 	BloomBitsPrefix,
 	PreimagePrefix,
@@ -225,6 +231,9 @@ var Buckets = []string{
 	Migrations,
 	LogTopicIndex,
 	LogAddressIndex,
+	LogId2Topic,
+	LogTopic2Id,
+	Counters,
 }
 
 // DeprecatedBuckets - list of buckets which can be programmatically deleted - for example after migration
@@ -234,6 +243,7 @@ var DeprecatedBuckets = []string{
 	CurrentStateBucketOld1,
 	PlainStateBucketOld1,
 	IntermediateTrieHashBucketOld1,
+	BlockReceiptsPrefixOld1,
 }
 
 type CustomComparator string
@@ -293,6 +303,13 @@ var BucketsConfigs = BucketsCfg{
 	IntermediateTrieHashBucket: {
 		Flags:               lmdb.DupSort,
 		CustomDupComparator: DupCmpSuffix32,
+	},
+	LogTopic2Id: {
+		Flags:                     lmdb.DupSort | lmdb.DupFixed,
+		AutoDupSortKeysConversion: true,
+		DupFromLen:                32,
+		DupToLen:                  8,
+		DupFixedSize:              28,
 	},
 }
 

--- a/common/dbutils/composite_keys.go
+++ b/common/dbutils/composite_keys.go
@@ -57,9 +57,9 @@ func BlockBodyKey(number uint64, hash common.Hash) []byte {
 	return append(EncodeBlockNumber(number), hash.Bytes()...)
 }
 
-// blockReceiptsKey = blockReceiptsPrefix + num (uint64 big endian) + hash
-func BlockReceiptsKey(number uint64, hash common.Hash) []byte {
-	return append(EncodeBlockNumber(number), hash.Bytes()...)
+// blockReceiptsKey = num (uint64 big endian)
+func BlockReceiptsKey(number uint64) []byte {
+	return EncodeBlockNumber(number)
 }
 
 // bloomBitsKey = bloomBitsPrefix + bit (uint16 big endian) + section (uint64 big endian) + hash

--- a/common/dbutils/counters.go
+++ b/common/dbutils/counters.go
@@ -1,0 +1,59 @@
+package dbutils
+
+import (
+	"bytes"
+
+	"github.com/ledgerwatch/turbo-geth/ethdb/codecpool"
+)
+
+const KeyIDs = "ids"
+
+// IDs - store id of last inserted entity to db - increment before use
+type IDs struct {
+	Topic uint32
+}
+
+const KeyAggregates = "aggregates"
+
+// Aggregates - store some statistical aggregates of data: for example min/max of values in some bucket
+type Aggregates struct {
+}
+
+func (c *IDs) Unmarshal(data []byte) error {
+	decoder := codecpool.Decoder(bytes.NewReader(data))
+	defer codecpool.Return(decoder)
+
+	if err := decoder.Decode(c); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (c *IDs) Marshal() (data []byte, err error) {
+	var buf bytes.Buffer
+	encoder := codecpool.Encoder(&buf)
+	defer codecpool.Return(encoder)
+	if err := encoder.Encode(c); err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
+}
+
+func (c *Aggregates) Unmarshal(data []byte) error {
+	decoder := codecpool.Decoder(bytes.NewReader(data))
+	defer codecpool.Return(decoder)
+	if err := decoder.Decode(c); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (c *Aggregates) Marshal() (data []byte, err error) {
+	var buf bytes.Buffer
+	encoder := codecpool.Encoder(&buf)
+	defer codecpool.Return(encoder)
+	if err := encoder.Encode(c); err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
+}

--- a/core/bench_test.go
+++ b/core/bench_test.go
@@ -253,7 +253,7 @@ func makeChainForBench(db ethdb.Database, full bool, count uint64) {
 		if full || n == 0 {
 			block := types.NewBlockWithHeader(header)
 			rawdb.WriteBody(ctx, db, hash, n, block.Body())
-			rawdb.WriteReceipts(db, hash, n, nil)
+			rawdb.WriteReceipts(db, n, nil)
 		}
 	}
 }
@@ -298,7 +298,7 @@ func benchReadChain(b *testing.B, full bool, count uint64) {
 			if full {
 				hash := header.Hash()
 				rawdb.ReadBody(db, hash, n)
-				rawdb.ReadReceipts(db, hash, n)
+				rawdb.ReadReceipts(db, n)
 			}
 		}
 		chain.Stop()

--- a/core/blockchain_test.go
+++ b/core/blockchain_test.go
@@ -776,7 +776,7 @@ func TestFastVsFullChains(t *testing.T) {
 		} else if types.CalcUncleHash(fblock.Uncles()) != types.CalcUncleHash(arblock.Uncles()) || types.CalcUncleHash(anblock.Uncles()) != types.CalcUncleHash(arblock.Uncles()) {
 			t.Errorf("block #%d [%x]: uncles mismatch: fastdb %v, ancientdb %v, archivedb %v", num, hash, fblock.Uncles(), anblock, arblock.Uncles())
 		}
-		if freceipts, anreceipts, areceipts := rawdb.ReadReceipts(fastDb, hash, *rawdb.ReadHeaderNumber(fastDb, hash)), rawdb.ReadReceipts(ancientDb, hash, *rawdb.ReadHeaderNumber(ancientDb, hash)), rawdb.ReadReceipts(archiveDb, hash, *rawdb.ReadHeaderNumber(archiveDb, hash)); types.DeriveSha(freceipts) != types.DeriveSha(areceipts) {
+		if freceipts, anreceipts, areceipts := rawdb.ReadReceipts(fastDb, *rawdb.ReadHeaderNumber(fastDb, hash)), rawdb.ReadReceipts(ancientDb, *rawdb.ReadHeaderNumber(ancientDb, hash)), rawdb.ReadReceipts(archiveDb, *rawdb.ReadHeaderNumber(archiveDb, hash)); types.DeriveSha(freceipts) != types.DeriveSha(areceipts) {
 			t.Errorf("block #%d [%x]: receipts mismatch: fastdb %v, ancientdb %v, archivedb %v", num, hash, freceipts, anreceipts, areceipts)
 		}
 	}
@@ -1029,7 +1029,7 @@ func TestChainTxReorgs(t *testing.T) {
 	}
 
 	// removed tx
-	for i, tx := range (types.Transactions{pastDrop, freshDrop}) {
+	for i, tx := range types.Transactions{pastDrop, freshDrop} {
 		if txn, _, _, _ := rawdb.ReadTransaction(db, tx.Hash()); txn != nil {
 			t.Errorf("drop %d: tx %v found while shouldn't have been", i, txn)
 		}
@@ -1038,7 +1038,7 @@ func TestChainTxReorgs(t *testing.T) {
 		}
 	}
 	// added tx
-	for i, tx := range (types.Transactions{pastAdd, freshAdd, futureAdd}) {
+	for i, tx := range types.Transactions{pastAdd, freshAdd, futureAdd} {
 		if txn, _, _, _ := rawdb.ReadTransaction(db, tx.Hash()); txn == nil {
 			t.Errorf("add %d: expected tx to be found", i)
 		}
@@ -1047,7 +1047,7 @@ func TestChainTxReorgs(t *testing.T) {
 		}
 	}
 	// shared tx
-	for i, tx := range (types.Transactions{postponed, swapped}) {
+	for i, tx := range types.Transactions{postponed, swapped} {
 		if txn, _, _, _ := rawdb.ReadTransaction(db, tx.Hash()); txn == nil {
 			t.Errorf("share %d: expected tx to be found", i)
 		}
@@ -1644,7 +1644,7 @@ func doModesTest(history, preimages, receipts, txlookup bool) error {
 	for bucketName, shouldBeEmpty := range map[string]bool{
 		dbutils.AccountsHistoryBucket: !history,
 		dbutils.PreimagePrefix:        !preimages,
-		dbutils.BlockReceiptsPrefix:   !receipts,
+		dbutils.BlockReceipts:         !receipts,
 		dbutils.TxLookupPrefix:        !txlookup,
 	} {
 		numberOfEntries := 0
@@ -1652,7 +1652,7 @@ func doModesTest(history, preimages, receipts, txlookup bool) error {
 		err := db.Walk(bucketName, nil, 0, func(k, v []byte) (bool, error) {
 			// we ignore empty account history
 			//nolint:scopelint
-			if bucketName == string(dbutils.AccountsHistoryBucket) && len(v) == 0 {
+			if bucketName == dbutils.AccountsHistoryBucket && len(v) == 0 {
 				return true, nil
 			}
 
@@ -1663,12 +1663,12 @@ func doModesTest(history, preimages, receipts, txlookup bool) error {
 			return err
 		}
 
-		if bucketName == string(dbutils.BlockReceiptsPrefix) {
+		if bucketName == dbutils.BlockReceipts {
 			// we will always have a receipt for genesis
 			numberOfEntries--
 		}
 
-		if bucketName == string(dbutils.PreimagePrefix) {
+		if bucketName == dbutils.PreimagePrefix {
 			// we will always have 2 preimages because GenerateChain interface does not
 			// allow us to set it to ignore them
 			// but if the preimages are enabled in BlockChain, we will have more than 2.

--- a/core/genesis.go
+++ b/core/genesis.go
@@ -364,7 +364,7 @@ func (g *Genesis) Commit(db ethdb.Database, history bool) (*types.Block, *state.
 	}
 	rawdb.WriteTd(db, block.Hash(), block.NumberU64(), g.Difficulty)
 	rawdb.WriteBlock(context.Background(), db, block)
-	rawdb.WriteReceipts(db, block.Hash(), block.NumberU64(), nil)
+	rawdb.WriteReceipts(db, block.NumberU64(), nil)
 	rawdb.WriteCanonicalHash(db, block.Hash(), block.NumberU64())
 	rawdb.WriteHeadBlockHash(db, block.Hash())
 	rawdb.WriteHeadFastBlockHash(db, block.Hash())

--- a/core/rawdb/accessors_chain_test.go
+++ b/core/rawdb/accessors_chain_test.go
@@ -321,15 +321,15 @@ func TestBlockReceiptStorage(t *testing.T) {
 
 	// Check that no receipt entries are in a pristine database
 	hash := common.BytesToHash([]byte{0x03, 0x14})
-	if rs := ReadReceipts(db, hash, 0); len(rs) != 0 {
+	if rs := ReadReceipts(db, 0); len(rs) != 0 {
 		t.Fatalf("non existent receipts returned: %v", rs)
 	}
 	// Insert the body that corresponds to the receipts
 	WriteBody(ctx, db, hash, 0, body)
 
 	// Insert the receipt slice into the database and check presence
-	WriteReceipts(db, hash, 0, receipts)
-	if rs := ReadReceipts(db, hash, 0); len(rs) == 0 {
+	WriteReceipts(db, 0, receipts)
+	if rs := ReadReceipts(db, 0); len(rs) == 0 {
 		t.Fatalf("no receipts returned")
 	} else {
 		if err := checkReceiptsRLP(rs, receipts); err != nil {
@@ -338,18 +338,18 @@ func TestBlockReceiptStorage(t *testing.T) {
 	}
 	// Delete the body and ensure that the receipts are no longer returned (metadata can't be recomputed)
 	DeleteBody(db, hash, 0)
-	if rs := ReadReceipts(db, hash, 0); rs != nil {
+	if rs := ReadReceipts(db, 0); rs != nil {
 		t.Fatalf("receipts returned when body was deleted: %v", rs)
 	}
 	// Ensure that receipts without metadata can be returned without the block body too
-	if err := checkReceiptsRLP(ReadRawReceipts(db, hash, 0), receipts); err != nil {
+	if err := checkReceiptsRLP(ReadRawReceipts(db, 0), receipts); err != nil {
 		t.Fatalf(err.Error())
 	}
 	// Sanity check that body alone without the receipt is a full purge
 	WriteBody(ctx, db, hash, 0, body)
 
-	DeleteReceipts(db, hash, 0)
-	if rs := ReadReceipts(db, hash, 0); len(rs) != 0 {
+	DeleteReceipts(db, 0)
+	if rs := ReadReceipts(db, 0); len(rs) != 0 {
 		t.Fatalf("deleted receipts returned: %v", rs)
 	}
 }

--- a/core/rawdb/accessors_indexes.go
+++ b/core/rawdb/accessors_indexes.go
@@ -98,7 +98,7 @@ func ReadReceipt(db DatabaseReader, hash common.Hash) (*types.Receipt, common.Ha
 		return nil, common.Hash{}, 0, 0
 	}
 	// Read all the receipts from the block and return the one with the matching hash
-	receipts := ReadReceipts(db, blockHash, *blockNumber)
+	receipts := ReadReceipts(db, *blockNumber)
 	for receiptIndex, receipt := range receipts {
 		if receipt.TxHash == hash {
 			return receipt, blockHash, *blockNumber, uint64(receiptIndex)

--- a/core/types/receipt.go
+++ b/core/types/receipt.go
@@ -92,25 +92,11 @@ type storedReceiptRLP struct {
 	Logs              []*LogForStorage
 }
 
-// v4StoredReceiptRLP is the storage encoding of a receipt used in database version 4.
-type v4StoredReceiptRLP struct {
+// storedReceiptRLP is the storage encoding of a receipt.
+type deprecatedStoredReceiptRLP1 struct {
 	PostStateOrStatus []byte
 	CumulativeGasUsed uint64
-	TxHash            common.Hash
-	ContractAddress   common.Address
-	Logs              []*LogForStorage
-	GasUsed           uint64
-}
-
-// v3StoredReceiptRLP is the original storage encoding of a receipt including some unnecessary fields.
-type v3StoredReceiptRLP struct {
-	PostStateOrStatus []byte
-	CumulativeGasUsed uint64
-	//Bloom             Bloom
-	//TxHash            common.Hash
-	ContractAddress common.Address
-	Logs            []*LogForStorage
-	GasUsed         uint64
+	Logs              []*DeprecatedLogForStorage1
 }
 
 // NewReceipt creates a barebone transaction receipt, copying the init fields.
@@ -193,6 +179,7 @@ func (r *ReceiptForStorage) EncodeRLP(w io.Writer) error {
 		Logs:              make([]*LogForStorage, len(r.Logs)),
 	}
 	for i, log := range r.Logs {
+		//log.Data = leadingZeroEncode(log.Data)
 		enc.Logs[i] = (*LogForStorage)(log)
 	}
 	return rlp.Encode(w, enc)
@@ -206,19 +193,6 @@ func (r *ReceiptForStorage) DecodeRLP(s *rlp.Stream) error {
 	if err != nil {
 		return err
 	}
-	// Try decoding from the newest format for future proofness, then the older one
-	// for old nodes that just upgraded. V4 was an intermediate unreleased format so
-	// we do need to decode it, but it's not common (try last).
-	if err := decodeStoredReceiptRLP(r, blob); err == nil {
-		return nil
-	}
-	if err := decodeV3StoredReceiptRLP(r, blob); err == nil {
-		return nil
-	}
-	return decodeV4StoredReceiptRLP(r, blob)
-}
-
-func decodeStoredReceiptRLP(r *ReceiptForStorage, blob []byte) error {
 	var stored storedReceiptRLP
 	if err := rlp.DecodeBytes(blob, &stored); err != nil {
 		return err
@@ -229,49 +203,10 @@ func decodeStoredReceiptRLP(r *ReceiptForStorage, blob []byte) error {
 	r.CumulativeGasUsed = stored.CumulativeGasUsed
 	r.Logs = make([]*Log, len(stored.Logs))
 	for i, log := range stored.Logs {
+		//log.Data = leadingZeroDecode(log.Data)
 		r.Logs[i] = (*Log)(log)
 	}
 	//r.Bloom = CreateBloom(Receipts{(*Receipt)(r)})
-
-	return nil
-}
-
-func decodeV4StoredReceiptRLP(r *ReceiptForStorage, blob []byte) error {
-	var stored v4StoredReceiptRLP
-	if err := rlp.DecodeBytes(blob, &stored); err != nil {
-		return err
-	}
-	if err := (*Receipt)(r).setStatus(stored.PostStateOrStatus); err != nil {
-		return err
-	}
-	r.CumulativeGasUsed = stored.CumulativeGasUsed
-	r.TxHash = stored.TxHash
-	r.ContractAddress = stored.ContractAddress
-	r.GasUsed = stored.GasUsed
-	r.Logs = make([]*Log, len(stored.Logs))
-	for i, log := range stored.Logs {
-		r.Logs[i] = (*Log)(log)
-	}
-	//r.Bloom = CreateBloom(Receipts{(*Receipt)(r)})
-
-	return nil
-}
-
-func decodeV3StoredReceiptRLP(r *ReceiptForStorage, blob []byte) error {
-	var stored v3StoredReceiptRLP
-	if err := rlp.DecodeBytes(blob, &stored); err != nil {
-		return err
-	}
-	if err := (*Receipt)(r).setStatus(stored.PostStateOrStatus); err != nil {
-		return err
-	}
-	r.CumulativeGasUsed = stored.CumulativeGasUsed
-	r.ContractAddress = stored.ContractAddress
-	r.GasUsed = stored.GasUsed
-	r.Logs = make([]*Log, len(stored.Logs))
-	for i, log := range stored.Logs {
-		r.Logs[i] = (*Log)(log)
-	}
 	return nil
 }
 
@@ -330,4 +265,75 @@ func (r Receipts) DeriveFields(hash common.Hash, number uint64, txs Transactions
 		}
 	}
 	return nil
+}
+
+// DeprecatedReceiptForStorage1 - same as ReceiptForStorage but without leading zero compression
+type DeprecatedReceiptForStorage1 Receipt
+
+// DecodeRLP implements rlp.Decoder, and loads both consensus and implementation
+// fields of a receipt from an RLP stream.
+func (r *DeprecatedReceiptForStorage1) DecodeRLP(s *rlp.Stream) error {
+	// Retrieve the entire receipt blob as we need to try multiple decoders
+	blob, err := s.Raw()
+	if err != nil {
+		return err
+	}
+	var stored deprecatedStoredReceiptRLP1
+	if err := rlp.DecodeBytes(blob, &stored); err != nil {
+		return err
+	}
+	if err := (*Receipt)(r).setStatus(stored.PostStateOrStatus); err != nil {
+		return err
+	}
+	r.CumulativeGasUsed = stored.CumulativeGasUsed
+	r.Logs = make([]*Log, len(stored.Logs))
+	for i, log := range stored.Logs {
+		r.Logs[i] = (*Log)(log)
+	}
+	return nil
+}
+
+// 1st byte stores amount of leading zeroes - it's db-level detail, don't return it to user
+func leadingZeroEncode(in []byte) []byte { // nolint:deadcode,unused
+	if len(in) == 0 {
+		return in
+	}
+
+	leadingZeros := uint8(0)
+	for i := 0; i < len(in); i++ {
+		if in[i] != 0 || leadingZeros == 255 {
+			break
+		}
+		leadingZeros++
+	}
+	var out []byte
+	if leadingZeros > 0 {
+		out = common.CopyBytes(in)
+		out[leadingZeros-1] = leadingZeros
+		out = out[leadingZeros-1:]
+	} else {
+		out = append([]byte{0}, in...)
+	}
+
+	return out
+}
+
+// 1st byte stores amount of leading zeroes - it's db-level detail, don't return it to user
+func leadingZeroDecode(in []byte) []byte { // nolint:deadcode,unused
+	if len(in) == 0 {
+		return in
+	}
+
+	if in[0] == 0 {
+		return in[1:]
+	}
+
+	if in[0] == 1 {
+		in[0] = 0
+		return in
+	}
+
+	withLeadingZeroes := make([]byte, int(in[0])+len(in)-1)
+	copy(withLeadingZeroes[int(in[0]):], in[1:])
+	return withLeadingZeroes
 }

--- a/eth/api_backend.go
+++ b/eth/api_backend.go
@@ -225,7 +225,6 @@ func (b *EthAPIBackend) getReceiptsByReApplyingTransactions(block *types.Block, 
 func (b *EthAPIBackend) tryGetReceiptsFromDb(block *types.Block) types.Receipts {
 	return rawdb.ReadReceipts(
 		b.eth.chainDb,
-		block.Hash(),
 		block.NumberU64(),
 	)
 }

--- a/eth/downloader/fakepeer.go
+++ b/eth/downloader/fakepeer.go
@@ -154,7 +154,7 @@ func (p *FakePeer) RequestBodies(hashes []common.Hash) error {
 func (p *FakePeer) RequestReceipts(hashes []common.Hash) error {
 	var receipts [][]*types.Receipt
 	for _, hash := range hashes {
-		receipts = append(receipts, rawdb.ReadRawReceipts(p.db, hash, *p.hc.GetBlockNumber(p.db, hash)))
+		receipts = append(receipts, rawdb.ReadRawReceipts(p.db, *p.hc.GetBlockNumber(p.db, hash)))
 	}
 	p.dl.DeliverReceipts(p.id, receipts)
 	return nil

--- a/eth/filters/filter_system_test.go
+++ b/eth/filters/filter_system_test.go
@@ -83,7 +83,7 @@ func (b *testBackend) HeaderByHash(ctx context.Context, hash common.Hash) (*type
 
 func (b *testBackend) GetReceipts(ctx context.Context, hash common.Hash) (types.Receipts, error) {
 	if number := rawdb.ReadHeaderNumber(b.db, hash); number != nil {
-		return rawdb.ReadReceipts(b.db, hash, *number), nil
+		return rawdb.ReadReceipts(b.db, *number), nil
 	}
 	return nil, nil
 }
@@ -93,7 +93,7 @@ func (b *testBackend) GetLogs(ctx context.Context, hash common.Hash) ([][]*types
 	if number == nil {
 		return nil, nil
 	}
-	receipts := rawdb.ReadReceipts(b.db, hash, *number)
+	receipts := rawdb.ReadReceipts(b.db, *number)
 
 	logs := make([][]*types.Log, len(receipts))
 	for i, receipt := range receipts {

--- a/eth/filters/filter_test.go
+++ b/eth/filters/filter_test.go
@@ -88,7 +88,7 @@ func BenchmarkFilters(b *testing.B) {
 		rawdb.WriteBlock(context.Background(), db, block)
 		rawdb.WriteCanonicalHash(db, block.Hash(), block.NumberU64())
 		rawdb.WriteHeadBlockHash(db, block.Hash())
-		rawdb.WriteReceipts(db, block.Hash(), block.NumberU64(), receipts[i])
+		rawdb.WriteReceipts(db, block.NumberU64(), receipts[i])
 	}
 	b.ResetTimer()
 
@@ -169,7 +169,7 @@ func TestFilters(t *testing.T) {
 		rawdb.WriteBlock(context.Background(), db, block)
 		rawdb.WriteCanonicalHash(db, block.Hash(), block.NumberU64())
 		rawdb.WriteHeadBlockHash(db, block.Hash())
-		rawdb.WriteReceipts(db, block.Hash(), block.NumberU64(), receipts[i])
+		rawdb.WriteReceipts(db, block.NumberU64(), receipts[i])
 	}
 
 	filter := NewRangeFilter(backend, 0, -1, []common.Address{addr}, [][]common.Hash{{hash1, hash2, hash3, hash4}})

--- a/eth/stagedsync/stage_log_index_test.go
+++ b/eth/stagedsync/stage_log_index_test.go
@@ -43,10 +43,10 @@ func TestLogIndex(t *testing.T) {
 			},
 		},
 	}}
-	err = appendReceipts(tx, receipts1, 1, common.Hash{})
+	err = appendReceipts(tx, receipts1, 1)
 	require.NoError(err)
 
-	err = appendReceipts(tx, receipts2, 2, common.Hash{})
+	err = appendReceipts(tx, receipts2, 2)
 	require.NoError(err)
 
 	err = promoteLogIndex(tx, 0, nil)

--- a/ethdb/bitmapdb/dbutils.go
+++ b/ethdb/bitmapdb/dbutils.go
@@ -164,6 +164,14 @@ func TruncateRange(c ethdb.Cursor, key []byte, from, to uint64) error {
 	return nil
 }
 
+func Has(c ethdb.Cursor, key []byte) (bool, error) {
+	k, _, err := c.Seek(key)
+	if err != nil {
+		return false, err
+	}
+	return bytes.HasPrefix(k, key), nil
+}
+
 func Get(c ethdb.Cursor, key []byte) (*gocroaring.Bitmap, error) {
 	var shards []*gocroaring.Bitmap
 	for k, v, err := c.Seek(key); k != nil; k, v, err = c.Next() {

--- a/ethdb/mutation.go
+++ b/ethdb/mutation.go
@@ -239,6 +239,10 @@ func (m *mutation) MemCopy() Database {
 	return m.db
 }
 
+func (m *mutation) WithCounters(key []byte, counters Counters) (Counters, error) {
+	panic("only TxDb supports this method")
+}
+
 // [TURBO-GETH] Freezer support (not implemented yet)
 // Ancients returns an error as we don't have a backing chain freezer.
 func (m *mutation) Ancients() (uint64, error) {

--- a/ethdb/object_db.go
+++ b/ethdb/object_db.go
@@ -372,6 +372,10 @@ func (db *ObjectDatabase) Reserve(bucket string, key []byte, i int) ([]byte, err
 	panic("supported only by TxDb")
 }
 
+func (db *ObjectDatabase) WithCounters(key []byte, counters Counters) (Counters, error) {
+	panic("only TxDb supports this method")
+}
+
 // Type which expecting sequence of triplets: dbi, key, value, ....
 // It sorts entries by dbi name, then inside dbi clusters sort by keys
 type MultiPutTuples [][]byte

--- a/ethdb/tx_db.go
+++ b/ethdb/tx_db.go
@@ -3,6 +3,7 @@ package ethdb
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"github.com/ledgerwatch/turbo-geth/metrics"
 	"time"
@@ -23,6 +24,7 @@ type TxDb struct {
 	ParentTx Tx
 	cursors  map[string]Cursor
 	len      uint64
+	counters map[string]Counters
 }
 
 func (m *TxDb) Close() {
@@ -350,6 +352,9 @@ func (m *TxDb) Commit() (uint64, error) {
 	if m.tx == nil {
 		return 0, fmt.Errorf("second call .Commit() on same transaction")
 	}
+	if err := m.flushCounters(); err != nil {
+		return 0, err
+	}
 	if err := m.tx.Commit(context.Background()); err != nil {
 		return 0, err
 	}
@@ -366,6 +371,7 @@ func (m *TxDb) Rollback() {
 	}
 	m.tx.Rollback()
 	m.cursors = nil
+	m.counters = nil
 	m.tx = nil
 	m.ParentTx = nil
 	m.len = 0
@@ -435,4 +441,77 @@ func (m *TxDb) DropBuckets(buckets ...string) error {
 		}
 	}
 	return nil
+}
+
+func (m *TxDb) WithCounters(key []byte, counters Counters) (Counters, error) {
+	if m.counters == nil {
+		m.counters = make(map[string]Counters)
+	}
+	c, ok := m.counters[string(key)]
+	if ok {
+		return c, nil
+	}
+
+	m.counters[string(key)] = counters
+
+	v, err := m.Get(dbutils.Counters, key)
+	if err != nil {
+		if errors.Is(err, ErrKeyNotFound) {
+			return counters, nil
+		}
+		return nil, err
+	}
+	err = counters.Unmarshal(v)
+	if err != nil {
+		return nil, err
+	}
+	return counters, nil
+}
+
+func (m *TxDb) flushCounters() error {
+	for k, obj := range m.counters {
+		newV, err := obj.Marshal()
+		if err != nil {
+			return err
+		}
+
+		err = m.Put(dbutils.Counters, []byte(k), newV)
+		if err != nil {
+			return err
+		}
+	}
+
+	m.counters = nil
+	return nil
+}
+
+type CountersStorage interface {
+	WithCounters(key []byte, counters Counters) (Counters, error)
+}
+
+var keyIDsBytes = []byte(dbutils.KeyIDs)
+
+// Ids - returns ids of all last inserted entities to db,
+// !Important: increment before use.
+// to understand more about this method, see docs of DbWithPendingMutations.WithCounters
+func Ids(db CountersStorage) (*dbutils.IDs, error) {
+	v, err := db.WithCounters(keyIDsBytes, &dbutils.IDs{})
+	if err != nil {
+		return nil, err
+	}
+	return v.(*dbutils.IDs), nil
+}
+
+var keyAggregatesBytes = []byte(dbutils.KeyAggregates)
+
+// Aggregates - returns last state of all aggregated values in current database,
+// If you need store min/max or other single-value aggregated value about any data - store it here.
+//
+// to understand more about this method, see docs of DbWithPendingMutations.WithCounters
+func Aggregates(db CountersStorage) (*dbutils.Aggregates, error) {
+	v, err := db.WithCounters(keyAggregatesBytes, &dbutils.Aggregates{})
+	if err != nil {
+		return nil, err
+	}
+	return v.(*dbutils.Aggregates), nil
 }

--- a/migrations/compress_receipts.go
+++ b/migrations/compress_receipts.go
@@ -1,0 +1,168 @@
+package migrations
+
+import (
+	"bytes"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"github.com/ledgerwatch/turbo-geth/common"
+	"github.com/ledgerwatch/turbo-geth/common/dbutils"
+	"github.com/ledgerwatch/turbo-geth/common/etl"
+	"github.com/ledgerwatch/turbo-geth/core/rawdb"
+	"github.com/ledgerwatch/turbo-geth/core/types"
+	"github.com/ledgerwatch/turbo-geth/ethdb"
+	"github.com/ledgerwatch/turbo-geth/log"
+	"github.com/ledgerwatch/turbo-geth/rlp"
+	"time"
+)
+
+var receiptLeadingZeroes = Migration{
+	Name: "receipt_leading_zeroes_and_topic_id_5",
+	Up: func(tx ethdb.DbWithPendingMutations, datadir string, OnLoadCommit etl.LoadCommitHandler) error {
+		if exists, err := tx.(ethdb.BucketsMigrator).BucketExists(dbutils.BlockReceiptsPrefixOld1); err != nil {
+			return err
+		} else if !exists {
+			return OnLoadCommit(tx, nil, true)
+		}
+
+		if err := tx.(ethdb.BucketsMigrator).ClearBuckets(dbutils.BlockReceipts, dbutils.LogTopic2Id, dbutils.LogId2Topic); err != nil {
+			return err
+		}
+
+		logEvery := time.NewTicker(30 * time.Second)
+		defer logEvery.Stop()
+
+		ids, err := ethdb.Ids(tx)
+		if err != nil {
+			return err
+		}
+		ids.Topic = 0 // Important! to reset topicID counter
+
+		iBytes := make([]byte, 4)
+		if err := tx.Walk(dbutils.BlockReceiptsPrefixOld1, nil, 0, func(k, v []byte) (bool, error) {
+			blockHashBytes := k[len(k)-32:]
+			blockNum64Bytes := k[:len(k)-32]
+			blockNum := binary.BigEndian.Uint64(blockNum64Bytes)
+			canonicalHash := rawdb.ReadCanonicalHash(tx, blockNum)
+			if !bytes.Equal(blockHashBytes, canonicalHash[:]) {
+				return true, nil
+			}
+
+			// Decode the receipts by legacy data type
+			storageReceiptsLegacy := []*types.DeprecatedReceiptForStorage1{}
+			if err := rlp.DecodeBytes(v, &storageReceiptsLegacy); err != nil {
+				return false, fmt.Errorf("invalid receipt array RLP: %w, blockNum=%d", err, blockNum)
+			}
+
+			// Encode by new data type
+			storageReceipts := make([]*types.ReceiptForStorage, len(storageReceiptsLegacy))
+			for i, r := range storageReceiptsLegacy {
+				storageReceipts[i] = (*types.ReceiptForStorage)(r)
+			}
+
+			for ri, r := range storageReceiptsLegacy {
+				for li, l := range r.Logs {
+					storageReceipts[ri].Logs[li].TopicIds = make([]uint32, len(storageReceipts[ri].Logs[li].Topics))
+					for ti, topic := range l.Topics {
+						id, err := tx.Get(dbutils.LogTopic2Id, topic[:])
+						if err != nil && !errors.Is(err, ethdb.ErrKeyNotFound) {
+							return false, err
+						}
+
+						// create topic if not exists with topicID++
+						if err != nil && errors.Is(err, ethdb.ErrKeyNotFound) {
+							ids.Topic++
+							binary.BigEndian.PutUint32(iBytes, ids.Topic)
+							storageReceipts[ri].Logs[li].TopicIds[ti] = ids.Topic
+
+							err = tx.Put(dbutils.LogTopic2Id, topic[:], common.CopyBytes(iBytes))
+							if err != nil {
+								return false, err
+							}
+							err = tx.Append(dbutils.LogId2Topic, common.CopyBytes(iBytes), topic[:])
+							if err != nil {
+								return false, err
+							}
+							continue
+						}
+
+						storageReceipts[ri].Logs[li].TopicIds[ti] = binary.BigEndian.Uint32(id)
+					}
+				}
+			}
+
+			newV, err := rlp.EncodeToBytes(storageReceipts)
+			if err != nil {
+				log.Crit("Failed to encode block receipts", "err", err)
+			}
+
+			if err := tx.Append(dbutils.BlockReceipts, blockNum64Bytes, newV); err != nil {
+				return false, err
+			}
+
+			select {
+			default:
+			case <-logEvery.C:
+				sz, _ := tx.(ethdb.HasTx).Tx().BucketSize(dbutils.BlockReceipts)
+				sz1, _ := tx.(ethdb.HasTx).Tx().BucketSize(dbutils.LogTopic2Id)
+				sz2, _ := tx.(ethdb.HasTx).Tx().BucketSize(dbutils.LogId2Topic)
+				log.Info("Progress", "blockNum", blockNum,
+					dbutils.BlockReceipts, common.StorageSize(sz),
+					dbutils.LogTopic2Id, common.StorageSize(sz1),
+					dbutils.LogId2Topic, common.StorageSize(sz2),
+				)
+			}
+			return true, nil
+		}); err != nil {
+			return err
+		}
+
+		//if err := tx.(ethdb.BucketsMigrator).DropBuckets(dbutils.BlockReceiptsPrefixOld1); err != nil {
+		//	return err
+		//}
+		return OnLoadCommit(tx, nil, true)
+	},
+}
+
+var topicIndexID = Migration{
+	Name: "topic_index_id",
+	Up: func(tx ethdb.DbWithPendingMutations, datadir string, OnLoadCommit etl.LoadCommitHandler) error {
+		extractFunc := func(k []byte, v []byte, next etl.ExtractNextFunc) error {
+			if len(k) != 32+2 {
+				return next(k, k, v)
+			}
+
+			topic := k[:32]
+			shardN := k[32:]
+
+			if err := next(k, k, nil); err != nil { // delete old type of keys
+				return err
+			}
+
+			id, err := tx.Get(dbutils.LogTopic2Id, topic[:])
+			if err != nil {
+				return err
+			}
+
+			newK := make([]byte, 4+2)
+			copy(newK[:4], id)
+			copy(newK[4:], shardN)
+
+			if err := next(k, newK, v); err != nil { // create new type of keys
+				return err
+			}
+
+			return nil
+		}
+
+		return etl.Transform(
+			tx,
+			dbutils.LogTopicIndex,
+			dbutils.LogTopicIndex,
+			datadir,
+			extractFunc,
+			etl.IdentityLoadFunc,
+			etl.TransformArgs{OnLoadCommit: OnLoadCommit},
+		)
+	},
+}

--- a/migrations/compress_receipts.go
+++ b/migrations/compress_receipts.go
@@ -16,8 +16,8 @@ import (
 	"time"
 )
 
-var receiptLeadingZeroes = Migration{
-	Name: "receipt_leading_zeroes_and_topic_id_5",
+var receiptsTopicNormalForm = Migration{
+	Name: "receipt_topic_normal_form",
 	Up: func(tx ethdb.DbWithPendingMutations, datadir string, OnLoadCommit etl.LoadCommitHandler) error {
 		if exists, err := tx.(ethdb.BucketsMigrator).BucketExists(dbutils.BlockReceiptsPrefixOld1); err != nil {
 			return err

--- a/migrations/dupsort_state.go
+++ b/migrations/dupsort_state.go
@@ -141,7 +141,7 @@ var clearIndices = Migration{
 
 var resetIHBucketToRecoverDB = Migration{
 	Name: "reset_in_bucket_to_recover_db",
-	Up: func(db ethdb.Database, datadir string, OnLoadCommit etl.LoadCommitHandler) error {
+	Up: func(db ethdb.DbWithPendingMutations, datadir string, OnLoadCommit etl.LoadCommitHandler) error {
 		if err := db.(ethdb.BucketsMigrator).ClearBuckets(dbutils.IntermediateTrieHashBucket); err != nil {
 			return err
 		}

--- a/migrations/dupsort_state.go
+++ b/migrations/dupsort_state.go
@@ -12,7 +12,7 @@ import (
 
 var dupSortHashState = Migration{
 	Name: "dupsort_hash_state",
-	Up: func(db ethdb.Database, datadir string, OnLoadCommit etl.LoadCommitHandler) error {
+	Up: func(db ethdb.DbWithPendingMutations, datadir string, OnLoadCommit etl.LoadCommitHandler) error {
 		if exists, err := db.(ethdb.BucketsMigrator).BucketExists(dbutils.CurrentStateBucketOld1); err != nil {
 			return err
 		} else if !exists {
@@ -47,7 +47,7 @@ var dupSortHashState = Migration{
 
 var dupSortPlainState = Migration{
 	Name: "dupsort_plain_state",
-	Up: func(db ethdb.Database, datadir string, OnLoadCommit etl.LoadCommitHandler) error {
+	Up: func(db ethdb.DbWithPendingMutations, datadir string, OnLoadCommit etl.LoadCommitHandler) error {
 		if exists, err := db.(ethdb.BucketsMigrator).BucketExists(dbutils.PlainStateBucketOld1); err != nil {
 			return err
 		} else if !exists {
@@ -82,7 +82,7 @@ var dupSortPlainState = Migration{
 
 var dupSortIH = Migration{
 	Name: "dupsort_intermediate_trie_hashes",
-	Up: func(db ethdb.Database, datadir string, OnLoadCommit etl.LoadCommitHandler) error {
+	Up: func(db ethdb.DbWithPendingMutations, datadir string, OnLoadCommit etl.LoadCommitHandler) error {
 		if err := db.(ethdb.BucketsMigrator).ClearBuckets(dbutils.IntermediateTrieHashBucket); err != nil {
 			return err
 		}
@@ -123,7 +123,7 @@ var dupSortIH = Migration{
 
 var clearIndices = Migration{
 	Name: "clear_log_indices6",
-	Up: func(db ethdb.Database, datadir string, OnLoadCommit etl.LoadCommitHandler) error {
+	Up: func(db ethdb.DbWithPendingMutations, datadir string, OnLoadCommit etl.LoadCommitHandler) error {
 		if err := db.(ethdb.BucketsMigrator).ClearBuckets(dbutils.LogAddressIndex, dbutils.LogTopicIndex); err != nil {
 			return err
 		}

--- a/migrations/migrations.go
+++ b/migrations/migrations.go
@@ -63,9 +63,8 @@ var migrations = []Migration{
 	dupSortIH,
 	clearIndices,
 	resetIHBucketToRecoverDB,
-	receiptLeadingZeroes,
+	receiptsTopicNormalForm,
 	topicIndexID,
-	//receiptLeadingZeroes2,
 }
 
 type Migration struct {

--- a/migrations/migrations.go
+++ b/migrations/migrations.go
@@ -63,11 +63,14 @@ var migrations = []Migration{
 	dupSortIH,
 	clearIndices,
 	resetIHBucketToRecoverDB,
+	receiptLeadingZeroes,
+	topicIndexID,
+	//receiptLeadingZeroes2,
 }
 
 type Migration struct {
 	Name string
-	Up   func(db ethdb.Database, dataDir string, OnLoadCommit etl.LoadCommitHandler) error
+	Up   func(db ethdb.DbWithPendingMutations, dataDir string, OnLoadCommit etl.LoadCommitHandler) error
 }
 
 var (

--- a/migrations/migrations_test.go
+++ b/migrations/migrations_test.go
@@ -17,13 +17,13 @@ func TestApplyWithInit(t *testing.T) {
 	migrations = []Migration{
 		{
 			"one",
-			func(db ethdb.Database, datadir string, OnLoadCommit etl.LoadCommitHandler) error {
+			func(db ethdb.DbWithPendingMutations, datadir string, OnLoadCommit etl.LoadCommitHandler) error {
 				return OnLoadCommit(db, nil, true)
 			},
 		},
 		{
 			"two",
-			func(db ethdb.Database, datadir string, OnLoadCommit etl.LoadCommitHandler) error {
+			func(db ethdb.DbWithPendingMutations, datadir string, OnLoadCommit etl.LoadCommitHandler) error {
 				return OnLoadCommit(db, nil, true)
 			},
 		},
@@ -56,14 +56,14 @@ func TestApplyWithoutInit(t *testing.T) {
 	migrations = []Migration{
 		{
 			"one",
-			func(db ethdb.Database, datadir string, OnLoadCommit etl.LoadCommitHandler) error {
+			func(db ethdb.DbWithPendingMutations, datadir string, OnLoadCommit etl.LoadCommitHandler) error {
 				t.Fatal("shouldn't been executed")
 				return nil
 			},
 		},
 		{
 			"two",
-			func(db ethdb.Database, datadir string, OnLoadCommit etl.LoadCommitHandler) error {
+			func(db ethdb.DbWithPendingMutations, datadir string, OnLoadCommit etl.LoadCommitHandler) error {
 				return OnLoadCommit(db, nil, true)
 			},
 		},
@@ -99,13 +99,13 @@ func TestWhenNonFirstMigrationAlreadyApplied(t *testing.T) {
 	migrations = []Migration{
 		{
 			"one",
-			func(db ethdb.Database, datadir string, OnLoadCommit etl.LoadCommitHandler) error {
+			func(db ethdb.DbWithPendingMutations, datadir string, OnLoadCommit etl.LoadCommitHandler) error {
 				return OnLoadCommit(db, nil, true)
 			},
 		},
 		{
 			"two",
-			func(db ethdb.Database, datadir string, OnLoadCommit etl.LoadCommitHandler) error {
+			func(db ethdb.DbWithPendingMutations, datadir string, OnLoadCommit etl.LoadCommitHandler) error {
 				t.Fatal("shouldn't been executed")
 				return nil
 			},
@@ -160,13 +160,13 @@ func TestValidation(t *testing.T) {
 	migrations = []Migration{
 		{
 			Name: "repeated_name",
-			Up: func(db ethdb.Database, datadir string, OnLoadCommit etl.LoadCommitHandler) error {
+			Up: func(db ethdb.DbWithPendingMutations, datadir string, OnLoadCommit etl.LoadCommitHandler) error {
 				return OnLoadCommit(db, nil, true)
 			},
 		},
 		{
 			Name: "repeated_name",
-			Up: func(db ethdb.Database, datadir string, OnLoadCommit etl.LoadCommitHandler) error {
+			Up: func(db ethdb.DbWithPendingMutations, datadir string, OnLoadCommit etl.LoadCommitHandler) error {
 				return OnLoadCommit(db, nil, true)
 			},
 		},
@@ -186,7 +186,7 @@ func TestCommitCallRequired(t *testing.T) {
 	migrations = []Migration{
 		{
 			Name: "one",
-			Up: func(db ethdb.Database, datadir string, OnLoadCommit etl.LoadCommitHandler) error {
+			Up: func(db ethdb.DbWithPendingMutations, datadir string, OnLoadCommit etl.LoadCommitHandler) error {
 				return nil // don't call OnLoadCommit
 			},
 		},

--- a/migrations/stagedsync_to_use_stage_blockhashes.go
+++ b/migrations/stagedsync_to_use_stage_blockhashes.go
@@ -8,7 +8,7 @@ import (
 
 var stagedsyncToUseStageBlockhashes = Migration{
 	Name: "stagedsync_to_use_stage_blockhashes",
-	Up: func(db ethdb.Database, datadir string, OnLoadCommit etl.LoadCommitHandler) error {
+	Up: func(db ethdb.DbWithPendingMutations, datadir string, OnLoadCommit etl.LoadCommitHandler) error {
 
 		var progress uint64
 		var err error
@@ -30,7 +30,7 @@ var stagedsyncToUseStageBlockhashes = Migration{
 
 var unwindStagedsyncToUseStageBlockhashes = Migration{
 	Name: "unwind_stagedsync_to_use_stage_blockhashes",
-	Up: func(db ethdb.Database, datadir string, OnLoadCommit etl.LoadCommitHandler) error {
+	Up: func(db ethdb.DbWithPendingMutations, datadir string, OnLoadCommit etl.LoadCommitHandler) error {
 
 		var progress uint64
 		var err error

--- a/migrations/stages_to_use_named_keys.go
+++ b/migrations/stages_to_use_named_keys.go
@@ -24,7 +24,7 @@ var dbKeys = []stages.SyncStage{
 
 var stagesToUseNamedKeys = Migration{
 	Name: "stages_to_use_named_keys",
-	Up: func(db ethdb.Database, datadir string, OnLoadCommit etl.LoadCommitHandler) error {
+	Up: func(db ethdb.DbWithPendingMutations, datadir string, OnLoadCommit etl.LoadCommitHandler) error {
 
 		if exists, err := db.(ethdb.BucketsMigrator).BucketExists(dbutils.SyncStageProgressOld1); err != nil {
 			return err
@@ -69,7 +69,7 @@ var stagesToUseNamedKeys = Migration{
 
 var unwindStagesToUseNamedKeys = Migration{
 	Name: "unwind_stages_to_use_named_keys",
-	Up: func(db ethdb.Database, datadir string, OnLoadCommit etl.LoadCommitHandler) error {
+	Up: func(db ethdb.DbWithPendingMutations, datadir string, OnLoadCommit etl.LoadCommitHandler) error {
 		if exists, err := db.(ethdb.BucketsMigrator).BucketExists(dbutils.SyncStageUnwindOld1); err != nil {
 			return err
 		} else if !exists {


### PR DESCRIPTION
About topics enumeration. It:
- reduces Receipt buckets size to 80Gb
- adding topic -> topicID bucket = 700Mb, and topicID->topic bucket = 5GB
- also reducing bucket log_indices bucket from 13Gb to 11Gb.

It not increase much amount of calls from rpcdaemon (for all filtered logs - fetch topics by id's). 
It adding a bit logic to exec stage: Block execution producing Receipt with topics and need convert them to ids by calling topicID->topic.

About first experiments with zstd:
- Interesting thing is - you can manage: "amount of training samples", "size of dictionary", "level of compression" to fit into given overhead requirements. 
- I set requirement: overhead of compression all Receipts/BlockBodies is not more than 3Min. 
- And it shows 4x compression of Receipts, 3x compression of Receipts after topics enumeration, 1.5x compression of blocks: on 32Kb dictionary, 4K samples and compression level=-2 (it's between -22 and +22, default is 3).