### PR TITLE
Revert "rpcdaemon to cache chainconfig"

### DIFF
--- a/cmd/rpcdaemon/commands/daemon.go
+++ b/cmd/rpcdaemon/commands/daemon.go
@@ -3,7 +3,6 @@ package commands
 import (
 	"context"
 	"fmt"
-	"github.com/ledgerwatch/turbo-geth/params"
 
 	"github.com/ledgerwatch/turbo-geth/cmd/rpcdaemon/cli"
 	"github.com/ledgerwatch/turbo-geth/common"
@@ -84,22 +83,14 @@ func (api *APIImpl) GetHeaderByHash(_ context.Context, hash common.Hash) (*types
 	return header, nil
 }
 
-func getChainConfig(db rawdb.DatabaseReader) *params.ChainConfig {
-	genesisHash := rawdb.ReadBlockByNumber(db, 0).Hash()
-	return rawdb.ReadChainConfig(db, genesisHash)
-}
-
 func APIList(db ethdb.KV, eth ethdb.Backend, cfg cli.Flags, customApiList []rpc.API) []rpc.API {
 	var defaultAPIList []rpc.API
 
 	dbReader := ethdb.NewObjectDatabase(db)
-
-	chainConfig := getChainConfig(dbReader)
-
-	apiImpl := NewAPI(db, dbReader, eth, cfg.Gascap, chainConfig)
+	apiImpl := NewAPI(db, dbReader, eth, cfg.Gascap)
 	netImpl := NewNetAPIImpl(eth)
-	dbgAPIImpl := NewPrivateDebugAPI(db, dbReader, chainConfig)
-	traceAPIImpl := NewTraceAPI(db, dbReader, &cfg, chainConfig)
+	dbgAPIImpl := NewPrivateDebugAPI(db, dbReader)
+	traceAPIImpl := NewTraceAPI(db, dbReader, &cfg)
 	web3Impl := NewWeb3APIImpl()
 
 	for _, enabledAPI := range cfg.API {

--- a/cmd/rpcdaemon/commands/eth_api.go
+++ b/cmd/rpcdaemon/commands/eth_api.go
@@ -3,7 +3,6 @@ package commands
 import (
 	"context"
 	"fmt"
-	"github.com/ledgerwatch/turbo-geth/params"
 	"math/big"
 
 	"github.com/ledgerwatch/turbo-geth/eth"
@@ -63,17 +62,15 @@ type APIImpl struct {
 	dbReader     ethdb.Database
 	chainContext core.ChainContext
 	GasCap       uint64
-	chainConfig  *params.ChainConfig
 }
 
 // NewAPI returns APIImpl instance
-func NewAPI(db ethdb.KV, dbReader ethdb.Database, eth ethdb.Backend, gascap uint64, chainConfig *params.ChainConfig) *APIImpl {
+func NewAPI(db ethdb.KV, dbReader ethdb.Database, eth ethdb.Backend, gascap uint64) *APIImpl {
 	return &APIImpl{
-		db:          db,
-		dbReader:    dbReader,
-		ethBackend:  eth,
-		GasCap:      gascap,
-		chainConfig: chainConfig,
+		db:         db,
+		dbReader:   dbReader,
+		ethBackend: eth,
+		GasCap:     gascap,
 	}
 }
 
@@ -136,7 +133,8 @@ func (api *APIImpl) GetBlockTransactionCountByHash(ctx context.Context, blockHas
 
 // ChainId returns the chain id from the config
 func (api *APIImpl) ChainId(_ context.Context) (hexutil.Uint64, error) {
-	return hexutil.Uint64(api.chainConfig.ChainID.Uint64()), nil
+	chainConfig := getChainConfig(api.dbReader)
+	return hexutil.Uint64(chainConfig.ChainID.Uint64()), nil
 }
 
 // ProtocolVersion returns the chain id from the config

--- a/cmd/rpcdaemon/commands/get_chain_config.go
+++ b/cmd/rpcdaemon/commands/get_chain_config.go
@@ -1,0 +1,11 @@
+package commands
+
+import (
+	"github.com/ledgerwatch/turbo-geth/core/rawdb"
+	"github.com/ledgerwatch/turbo-geth/params"
+)
+
+func getChainConfig(db rawdb.DatabaseReader) *params.ChainConfig {
+	genesisHash := rawdb.ReadBlockByNumber(db, 0).Hash()
+	return rawdb.ReadChainConfig(db, genesisHash)
+}

--- a/cmd/rpcdaemon/commands/trace_api.go
+++ b/cmd/rpcdaemon/commands/trace_api.go
@@ -2,7 +2,6 @@ package commands
 
 import (
 	"context"
-	"github.com/ledgerwatch/turbo-geth/params"
 
 	"github.com/ledgerwatch/turbo-geth/cmd/rpcdaemon/cli"
 	"github.com/ledgerwatch/turbo-geth/common"
@@ -36,21 +35,19 @@ type TraceAPI interface {
 
 // TraceAPIImpl is implementation of the TraceAPI interface based on remote Db access
 type TraceAPIImpl struct {
-	db          ethdb.KV
-	dbReader    ethdb.Getter
-	maxTraces   uint64
-	traceType   string
-	chainConfig *params.ChainConfig
+	db        ethdb.KV
+	dbReader  ethdb.Getter
+	maxTraces uint64
+	traceType string
 }
 
 // NewTraceAPI returns NewTraceAPI instance
-func NewTraceAPI(db ethdb.KV, dbReader ethdb.Getter, cfg *cli.Flags, chainConfig *params.ChainConfig) *TraceAPIImpl {
+func NewTraceAPI(db ethdb.KV, dbReader ethdb.Getter, cfg *cli.Flags) *TraceAPIImpl {
 	return &TraceAPIImpl{
-		db:          db,
-		dbReader:    dbReader,
-		maxTraces:   cfg.MaxTraces,
-		traceType:   cfg.TraceType,
-		chainConfig: chainConfig,
+		db:        db,
+		dbReader:  dbReader,
+		maxTraces: cfg.MaxTraces,
+		traceType: cfg.TraceType,
 	}
 }
 

--- a/cmd/rpcdaemon/commands/trace_api_filtering.go
+++ b/cmd/rpcdaemon/commands/trace_api_filtering.go
@@ -227,6 +227,8 @@ func (api *TraceAPIImpl) Filter(ctx context.Context, req TraceFilterRequest) (Pa
 	}
 	getter := adapter.NewBlockGetter(api.dbReader)
 	chainContext := adapter.NewChainContext(api.dbReader)
+	genesisHash := rawdb.ReadBlockByNumber(api.dbReader, 0).Hash()
+	chainConfig := rawdb.ReadChainConfig(api.dbReader, genesisHash)
 	traceType := "callTracer" // nolint: goconst
 	traces := ParityTraces{}
 	for i, txOrBlockHash := range filteredHashes {
@@ -234,7 +236,7 @@ func (api *TraceAPIImpl) Filter(ctx context.Context, req TraceFilterRequest) (Pa
 			// In this case, we're processing a block (or uncle) reward trace. The hash is a block hash
 			// Because Geth does not return blockReward or uncleReward traces, we must create them here
 			block := rawdb.ReadBlockByHash(api.dbReader, txOrBlockHash)
-			minerReward, uncleRewards := ethash.AccumulateRewards(api.chainConfig, block.Header(), block.Uncles())
+			minerReward, uncleRewards := ethash.AccumulateRewards(chainConfig, block.Header(), block.Uncles())
 			var tr ParityTrace
 			tr.Action.Author = strings.ToLower(block.Coinbase().String())
 			tr.Action.RewardType = "block" // goconst
@@ -258,7 +260,7 @@ func (api *TraceAPIImpl) Filter(ctx context.Context, req TraceFilterRequest) (Pa
 		} else {
 			// In this case, we're processing a transaction hash
 			tx, blockHash, blockNumber, txIndex := rawdb.ReadTransaction(api.dbReader, txOrBlockHash)
-			msg, vmctx, ibs, _, err := transactions.ComputeTxEnv(ctx, getter, api.chainConfig, chainContext, api.db, blockHash, txIndex)
+			msg, vmctx, ibs, _, err := transactions.ComputeTxEnv(ctx, getter, chainConfig, chainContext, api.db, blockHash, txIndex)
 			if err != nil {
 				return nil, err
 			}
@@ -344,10 +346,12 @@ func isAddressInFilter(addr *common.Address, filter []*common.Address) bool {
 func (api *TraceAPIImpl) getTransactionTraces(ctx context.Context, txHash common.Hash) (ParityTraces, error) {
 	getter := adapter.NewBlockGetter(api.dbReader)
 	chainContext := adapter.NewChainContext(api.dbReader)
+	genesisHash := rawdb.ReadBlockByNumber(api.dbReader, 0).Hash()
+	chainConfig := rawdb.ReadChainConfig(api.dbReader, genesisHash)
 	traceType := "callTracer" // nolint: goconst
 
 	tx, blockHash, blockNumber, txIndex := rawdb.ReadTransaction(api.dbReader, txHash)
-	msg, vmctx, ibs, _, err := transactions.ComputeTxEnv(ctx, getter, api.chainConfig, chainContext, api.db, blockHash, txIndex)
+	msg, vmctx, ibs, _, err := transactions.ComputeTxEnv(ctx, getter, chainConfig, chainContext, api.db, blockHash, txIndex)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
rpc daemon will not start if TG not started - which is bad architecture practice - startup must be independent. need find another way to cache - something like sync.Once