### PR TITLE
Rpcdaemon: Gracefull shutdown, better grpc stream close

### DIFF
--- a/cmd/prometheus/prometheus.yml
+++ b/cmd/prometheus/prometheus.yml
@@ -22,16 +22,19 @@ scrape_configs:
           - host.docker.internal:6060 # this is how docker-for-mac allow to access host machine
           - host.docker.internal:6061
           - host.docker.internal:6062
+          - 192.168.255.138:6060
+          - 192.168.255.138:6061
 
   - job_name: turbo-geth2
     metrics_path: /debug/metrics/prometheus2
     scheme: http
     static_configs:
       - targets:
-        - turbo-geth:6060
-        - turbo-geth:6061
-        - turbo-geth:6062
-        - host.docker.internal:6060
-        - host.docker.internal:6061
-        - host.docker.internal:6062
-
+          - turbo-geth:6060
+          - turbo-geth:6061
+          - turbo-geth:6062
+          - host.docker.internal:6060
+          - host.docker.internal:6061
+          - host.docker.internal:6062
+          - 192.168.255.138:6060
+          - 192.168.255.138:6061

--- a/cmd/rpcdaemon/cli/config.go
+++ b/cmd/rpcdaemon/cli/config.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"time"
 
 	"github.com/ledgerwatch/turbo-geth/cmd/utils"
 	"github.com/ledgerwatch/turbo-geth/ethdb"
@@ -132,10 +133,12 @@ func StartRpcServer(ctx context.Context, cfg Flags, rpcAPI []rpc.API) error {
 
 	defer func() {
 		srv.Stop()
-		listener.Close()
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		_ = listener.Shutdown(ctx)
 		log.Info("HTTP endpoint closed", "url", httpEndpoint)
 	}()
-	sig := <-ctx.Done()
-	log.Info("Exiting...", "signal", sig)
+	<-ctx.Done()
+	log.Info("Exiting...")
 	return nil
 }

--- a/cmd/rpcdaemon/cli/config.go
+++ b/cmd/rpcdaemon/cli/config.go
@@ -121,7 +121,6 @@ func StartRpcServer(ctx context.Context, cfg Flags, rpcAPI []rpc.API) error {
 	})
 
 	listener, _, err := node.StartHTTPEndpoint(httpEndpoint, rpc.DefaultHTTPTimeouts, handler)
-
 	if err != nil {
 		return fmt.Errorf("could not start RPC api: %w", err)
 	}
