### PR TITLE
Update rpcdaemon README

### DIFF
--- a/cmd/rpcdaemon/README.md
+++ b/cmd/rpcdaemon/README.md
@@ -119,7 +119,7 @@ The following table shows the current implementation status of turbo-geth's RPC 
 | eth_getFilterChanges                    | -       |                                            |
 | eth_getFilterLogs                       | -       |                                            |
 | eth_uninstallFilter                     | -       |                                            |
-| eth_getLogs                             | Yes     | remote only                                |
+| eth_getLogs                             | Yes     |                                            |
 |                                         |         |                                            |
 | eth_accounts                            | -       |                                            |
 | eth_sendRawTransaction                  | Yes     | remote only                                |


### PR DESCRIPTION
Just a small README fix since eth_getLogs should now work with `--chaindata`. See https://github.com/ledgerwatch/turbo-geth/issues/1168#issuecomment-702564359 for context.