### PR TITLE
History-style sharding for bitmap indices 

### DIFF
--- a/cmd/rpcdaemon/commands/get_receipts.go
+++ b/cmd/rpcdaemon/commands/get_receipts.go
@@ -3,8 +3,6 @@ package commands
 import (
 	"context"
 	"fmt"
-	"math/big"
-
 	"github.com/RoaringBitmap/gocroaring"
 	"github.com/ledgerwatch/turbo-geth/common"
 	"github.com/ledgerwatch/turbo-geth/common/dbutils"
@@ -18,6 +16,7 @@ import (
 	"github.com/ledgerwatch/turbo-geth/ethdb/bitmapdb"
 	"github.com/ledgerwatch/turbo-geth/turbo/adapter"
 	"github.com/ledgerwatch/turbo-geth/turbo/transactions"
+	"math/big"
 )
 
 func getReceipts(ctx context.Context, tx rawdb.DatabaseReader, kv ethdb.KV, number uint64, hash common.Hash) (types.Receipts, error) {
@@ -109,7 +108,7 @@ func (api *APIImpl) GetLogs(ctx context.Context, crit filters.FilterCriteria) ([
 	blockNumbers := gocroaring.New()
 	blockNumbers.AddRange(begin, end+1) // [min,max)
 
-	topicsBitmap, err := getTopicsBitmap(tx.(ethdb.HasTx).Tx().Cursor(dbutils.LogTopicIndex), crit.Topics)
+	topicsBitmap, err := getTopicsBitmap(tx.(ethdb.HasTx).Tx().Cursor(dbutils.LogTopicIndex).Prefetch(1), crit.Topics, uint32(begin), uint32(end))
 	if err != nil {
 		return nil, err
 	}
@@ -124,7 +123,7 @@ func (api *APIImpl) GetLogs(ctx context.Context, crit filters.FilterCriteria) ([
 	logAddrIndex := tx.(ethdb.HasTx).Tx().Cursor(dbutils.LogAddressIndex)
 	var addrBitmap *gocroaring.Bitmap
 	for _, addr := range crit.Addresses {
-		m, err := bitmapdb.Get(logAddrIndex, addr[:])
+		m, err := bitmapdb.Get(logAddrIndex, addr[:], uint32(begin), uint32(end))
 		if err != nil {
 			return nil, err
 		}
@@ -178,12 +177,12 @@ func (api *APIImpl) GetLogs(ctx context.Context, crit filters.FilterCriteria) ([
 // {{}, {B}}          matches any topic in first position AND B in second position
 // {{A}, {B}}         matches topic A in first position AND B in second position
 // {{A, B}, {C, D}}   matches topic (A OR B) in first position AND (C OR D) in second position
-func getTopicsBitmap(c ethdb.Cursor, topics [][]common.Hash) (*gocroaring.Bitmap, error) {
+func getTopicsBitmap(c ethdb.Cursor, topics [][]common.Hash, from, to uint32) (*gocroaring.Bitmap, error) {
 	var result *gocroaring.Bitmap
 	for _, sub := range topics {
 		var bitmapForORing *gocroaring.Bitmap
 		for _, topic := range sub {
-			m, err := bitmapdb.Get(c, topic[:])
+			m, err := bitmapdb.Get(c, topic[:], from, to)
 			if err != nil {
 				return nil, err
 			}

--- a/cmd/rpcdaemon/commands/get_receipts.go
+++ b/cmd/rpcdaemon/commands/get_receipts.go
@@ -120,7 +120,7 @@ func (api *APIImpl) GetLogs(ctx context.Context, crit filters.FilterCriteria) ([
 		}
 	}
 
-	logAddrIndex := tx.(ethdb.HasTx).Tx().Cursor(dbutils.LogAddressIndex)
+	logAddrIndex := tx.(ethdb.HasTx).Tx().Cursor(dbutils.LogAddressIndex).Prefetch(1)
 	var addrBitmap *gocroaring.Bitmap
 	for _, addr := range crit.Addresses {
 		m, err := bitmapdb.Get(logAddrIndex, addr[:], uint32(begin), uint32(end))

--- a/common/dbutils/bucket.go
+++ b/common/dbutils/bucket.go
@@ -119,11 +119,9 @@ var (
 	// indices are sharded - because some bitmaps are >1Mb and when new incoming blocks process it
 	//	 updates ~300 of bitmaps - by append small amount new values. It cause much big writes (LMDB does copy-on-write).
 	//
-	// 3 terms are used: cold_shard, hot_shard, delta
-	//   delta - most recent changes (appendable) - which need save into database
-	//   hot_shard - merge delta here until hot_shard size < HotShardLimit, otherwise merge hot to cold
-	//   cold_shard - merge hot_shard here until cold_shard size < ColdShardLimit, otherwise mark hot as cold, create new hot from delta
-	// cold shards never merged for compaction - because it's expensive operation (expensive means attackable)
+	// if last existing shard size merge it with delta
+	// if serialized size of delta > ShardLimit - break down to multiple shards
+	// shard number - it's biggest value in bitmap
 	LogTopicIndex   = "log_topic_index"
 	LogAddressIndex = "log_address_index"
 

--- a/eth/stagedsync/stage_log_index.go
+++ b/eth/stagedsync/stage_log_index.go
@@ -226,10 +226,10 @@ func unwindLogIndex(db ethdb.DbWithPendingMutations, from, to uint64, quitCh <-c
 		}
 	}
 
-	if err := truncateBitmaps(tx.(ethdb.HasTx).Tx(), dbutils.LogTopicIndex, topics, to+1, from+1); err != nil {
+	if err := truncateBitmaps(tx, dbutils.LogTopicIndex, topics, to+1, from+1); err != nil {
 		return err
 	}
-	if err := truncateBitmaps(tx.(ethdb.HasTx).Tx(), dbutils.LogAddressIndex, addrs, to+1, from+1); err != nil {
+	if err := truncateBitmaps(tx, dbutils.LogAddressIndex, addrs, to+1, from+1); err != nil {
 		return err
 	}
 	return nil

--- a/eth/stagedsync/stage_log_index.go
+++ b/eth/stagedsync/stage_log_index.go
@@ -114,7 +114,6 @@ func promoteLogIndex(tx ethdb.DbWithPendingMutations, start uint64, quit <-chan 
 			}
 
 			if needFlush(addresses, logIndicesMemLimit) {
-				topics = map[string]*gocroaring.Bitmap{}
 				if err := flushBitmaps(logAddrIndexCursor, addresses); err != nil {
 					return err
 				}

--- a/eth/stagedsync/stage_log_index_test.go
+++ b/eth/stagedsync/stage_log_index_test.go
@@ -56,19 +56,19 @@ func TestLogIndex(t *testing.T) {
 	logTopicIndex := tx.(ethdb.HasTx).Tx().Cursor(dbutils.LogTopicIndex)
 	logAddrIndex := tx.(ethdb.HasTx).Tx().Cursor(dbutils.LogAddressIndex)
 
-	m, err := bitmapdb.Get(logAddrIndex, addr1[:])
+	m, err := bitmapdb.Get(logAddrIndex, addr1[:], 0, 10_000_000)
 	require.NoError(err)
 	require.Equal(1, int(m.Cardinality()))
 
-	m, err = bitmapdb.Get(logAddrIndex, addr2[:])
+	m, err = bitmapdb.Get(logAddrIndex, addr2[:], 0, 10_000_000)
 	require.NoError(err)
 	require.Equal(1, int(m.Cardinality()))
 
-	m, err = bitmapdb.Get(logTopicIndex, topic1[:])
+	m, err = bitmapdb.Get(logTopicIndex, topic1[:], 0, 10_000_000)
 	require.NoError(err)
-	require.Equal(1, int(m.Cardinality()))
+	require.Equal(1, int(m.Cardinality()), 0, 10_000_000)
 
-	m, err = bitmapdb.Get(logTopicIndex, topic2[:])
+	m, err = bitmapdb.Get(logTopicIndex, topic2[:], 0, 10_000_000)
 	require.NoError(err)
 	require.Equal(2, int(m.Cardinality()))
 
@@ -76,19 +76,19 @@ func TestLogIndex(t *testing.T) {
 	err = unwindLogIndex(tx, 2, 1, nil)
 	require.NoError(err)
 
-	m, err = bitmapdb.Get(logAddrIndex, addr1[:])
+	m, err = bitmapdb.Get(logAddrIndex, addr1[:], 0, 10_000_000)
 	require.NoError(err)
 	require.Equal(1, int(m.Cardinality()))
 
-	m, err = bitmapdb.Get(logAddrIndex, addr2[:])
+	m, err = bitmapdb.Get(logAddrIndex, addr2[:], 0, 10_000_000)
 	require.NoError(err)
 	require.Equal(0, int(m.Cardinality()))
 
-	m, err = bitmapdb.Get(logTopicIndex, topic1[:])
+	m, err = bitmapdb.Get(logTopicIndex, topic1[:], 0, 10_000_000)
 	require.NoError(err)
 	require.Equal(1, int(m.Cardinality()))
 
-	m, err = bitmapdb.Get(logTopicIndex, topic2[:])
+	m, err = bitmapdb.Get(logTopicIndex, topic2[:], 0, 10_000_000)
 	require.NoError(err)
 	require.Equal(1, int(m.Cardinality()))
 
@@ -96,19 +96,19 @@ func TestLogIndex(t *testing.T) {
 	err = unwindLogIndex(tx, 1, 0, nil)
 	require.NoError(err)
 
-	m, err = bitmapdb.Get(logAddrIndex, addr1[:])
+	m, err = bitmapdb.Get(logAddrIndex, addr1[:], 0, 10_000_000)
 	require.NoError(err)
 	require.Equal(0, int(m.Cardinality()))
 
-	m, err = bitmapdb.Get(logAddrIndex, addr2[:])
+	m, err = bitmapdb.Get(logAddrIndex, addr2[:], 0, 10_000_000)
 	require.NoError(err)
 	require.Equal(0, int(m.Cardinality()))
 
-	m, err = bitmapdb.Get(logTopicIndex, topic1[:])
+	m, err = bitmapdb.Get(logTopicIndex, topic1[:], 0, 10_000_000)
 	require.NoError(err)
 	require.Equal(0, int(m.Cardinality()))
 
-	m, err = bitmapdb.Get(logTopicIndex, topic2[:])
+	m, err = bitmapdb.Get(logTopicIndex, topic2[:], 0, 10_000_000)
 	require.NoError(err)
 	require.Equal(0, int(m.Cardinality()))
 }

--- a/ethdb/bitmapdb/dbutils.go
+++ b/ethdb/bitmapdb/dbutils.go
@@ -11,8 +11,6 @@ import (
 
 const ShardLimit = 3 * datasize.KB
 
-var blockNBytes = make([]byte, 4)
-
 // AppendMergeByOr - appending delta to existing data in db, merge by Or
 // Method maintains sharding - because some bitmaps are >1Mb and when new incoming blocks process it
 //	 updates ~300 of bitmaps - by append small amount new values. It cause much big writes (LMDB does copy-on-write).

--- a/ethdb/bitmapdb/dbutils.go
+++ b/ethdb/bitmapdb/dbutils.go
@@ -152,7 +152,7 @@ func TruncateRange(tx ethdb.Tx, bucket string, key []byte, from, to uint64) erro
 
 		bm.RemoveRange(from, to)
 		if bm.GetCardinality() == 0 { // don't store empty bitmaps
-			err := cForDelete.Delete(k)
+			err = cForDelete.Delete(k)
 			if err != nil {
 				return err
 			}

--- a/ethdb/bitmapdb/dbutils.go
+++ b/ethdb/bitmapdb/dbutils.go
@@ -3,121 +3,145 @@ package bitmapdb
 import (
 	"bytes"
 	"encoding/binary"
-	"fmt"
-
 	"github.com/RoaringBitmap/gocroaring"
 	"github.com/c2h5oh/datasize"
 	"github.com/ledgerwatch/turbo-geth/common"
 	"github.com/ledgerwatch/turbo-geth/ethdb"
 )
 
-const ColdShardLimit = 512 * datasize.KB
-const HotShardLimit = 4 * datasize.KB
+//const ShardLimit = 4 * datasize.KB
+const ShardLimit = 3 * datasize.KB
 
-// AppendMergeByOr - appending delta to existing data in db, merge by Or
-// Method maintains sharding - because some bitmaps are >1Mb and when new incoming blocks process it
-//	 updates ~300 of bitmaps - by append small amount new values. It cause much big writes (LMDB does copy-on-write).
-//
-// 3 terms are used: cold_shard, hot_shard, delta
-//   delta - most recent changes (appendable)
-//   hot_shard - merge delta here until hot_shard size < HotShardLimit, otherwise merge hot to cold
-//   cold_shard - merge hot_shard here until cold_shard size < ColdShardLimit, otherwise mark hot as cold, create new hot from delta
-// if no cold shard, create new hot from delta - it will turn hot to cold automatically
-// never merges cold with cold for compaction - because it's expensive operation
+var blockNBytes = make([]byte, 4)
+
 func AppendMergeByOr(c ethdb.Cursor, key []byte, delta *gocroaring.Bitmap) error {
-	shardNForDelta := uint16(0)
+	lastShardKey := make([]byte, len(key)+4)
+	copy(lastShardKey, key)
+	binary.BigEndian.PutUint32(lastShardKey[len(lastShardKey)-4:], ^uint32(0))
 
-	hotK, hotV, seekErr := c.Seek(key)
+	currentLastV, seekErr := c.SeekExact(lastShardKey)
 	if seekErr != nil {
 		return seekErr
 	}
-	if hotK != nil && bytes.HasPrefix(hotK, key) {
-		hotShardN := ^binary.BigEndian.Uint16(hotK[len(hotK)-2:])
-		if len(hotV) > int(HotShardLimit) { // merge hot to cold
-			var err error
-			shardNForDelta, err = hotShardOverflow(c, key, hotShardN, hotV)
-			if err != nil {
-				return err
-			}
-		} else { // merge delta to hot, write result to `hotShardN`
-			hot, err := gocroaring.Read(hotV)
-			if err != nil {
-				return err
-			}
 
-			delta = gocroaring.FastOr(delta, hot)
-			shardNForDelta = hotShardN
+	if currentLastV == nil { // no existing shards, then just create one
+		err := writeBitmapSharded(c, key, delta)
+		if err != nil {
+			return err
 		}
+		return nil
 	}
 
-	newK := make([]byte, len(key)+2)
-	copy(newK, key)
-	binary.BigEndian.PutUint16(newK[len(newK)-2:], ^shardNForDelta)
-
-	//delta.RunOptimize()
-	newV := make([]byte, delta.SerializedSizeInBytes())
-	err := delta.Write(newV)
+	last, err := gocroaring.Read(currentLastV)
 	if err != nil {
 		return err
 	}
-	err = c.Put(newK, newV)
+
+	if len(currentLastV) < int(ShardLimit) { // merge delta to last shard
+		delta = gocroaring.Or(delta, last)
+
+		err = writeBitmapSharded(c, key, delta)
+		if err != nil {
+			return err
+		}
+
+		return nil
+	}
+
+	// rename existing last shard and create new last shard
+	max := last.Maximum()
+	binary.BigEndian.PutUint32(blockNBytes, max)
+	err = c.Put(append(common.CopyBytes(key), blockNBytes...), currentLastV)
+	if err != nil {
+		return err
+	}
+
+	err = writeBitmapSharded(c, key, delta)
 	if err != nil {
 		return err
 	}
 	return nil
 }
 
-func hotShardOverflow(c ethdb.Cursor, initialKey []byte, hotShardN uint16, hotV []byte) (shardNForDelta uint16, err error) {
-	if hotShardN == 0 { // no cold shards, create new hot from delta - it will turn hot to cold automatically
-		return 1, nil
+func writeBitmapSharded(c ethdb.Cursor, key []byte, delta *gocroaring.Bitmap) error {
+	shardKey := make([]byte, len(key)+4)
+	copy(shardKey, key)
+	sz := delta.SerializedSizeInBytes()
+	if sz <= int(ShardLimit) {
+		newV := make([]byte, delta.SerializedSizeInBytes())
+		err := delta.Write(newV)
+		if err != nil {
+			return err
+		}
+		binary.BigEndian.PutUint32(shardKey[len(shardKey)-4:], ^uint32(0))
+		err = c.Put(common.CopyBytes(shardKey), newV)
+		if err != nil {
+			return err
+		}
+		return nil
 	}
 
-	coldK, coldV, err := c.Next() // get cold shard from db
-	if err != nil {
-		return 0, err
+	shardsAmount := uint32(sz / int(ShardLimit))
+	if shardsAmount == 0 {
+		shardsAmount = 1
+	}
+	step := (delta.Maximum() - delta.Minimum()) / shardsAmount
+	step = step / 16
+	shard, tmp := gocroaring.New(), gocroaring.New() // shard will write to db, tmp will use to add data to shard
+	for delta.Cardinality() > 0 {
+		from := uint64(delta.Minimum())
+		to := from + uint64(step)
+		tmp.Clear()
+		tmp.AddRange(from, to)
+		tmp.And(delta)
+		shard.Or(tmp)
+		shard.RunOptimize()
+		delta.RemoveRange(from, to)
+		if delta.Cardinality() == 0 {
+			break
+		}
+		if shard.SerializedSizeInBytes() >= int(ShardLimit) {
+			newV := make([]byte, shard.SerializedSizeInBytes())
+			err := shard.Write(newV)
+			if err != nil {
+				return err
+			}
+			binary.BigEndian.PutUint32(shardKey[len(shardKey)-4:], shard.Maximum())
+
+			err = c.Put(common.CopyBytes(shardKey), newV)
+			if err != nil {
+				return err
+			}
+			shard.Clear()
+		}
 	}
 
-	if coldK == nil || !bytes.HasPrefix(coldK, initialKey) {
-		return 0, fmt.Errorf("cold shard not found in db: key=%x, hotShardN=%d, found=%x", initialKey, hotShardN, coldK)
+	if shard.SerializedSizeInBytes() > 0 {
+		newV := make([]byte, shard.SerializedSizeInBytes())
+		err := shard.Write(newV)
+		if err != nil {
+			return err
+		}
+		binary.BigEndian.PutUint32(shardKey[len(shardKey)-4:], ^uint32(0))
+		err = c.Put(common.CopyBytes(shardKey), newV)
+		if err != nil {
+			return err
+		}
+		return nil
 	}
 
-	if len(coldV) > int(ColdShardLimit) { // cold shard is too big, write delta to `hotShardN + 1` - it will turn hot to cold automatically
-		return hotShardN + 1, nil
-	}
-
-	// merge hot to cold and replace hot by delta (by write delta to `hotShardN`)
-	cold, err := gocroaring.Read(coldV)
-	if err != nil {
-		return 0, err
-	}
-
-	hot, err := gocroaring.Read(hotV)
-	if err != nil {
-		return 0, err
-	}
-
-	cold = gocroaring.FastOr(cold, hot)
-
-	//cold.RunOptimize()
-	coldBytes := make([]byte, cold.SerializedSizeInBytes())
-	err = cold.Write(coldBytes)
-	if err != nil {
-		return 0, err
-	}
-	err = c.Put(common.CopyBytes(coldK), coldBytes) // copy 'coldK' if want replace c.PutCurrent() by c.Put()
-	if err != nil {
-		return 0, err
-	}
-
-	return hotShardN, nil
+	return nil
 }
 
 // TruncateRange - gets existing bitmap in db and call RemoveRange operator on it.
 // starts from hot shard, stops when shard not overlap with [from-to)
 // !Important: [from, to)
 func TruncateRange(c ethdb.Cursor, key []byte, from, to uint64) error {
-	updated := 0
-	for k, v, err := c.Seek(key); k != nil; k, v, err = c.Next() {
+	shardKey := make([]byte, len(key)+4)
+	copy(shardKey, key)
+	binary.BigEndian.PutUint32(shardKey[len(shardKey)-4:], uint32(from))
+
+	for k, v, err := c.Seek(shardKey); k != nil; k, v, err = c.Next() {
 		if err != nil {
 			return err
 		}
@@ -130,17 +154,16 @@ func TruncateRange(c ethdb.Cursor, key []byte, from, to uint64) error {
 		if err != nil {
 			return err
 		}
-		if uint64(bm.Maximum()) < from {
-			break
-		}
-		noReasonToCheckNextShard := uint64(bm.Minimum()) <= from && uint64(bm.Maximum()) >= to
+		noReasonToCheckNextShard := (uint64(bm.Minimum()) <= from && uint64(bm.Maximum()) >= to) || binary.BigEndian.Uint32(k[len(k)-4:]) == ^uint32(0)
 
-		updated++
 		bm.RemoveRange(from, to)
 		if bm.GetCardinality() == 0 { // don't store empty bitmaps
 			err = c.DeleteCurrent()
 			if err != nil {
 				return err
+			}
+			if noReasonToCheckNextShard {
+				break
 			}
 			continue
 		}
@@ -161,12 +184,47 @@ func TruncateRange(c ethdb.Cursor, key []byte, from, to uint64) error {
 		}
 	}
 
+	// rename last shard
+	k, v, err := c.Current()
+	if err != nil {
+		return err
+	}
+	if k == nil { // if last shard was deleted, do 1 step back
+		k, v, err = c.Prev()
+		if err != nil {
+			return err
+		}
+	}
+
+	if binary.BigEndian.Uint32(k[len(k)-4:]) == ^uint32(0) { // nothing to return
+		return nil
+	}
+	if !bytes.HasPrefix(k, key) {
+		return nil
+	}
+
+	copyV := common.CopyBytes(v)
+	err = c.DeleteCurrent()
+	if err != nil {
+		return err
+	}
+
+	binary.BigEndian.PutUint32(shardKey[len(shardKey)-4:], ^uint32(0))
+	err = c.Put(shardKey, copyV)
+	if err != nil {
+		return err
+	}
+
 	return nil
 }
 
-func Get(c ethdb.Cursor, key []byte) (*gocroaring.Bitmap, error) {
+func Get(c ethdb.Cursor, key []byte, from, to uint32) (*gocroaring.Bitmap, error) {
 	var shards []*gocroaring.Bitmap
-	for k, v, err := c.Seek(key); k != nil; k, v, err = c.Next() {
+
+	fromKey := make([]byte, len(key)+4)
+	copy(fromKey, key)
+	binary.BigEndian.PutUint32(fromKey[len(fromKey)-4:], from)
+	for k, v, err := c.Seek(fromKey); k != nil; k, v, err = c.Next() {
 		if err != nil {
 			return nil, err
 		}
@@ -180,6 +238,10 @@ func Get(c ethdb.Cursor, key []byte) (*gocroaring.Bitmap, error) {
 			return nil, err
 		}
 		shards = append(shards, bm)
+
+		if binary.BigEndian.Uint32(k[len(k)-4:]) >= to {
+			break
+		}
 	}
 
 	if len(shards) == 0 {

--- a/ethdb/kv_abstract.go
+++ b/ethdb/kv_abstract.go
@@ -134,6 +134,7 @@ type Cursor interface {
 	PutCurrent(key, value []byte) error
 
 	Count() (uint64, error) // Count - fast way to calculate amount of keys in bucket. It counts all keys even if Prefix was set.
+	Close()
 }
 
 type CursorDupSort interface {

--- a/ethdb/kv_lmdb.go
+++ b/ethdb/kv_lmdb.go
@@ -1159,12 +1159,11 @@ func (c *LmdbCursor) Append(k []byte, v []byte) error {
 	return c.append(k, v)
 }
 
-func (c *LmdbCursor) Close() error {
+func (c *LmdbCursor) Close() {
 	if c.c != nil {
 		c.c.Close()
 		c.c = nil
 	}
-	return nil
 }
 
 type LmdbDupSortCursor struct {

--- a/ethdb/kv_remote.go
+++ b/ethdb/kv_remote.go
@@ -382,6 +382,14 @@ func (c *remoteCursor) Last() ([]byte, []byte, error) {
 	panic("not implemented yet")
 }
 
+func (c *remoteCursor) Close() {
+	if c.stream != nil {
+		c.streamCancelFn() // This will close the stream and free resources
+		c.stream = nil
+		c.streamingRequested = false
+	}
+}
+
 func (tx *remoteTx) CursorDupSort(bucket string) CursorDupSort {
 	return &remoteCursorDupSort{remoteCursor: tx.Cursor(bucket).(*remoteCursor)}
 }

--- a/ethdb/remote/remotedbserver/server.go
+++ b/ethdb/remote/remotedbserver/server.go
@@ -51,8 +51,8 @@ func StartGrpc(kv ethdb.KV, eth core.Backend, addr string, creds *credentials.Tr
 	var grpcServer *grpc.Server
 	if creds == nil {
 		grpcServer = grpc.NewServer(
-			grpc.NumStreamWorkers(20),    // reduce amount of goroutines
-			grpc.WriteBufferSize(114096), // reduce buffers to save mem
+			grpc.NumStreamWorkers(20),  // reduce amount of goroutines
+			grpc.WriteBufferSize(1024), // reduce buffers to save mem
 			grpc.ReadBufferSize(1024),
 			grpc.MaxConcurrentStreams(40), // to force clients reduce concurency level
 			grpc.StreamInterceptor(grpc_middleware.ChainStreamServer(streamInterceptors...)),

--- a/migrations/dupsort_state.go
+++ b/migrations/dupsort_state.go
@@ -2,10 +2,10 @@ package migrations
 
 import (
 	"fmt"
-	"github.com/ledgerwatch/turbo-geth/eth/stagedsync/stages"
 
 	"github.com/ledgerwatch/turbo-geth/common/dbutils"
 	"github.com/ledgerwatch/turbo-geth/common/etl"
+	"github.com/ledgerwatch/turbo-geth/eth/stagedsync/stages"
 	"github.com/ledgerwatch/turbo-geth/ethdb"
 	"github.com/ledgerwatch/turbo-geth/turbo/trie"
 )
@@ -122,7 +122,7 @@ var dupSortIH = Migration{
 }
 
 var clearIndices = Migration{
-	Name: "clear_log_indices6",
+	Name: "clear_log_indices7",
 	Up: func(db ethdb.Database, datadir string, OnLoadCommit etl.LoadCommitHandler) error {
 		if err := db.(ethdb.BucketsMigrator).ClearBuckets(dbutils.LogAddressIndex, dbutils.LogTopicIndex); err != nil {
 			return err


### PR DESCRIPTION
Method `writeBitmapSharded` using not optimal algo to split big bitmap to shards - probably need do kind of binary search. 
But it works fast enough, tomorrow will try to improve/simplify it. 

4Kb shard size - increase bucket size 1%.