@@ -132,6 +131,7 @@ func StartRpcServer(ctx context.Context, cfg Flags, rpcAPI []rpc.API) error {
 	log.Info("HTTP endpoint opened", "url", httpEndpoint, "ws", cfg.WebsocketEnabled)
 
 	defer func() {
+		srv.Stop()
 		listener.Close()
 		log.Info("HTTP endpoint closed", "url", httpEndpoint)
 	}()

--- a/cmd/rpcdaemon/cli/config.go
+++ b/cmd/rpcdaemon/cli/config.go
@@ -133,9 +133,9 @@ func StartRpcServer(ctx context.Context, cfg Flags, rpcAPI []rpc.API) error {
 
 	defer func() {
 		srv.Stop()
-		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel()
-		_ = listener.Shutdown(ctx)
+		_ = listener.Shutdown(shutdownCtx)
 		log.Info("HTTP endpoint closed", "url", httpEndpoint)
 	}()
 	<-ctx.Done()

--- a/cmd/rpcdaemon/main.go
+++ b/cmd/rpcdaemon/main.go
@@ -23,6 +23,7 @@ func main() {
 			log.Error("Could not connect to remoteDb", "error", err)
 			return nil
 		}
+		defer db.Close()
 
 		var apiList = commands.APIList(db, backend, *cfg, nil)
 		return cli.StartRpcServer(cmd.Context(), *cfg, apiList)

--- a/cmd/rpcdaemon/main.go
+++ b/cmd/rpcdaemon/main.go
@@ -3,10 +3,9 @@ package main
 import (
 	"os"
 
-	"github.com/ledgerwatch/turbo-geth/cmd/utils"
-
 	"github.com/ledgerwatch/turbo-geth/cmd/rpcdaemon/cli"
 	"github.com/ledgerwatch/turbo-geth/cmd/rpcdaemon/commands"
+	"github.com/ledgerwatch/turbo-geth/cmd/utils"
 	"github.com/ledgerwatch/turbo-geth/log"
 	"github.com/spf13/cobra"
 )

--- a/cmd/rpcdaemon/test.http
+++ b/cmd/rpcdaemon/test.http
@@ -78,7 +78,7 @@ Content-Type: application/json
 
 ###
 
-POST localhost:8545
+POST 192.168.255.138:8545
 Content-Type: application/json
 
 {

--- a/cmd/rpctest/Readme.md
+++ b/cmd/rpctest/Readme.md
@@ -20,7 +20,7 @@ go get -u github.com/tsenart/vegeta
 ### Run vegeta
 ``` 
 tmpDir = "/var/folders/x_/1mnbt25s3291zr5_fxhjfnq9n86kng/T/"
-cat $(tmpDir)/turbo_geth_stress_test/vegeta_geth_debug_storageRangeAt.csv | vegeta attack -rate=600 -format=json -duration=20s | vegeta plot > plot.html
+cat $(tmpDir)/turbo_geth_stress_test/vegeta_geth_debug_storageRangeAt.csv | vegeta attack -rate=600 -format=json -duration=20s -timeout=300s | vegeta plot > plot.html
 open plot.html
 ```
 
@@ -37,7 +37,7 @@ GODEBUG=remotedb.debug=1 go run ./cmd/rpcdaemon --rpcapi eth,debug,net --rpcport
 
 On simple requests `eth_getBlockByNumber` RPC Daemon looks well:  
 ```
-cat /tmp/turbo_geth_stress_test/vegeta_turbo_geth_eth_getBlockByNumber.txt | vegeta attack -rate=1000 -format=json -duration=20s | vegeta report
+cat /tmp/turbo_geth_stress_test/vegeta_turbo_geth_eth_getBlockByNumber.txt | vegeta attack -rate=1000 -format=json -duration=20s -timeout=300s | vegeta report
 
 300rps: 
 - Geth Alone: 80% of CPU, 95-Latency 2ms
@@ -61,7 +61,7 @@ cat /tmp/turbo_geth_stress_test/vegeta_turbo_geth_eth_getBlockByNumber.txt | veg
 
 On complex request - `debug_storageRangeAt` producing >600 db.View calls with twice more .Bucket/.Cursor/.Seek calls:
 ```
-echo "POST http://localhost:8545 \n Content-Type: application/json \n @$(pwd)/cmd/rpctest/heavyStorageRangeAt.json" | vegeta attack -rate=20 -duration=20s | vegeta report
+echo "POST http://localhost:8545 \n Content-Type: application/json \n @$(pwd)/cmd/rpctest/heavyStorageRangeAt.json" | vegeta attack -rate=20 -duration=20s -timeout=300s | vegeta report
 
 10rps, batchSize 10K:
 - Geth Alone: 100% of CPU, 95-Latency 15ms 

--- a/cmd/rpctest/Readme.md
+++ b/cmd/rpctest/Readme.md
@@ -61,7 +61,7 @@ cat /tmp/turbo_geth_stress_test/vegeta_turbo_geth_eth_getBlockByNumber.txt | veg
 
 On complex request - `debug_storageRangeAt` producing >600 db.View calls with twice more .Bucket/.Cursor/.Seek calls:
 ```
-echo "POST http://localhost:9545 \n Content-Type: application/json \n @$(pwd)/cmd/rpctest/heavyStorageRangeAt.json" | vegeta attack -rate=20 -duration=20s | vegeta report
+echo "POST http://localhost:8545 \n Content-Type: application/json \n @$(pwd)/cmd/rpctest/heavyStorageRangeAt.json" | vegeta attack -rate=20 -duration=20s | vegeta report
 
 10rps, batchSize 10K:
 - Geth Alone: 100% of CPU, 95-Latency 15ms 

--- a/cmd/utils/cmd.go
+++ b/cmd/utils/cmd.go
@@ -342,8 +342,8 @@ func RootContext() context.Context {
 		defer signal.Stop(ch)
 
 		select {
-		case <-ch:
-			log.Info("Got interrupt, shutting down...")
+		case sig := <-ch:
+			log.Info("Got interrupt, shutting down...", "sig", sig)
 		case <-ctx.Done():
 		}
 	}()

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,7 +21,7 @@ services:
       - ${XDG_DATA_HOME:-~/.local/share}/tg-prometheus:/prometheus
 
   grafana:
-    image: grafana/grafana:7.1.5
+    image: grafana/grafana:7.2.1
     ports:
       - 3000:3000
     volumes:

--- a/ethdb/kv_remote.go
+++ b/ethdb/kv_remote.go
@@ -317,7 +317,9 @@ func (c *remoteCursor) First() ([]byte, []byte, error) {
 // Seek - doesn't start streaming (because much of code does only several .Seek calls without reading sequence of data)
 // .Next() - does request streaming (if configured by user)
 func (c *remoteCursor) Seek(seek []byte) ([]byte, []byte, error) {
-	c.closeGrpcStream()
+	if c.streamingRequested {
+		c.closeGrpcStream()
+	}
 	c.initialized = true
 
 	var err error
@@ -432,7 +434,9 @@ func (c *remoteCursorDupSort) SeekBothExact(key, value []byte) ([]byte, []byte, 
 }
 
 func (c *remoteCursorDupSort) SeekBothRange(key, value []byte) ([]byte, []byte, error) {
-	c.closeGrpcStream() // TODO: if streaming not requested then no reason to close
+	if c.streamingRequested {
+		c.closeGrpcStream() // TODO: if streaming not requested then no reason to close
+	}
 	c.initialized = true
 
 	var err error

--- a/ethdb/kv_remote.go
+++ b/ethdb/kv_remote.go
@@ -317,9 +317,7 @@ func (c *remoteCursor) First() ([]byte, []byte, error) {
 // Seek - doesn't start streaming (because much of code does only several .Seek calls without reading sequence of data)
 // .Next() - does request streaming (if configured by user)
 func (c *remoteCursor) Seek(seek []byte) ([]byte, []byte, error) {
-	if c.streamingRequested {
-		c.closeGrpcStream()
-	}
+	c.closeGrpcStream()
 	c.initialized = true
 
 	var err error
@@ -434,9 +432,7 @@ func (c *remoteCursorDupSort) SeekBothExact(key, value []byte) ([]byte, []byte, 
 }
 
 func (c *remoteCursorDupSort) SeekBothRange(key, value []byte) ([]byte, []byte, error) {
-	if c.streamingRequested {
-		c.closeGrpcStream() // TODO: if streaming not requested then no reason to close
-	}
+	c.closeGrpcStream() // TODO: if streaming not requested then no reason to close
 	c.initialized = true
 
 	var err error

--- a/ethdb/kv_remote.go
+++ b/ethdb/kv_remote.go
@@ -384,7 +384,7 @@ func (c *remoteCursor) closeGrpcStream() {
 		// try graceful close stream
 		err := c.stream.CloseSend()
 		if err != nil {
-			if !errors.Is(err, context.Canceled) {
+			if !errors.Is(err, io.EOF) && !errors.Is(err, context.Canceled) {
 				log.Warn("couldn't send msg CloseSend to server", "err", err)
 			}
 		} else {

--- a/ethdb/kv_remote.go
+++ b/ethdb/kv_remote.go
@@ -244,8 +244,6 @@ func (tx *remoteTx) Commit(ctx context.Context) error {
 }
 
 func (tx *remoteTx) Rollback() {
-	// signal server for graceful shutdown
-	// after signaling need wait for .Recv() or cancel context to ensure that resources are free
 	for _, c := range tx.cursors {
 		c.Close()
 	}

--- a/ethdb/kv_remote.go
+++ b/ethdb/kv_remote.go
@@ -347,7 +347,6 @@ func (c *remoteCursor) Seek(seek []byte) ([]byte, []byte, error) {
 
 	pair, err := c.stream.Recv()
 	if err != nil {
-		fmt.Printf("eee1: %s\n", err)
 		return []byte{}, nil, err
 	}
 
@@ -364,7 +363,6 @@ func (c *remoteCursor) Next() ([]byte, []byte, error) {
 	if !c.streamingRequested {
 		doStream := c.prefetch > 0
 		if err := c.stream.Send(&remote.SeekRequest{StartSreaming: doStream}); err != nil {
-			fmt.Printf("111: %s\n", err)
 			return []byte{}, nil, err
 		}
 		c.streamingRequested = doStream
@@ -372,7 +370,6 @@ func (c *remoteCursor) Next() ([]byte, []byte, error) {
 
 	pair, err := c.stream.Recv()
 	if err != nil {
-		fmt.Printf("22222: %s\n", err)
 		return []byte{}, nil, err
 	}
 	return pair.Key, pair.Value, nil

--- a/ethdb/kv_remote.go
+++ b/ethdb/kv_remote.go
@@ -271,16 +271,7 @@ func (tx *remoteTx) BucketSize(name string) (uint64, error) {
 
 func (tx *remoteTx) Get(bucket string, key []byte) (val []byte, err error) {
 	c := tx.Cursor(bucket)
-	defer func() {
-		if v, ok := c.(*remoteCursor); ok {
-			if v.stream == nil {
-				return
-			}
-			_ = v.stream.CloseSend()
-			v.streamCancelFn()
-		}
-	}()
-
+	defer c.Close()
 	return c.SeekExact(key)
 }
 

--- a/ethdb/remote/remotedbserver/server.go
+++ b/ethdb/remote/remotedbserver/server.go
@@ -50,7 +50,7 @@ func StartGrpc(kv ethdb.KV, eth core.Backend, addr string, creds *credentials.Tr
 	unaryInterceptors = append(unaryInterceptors, grpc_recovery.UnaryServerInterceptor())
 	var grpcServer *grpc.Server
 	opts := []grpc.ServerOption{
-		grpc.NumStreamWorkers(30),  // reduce amount of goroutines
+		grpc.NumStreamWorkers(20),  // reduce amount of goroutines
 		grpc.WriteBufferSize(1024), // reduce buffers to save mem
 		grpc.ReadBufferSize(1024),
 		grpc.MaxConcurrentStreams(60), // to force clients reduce concurrency level

--- a/ethdb/remote/remotedbserver/server.go
+++ b/ethdb/remote/remotedbserver/server.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"io"
 	"net"
-	"runtime"
 	"time"
 
 	grpc_middleware "github.com/grpc-ecosystem/go-grpc-middleware"
@@ -50,13 +49,8 @@ func StartGrpc(kv ethdb.KV, eth core.Backend, addr string, creds *credentials.Tr
 	streamInterceptors = append(streamInterceptors, grpc_recovery.StreamServerInterceptor())
 	unaryInterceptors = append(unaryInterceptors, grpc_recovery.UnaryServerInterceptor())
 	var grpcServer *grpc.Server
-	streamingWorkers := uint32(runtime.GOMAXPROCS(-1) / 2)
-	if streamingWorkers == 0 {
-		streamingWorkers = 1
-	}
 	opts := []grpc.ServerOption{
-		grpc.NumStreamWorkers(streamingWorkers), // reduce amount of goroutines
-		grpc.WriteBufferSize(1024),              // reduce buffers to save mem
+		grpc.WriteBufferSize(1024), // reduce buffers to save mem
 		grpc.ReadBufferSize(1024),
 		grpc.MaxConcurrentStreams(60), // to force clients reduce concurrency level
 		grpc.KeepaliveParams(keepalive.ServerParameters{

--- a/ethdb/remote/remotedbserver/server.go
+++ b/ethdb/remote/remotedbserver/server.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"io"
 	"net"
-	"runtime"
 	"time"
 
 	grpc_middleware "github.com/grpc-ecosystem/go-grpc-middleware"
@@ -50,13 +49,10 @@ func StartGrpc(kv ethdb.KV, eth core.Backend, addr string, creds *credentials.Tr
 	streamInterceptors = append(streamInterceptors, grpc_recovery.StreamServerInterceptor())
 	unaryInterceptors = append(unaryInterceptors, grpc_recovery.UnaryServerInterceptor())
 	var grpcServer *grpc.Server
-	streamingWorkers := uint32(runtime.GOMAXPROCS(-1) / 2)
-	if streamingWorkers == 0 {
-		streamingWorkers = 1
-	}
+	//streamingWorkers := uint32(runtime.GOMAXPROCS(-1))
 	opts := []grpc.ServerOption{
-		grpc.NumStreamWorkers(streamingWorkers), // reduce amount of goroutines
-		grpc.WriteBufferSize(1024),              // reduce buffers to save mem
+		//grpc.NumStreamWorkers(streamingWorkers), // reduce amount of goroutines
+		grpc.WriteBufferSize(1024), // reduce buffers to save mem
 		grpc.ReadBufferSize(1024),
 		grpc.MaxConcurrentStreams(60), // to force clients reduce concurrency level
 		grpc.KeepaliveParams(keepalive.ServerParameters{

--- a/ethdb/remote/remotedbserver/server.go
+++ b/ethdb/remote/remotedbserver/server.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io"
 	"net"
+	"runtime"
 	"time"
 
 	grpc_middleware "github.com/grpc-ecosystem/go-grpc-middleware"
@@ -49,9 +50,13 @@ func StartGrpc(kv ethdb.KV, eth core.Backend, addr string, creds *credentials.Tr
 	streamInterceptors = append(streamInterceptors, grpc_recovery.StreamServerInterceptor())
 	unaryInterceptors = append(unaryInterceptors, grpc_recovery.UnaryServerInterceptor())
 	var grpcServer *grpc.Server
+	streamingWorkers := uint32(runtime.GOMAXPROCS(-1) / 2)
+	if streamingWorkers == 0 {
+		streamingWorkers = 1
+	}
 	opts := []grpc.ServerOption{
-		grpc.NumStreamWorkers(20),  // reduce amount of goroutines
-		grpc.WriteBufferSize(1024), // reduce buffers to save mem
+		grpc.NumStreamWorkers(streamingWorkers), // reduce amount of goroutines
+		grpc.WriteBufferSize(1024),              // reduce buffers to save mem
 		grpc.ReadBufferSize(1024),
 		grpc.MaxConcurrentStreams(60), // to force clients reduce concurrency level
 		grpc.KeepaliveParams(keepalive.ServerParameters{

--- a/ethdb/remote/remotedbserver/server.go
+++ b/ethdb/remote/remotedbserver/server.go
@@ -53,7 +53,7 @@ func StartGrpc(kv ethdb.KV, eth core.Backend, addr string, creds *credentials.Tr
 		grpc.NumStreamWorkers(1024), // reduce amount of goroutines
 		grpc.WriteBufferSize(1024),  // reduce buffers to save mem
 		grpc.ReadBufferSize(1024),
-		grpc.MaxConcurrentStreams(80), // to force clients reduce concurrency level
+		grpc.MaxConcurrentStreams(200), // to force clients reduce concurrency level
 		grpc.KeepaliveParams(keepalive.ServerParameters{
 			Time: 10 * time.Minute,
 		}),

--- a/ethdb/remote/remotedbserver/server.go
+++ b/ethdb/remote/remotedbserver/server.go
@@ -50,10 +50,10 @@ func StartGrpc(kv ethdb.KV, eth core.Backend, addr string, creds *credentials.Tr
 	unaryInterceptors = append(unaryInterceptors, grpc_recovery.UnaryServerInterceptor())
 	var grpcServer *grpc.Server
 	opts := []grpc.ServerOption{
-		grpc.NumStreamWorkers(1024), // reduce amount of goroutines
-		grpc.WriteBufferSize(1024),  // reduce buffers to save mem
+		grpc.NumStreamWorkers(30),  // reduce amount of goroutines
+		grpc.WriteBufferSize(1024), // reduce buffers to save mem
 		grpc.ReadBufferSize(1024),
-		grpc.MaxConcurrentStreams(200), // to force clients reduce concurrency level
+		grpc.MaxConcurrentStreams(60), // to force clients reduce concurrency level
 		grpc.KeepaliveParams(keepalive.ServerParameters{
 			Time: 10 * time.Minute,
 		}),

--- a/ethdb/remote/remotedbserver/server.go
+++ b/ethdb/remote/remotedbserver/server.go
@@ -9,18 +9,18 @@ import (
 	grpc_middleware "github.com/grpc-ecosystem/go-grpc-middleware"
 	grpc_recovery "github.com/grpc-ecosystem/go-grpc-middleware/recovery"
 	grpc_prometheus "github.com/grpc-ecosystem/go-grpc-prometheus"
-	"google.golang.org/grpc"
-	"google.golang.org/grpc/credentials"
-
 	"github.com/ledgerwatch/turbo-geth/common"
 	"github.com/ledgerwatch/turbo-geth/core"
 	"github.com/ledgerwatch/turbo-geth/ethdb"
 	"github.com/ledgerwatch/turbo-geth/ethdb/remote"
 	"github.com/ledgerwatch/turbo-geth/log"
 	"github.com/ledgerwatch/turbo-geth/metrics"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/keepalive"
 )
 
-const MaxTxTTL = 30 * time.Second
+const MaxTxTTL = 10 * 30 * time.Second
 
 type KvServer struct {
 	remote.UnstableKVService // must be embedded to have forward compatible implementations.
@@ -55,6 +55,9 @@ func StartGrpc(kv ethdb.KV, eth core.Backend, addr string, creds *credentials.Tr
 			grpc.WriteBufferSize(1024), // reduce buffers to save mem
 			grpc.ReadBufferSize(1024),
 			grpc.MaxConcurrentStreams(40), // to force clients reduce concurency level
+			grpc.KeepaliveParams(keepalive.ServerParameters{
+				Time: 10 * time.Minute,
+			}),
 			grpc.StreamInterceptor(grpc_middleware.ChainStreamServer(streamInterceptors...)),
 			grpc.UnaryInterceptor(grpc_middleware.ChainUnaryServer(unaryInterceptors...)),
 		)
@@ -64,6 +67,9 @@ func StartGrpc(kv ethdb.KV, eth core.Backend, addr string, creds *credentials.Tr
 			grpc.WriteBufferSize(1024), // reduce buffers to save mem
 			grpc.ReadBufferSize(1024),
 			grpc.MaxConcurrentStreams(40), // to force clients reduce concurency level
+			grpc.KeepaliveParams(keepalive.ServerParameters{
+				Time: 10 * time.Minute,
+			}),
 			grpc.StreamInterceptor(grpc_middleware.ChainStreamServer(streamInterceptors...)),
 			grpc.UnaryInterceptor(grpc_middleware.ChainUnaryServer(unaryInterceptors...)),
 			grpc.Creds(*creds),
@@ -97,7 +103,7 @@ func (s *KvServer) Seek(stream remote.KV_SeekServer) error {
 	}
 	tx, err := s.kv.Begin(stream.Context(), nil, false)
 	if err != nil {
-		return err
+		return fmt.Errorf("server-side error: %w", err)
 	}
 	rollback := func() {
 		tx.Rollback()
@@ -117,18 +123,18 @@ func (s *KvServer) Seek(stream remote.KV_SeekServer) error {
 		c = tx.Cursor(bucketName).Prefix(prefix)
 		k, v, err = c.Seek(in.SeekKey)
 		if err != nil {
-			return err
+			return fmt.Errorf("server-side error: %w", err)
 		}
 	} else {
 		cd := tx.CursorDupSort(bucketName)
 		k, v, err = cd.SeekBothRange(in.SeekKey, in.SeekValue)
 		if err != nil {
-			return err
+			return fmt.Errorf("server-side error: %w", err)
 		}
 		if k == nil { // it may happen that key where we stopped disappeared after transaction reopen, then just move to next key
 			k, v, err = cd.Next()
 			if err != nil {
-				return err
+				return fmt.Errorf("server-side error: %w", err)
 			}
 		}
 		c = cd
@@ -138,7 +144,7 @@ func (s *KvServer) Seek(stream remote.KV_SeekServer) error {
 	for {
 		err = stream.Send(&remote.Pair{Key: common.CopyBytes(k), Value: common.CopyBytes(v)})
 		if err != nil {
-			return err
+			return fmt.Errorf("server-side error: %w", err)
 		}
 		if k == nil {
 			return nil
@@ -151,35 +157,35 @@ func (s *KvServer) Seek(stream remote.KV_SeekServer) error {
 				if err == io.EOF {
 					return nil
 				}
-				return err
+				return fmt.Errorf("server-side error: %w", err)
 			}
 
 			if len(in.SeekValue) > 0 {
 				k, v, err = c.(ethdb.CursorDupSort).SeekBothRange(in.SeekKey, in.SeekValue)
 				if err != nil {
-					return err
+					return fmt.Errorf("server-side error: %w", err)
 				}
 				if k == nil { // it may happen that key where we stopped disappeared after transaction reopen, then just move to next key
 					k, v, err = c.Next()
 					if err != nil {
-						return err
+						return fmt.Errorf("server-side error: %w", err)
 					}
 				}
 			} else if len(in.SeekKey) > 0 {
 				k, v, err = c.Seek(in.SeekKey)
 				if err != nil {
-					return err
+					return fmt.Errorf("server-side error: %w", err)
 				}
 			} else {
 				k, v, err = c.Next()
 				if err != nil {
-					return err
+					return fmt.Errorf("server-side error: %w", err)
 				}
 			}
 		} else {
 			k, v, err = c.Next()
 			if err != nil {
-				return err
+				return fmt.Errorf("server-side error: %w", err)
 			}
 		}
 
@@ -190,18 +196,19 @@ func (s *KvServer) Seek(stream remote.KV_SeekServer) error {
 			tx.Rollback()
 			tx, err = s.kv.Begin(stream.Context(), nil, false)
 			if err != nil {
-				return err
+				return fmt.Errorf("server-side error: %w", err)
+
 			}
 			if isDupsort {
 				dc := tx.CursorDupSort(bucketName)
 				k, v, err = dc.SeekBothRange(k, v)
 				if err != nil {
-					return err
+					return fmt.Errorf("server-side error: %w", err)
 				}
 				if k == nil { // it may happen that key where we stopped disappeared after transaction reopen, then just move to next key
 					k, v, err = dc.Next()
 					if err != nil {
-						return err
+						return fmt.Errorf("server-side error: %w", err)
 					}
 				}
 				c = dc
@@ -209,7 +216,7 @@ func (s *KvServer) Seek(stream remote.KV_SeekServer) error {
 				c = tx.Cursor(bucketName).Prefix(prefix)
 				k, v, err = c.Seek(k)
 				if err != nil {
-					return err
+					return fmt.Errorf("server-side error: %w", err)
 				}
 			}
 		}

--- a/ethdb/remote/remotedbserver/server.go
+++ b/ethdb/remote/remotedbserver/server.go
@@ -50,8 +50,8 @@ func StartGrpc(kv ethdb.KV, eth core.Backend, addr string, creds *credentials.Tr
 	unaryInterceptors = append(unaryInterceptors, grpc_recovery.UnaryServerInterceptor())
 	var grpcServer *grpc.Server
 	opts := []grpc.ServerOption{
-		grpc.NumStreamWorkers(60),  // reduce amount of goroutines
-		grpc.WriteBufferSize(1024), // reduce buffers to save mem
+		grpc.NumStreamWorkers(1024), // reduce amount of goroutines
+		grpc.WriteBufferSize(1024),  // reduce buffers to save mem
 		grpc.ReadBufferSize(1024),
 		grpc.MaxConcurrentStreams(80), // to force clients reduce concurrency level
 		grpc.KeepaliveParams(keepalive.ServerParameters{

--- a/ethdb/remote/remotedbserver/server.go
+++ b/ethdb/remote/remotedbserver/server.go
@@ -1,6 +1,7 @@
 package remotedbserver
 
 import (
+	"fmt"
 	"io"
 	"net"
 	"time"
@@ -27,12 +28,11 @@ type KvServer struct {
 	kv ethdb.KV
 }
 
-func StartGrpc(kv ethdb.KV, eth core.Backend, addr string, creds *credentials.TransportCredentials) {
+func StartGrpc(kv ethdb.KV, eth core.Backend, addr string, creds *credentials.TransportCredentials) (*grpc.Server, error) {
 	log.Info("Starting private RPC server", "on", addr)
 	lis, err := net.Listen("tcp", addr)
 	if err != nil {
-		log.Error("Could not create listener", "address", addr, "err", err)
-		return
+		return nil, fmt.Errorf("could not create listener: %w, addr=%s", err, addr)
 	}
 
 	kvSrv := NewKvServer(kv)
@@ -82,6 +82,8 @@ func StartGrpc(kv ethdb.KV, eth core.Backend, addr string, creds *credentials.Tr
 			log.Error("private RPC server fail", "err", err)
 		}
 	}()
+
+	return grpcServer, nil
 }
 
 func NewKvServer(kv ethdb.KV) *KvServer {

--- a/ethdb/remote/remotedbserver/server.go
+++ b/ethdb/remote/remotedbserver/server.go
@@ -53,7 +53,7 @@ func StartGrpc(kv ethdb.KV, eth core.Backend, addr string, creds *credentials.Tr
 		grpc.NumStreamWorkers(20),  // reduce amount of goroutines
 		grpc.WriteBufferSize(1024), // reduce buffers to save mem
 		grpc.ReadBufferSize(1024),
-		grpc.MaxConcurrentStreams(40), // to force clients reduce concurency level
+		grpc.MaxConcurrentStreams(80), // to force clients reduce concurrency level
 		grpc.KeepaliveParams(keepalive.ServerParameters{
 			Time: 10 * time.Minute,
 		}),

--- a/ethdb/remote/remotedbserver/server.go
+++ b/ethdb/remote/remotedbserver/server.go
@@ -20,7 +20,7 @@ import (
 	"google.golang.org/grpc/keepalive"
 )
 
-const MaxTxTTL = 10 * 30 * time.Second
+const MaxTxTTL = 30 * time.Second
 
 type KvServer struct {
 	remote.UnstableKVService // must be embedded to have forward compatible implementations.

--- a/ethdb/remote/remotedbserver/server.go
+++ b/ethdb/remote/remotedbserver/server.go
@@ -50,7 +50,7 @@ func StartGrpc(kv ethdb.KV, eth core.Backend, addr string, creds *credentials.Tr
 	unaryInterceptors = append(unaryInterceptors, grpc_recovery.UnaryServerInterceptor())
 	var grpcServer *grpc.Server
 	opts := []grpc.ServerOption{
-		grpc.NumStreamWorkers(20),  // reduce amount of goroutines
+		grpc.NumStreamWorkers(40),  // reduce amount of goroutines
 		grpc.WriteBufferSize(1024), // reduce buffers to save mem
 		grpc.ReadBufferSize(1024),
 		grpc.MaxConcurrentStreams(80), // to force clients reduce concurrency level

--- a/ethdb/remote/remotedbserver/server.go
+++ b/ethdb/remote/remotedbserver/server.go
@@ -50,7 +50,7 @@ func StartGrpc(kv ethdb.KV, eth core.Backend, addr string, creds *credentials.Tr
 	unaryInterceptors = append(unaryInterceptors, grpc_recovery.UnaryServerInterceptor())
 	var grpcServer *grpc.Server
 	opts := []grpc.ServerOption{
-		grpc.NumStreamWorkers(40),  // reduce amount of goroutines
+		grpc.NumStreamWorkers(60),  // reduce amount of goroutines
 		grpc.WriteBufferSize(1024), // reduce buffers to save mem
 		grpc.ReadBufferSize(1024),
 		grpc.MaxConcurrentStreams(80), // to force clients reduce concurrency level


### PR DESCRIPTION
Fixes:

- Server: GracefulShutdown grpc server
- Client: GracefulShutdown json server (stop accepting new requests, wait for pending request finish or cancel by 5sec timeout) and only when no pending clients left - then close db. 
- Client cursor: 1) If sreaming not requested: do `CloseSend+Recv` as "happy path" and `defer cancelCursorContext` as "unhappy path if send/recv finished with error" 2) if streaming requested - cancelCursorContext


Of course it's a bit stupid that we received "context canceled" instead of "connection closed" error. It making things harder to debug. 
