### PR TITLE
use less blockchain

### DIFF
--- a/cmd/integration/commands/state_stages.go
+++ b/cmd/integration/commands/state_stages.go
@@ -7,10 +7,9 @@ import (
 	"fmt"
 
 	"github.com/ledgerwatch/turbo-geth/cmd/utils"
-	"github.com/ledgerwatch/turbo-geth/common/dbutils"
-
 	"github.com/ledgerwatch/turbo-geth/common"
 	"github.com/ledgerwatch/turbo-geth/common/changeset"
+	"github.com/ledgerwatch/turbo-geth/common/dbutils"
 	"github.com/ledgerwatch/turbo-geth/core"
 	"github.com/ledgerwatch/turbo-geth/core/state"
 	"github.com/ledgerwatch/turbo-geth/eth/stagedsync"
@@ -94,16 +93,15 @@ func syncBySmallSteps(ctx context.Context, chaindata string) error {
 		}
 	}
 
-	tx, errBegin := db.Begin(context.Background())
-	if errBegin != nil {
-		return errBegin
-	}
+	var tx ethdb.DbWithPendingMutations = ethdb.NewTxDbWithoutTransaction(db)
 	defer tx.Rollback()
 
-	bc, st, progress := newSync(ch, db, tx, changeSetHook)
+	cc, bc, st, progress := newSync(ch, db, tx, changeSetHook)
 	defer bc.Stop()
+	cc.SetDB(tx)
 
-	if err := tx.CommitAndBegin(context.Background()); err != nil {
+	tx, err = tx.Begin(context.Background())
+	if err != nil {
 		return err
 	}
 
@@ -139,7 +137,7 @@ func syncBySmallSteps(ctx context.Context, chaindata string) error {
 		st.MockExecFunc(stages.Execution, func(stageState *stagedsync.StageState, unwinder stagedsync.Unwinder) error {
 			if err := stagedsync.SpawnExecuteBlocksStage(
 				stageState, tx,
-				bc.Config(), bc, bc.GetVMConfig(),
+				bc.Config(), cc, bc.GetVMConfig(),
 				ch,
 				stagedsync.ExecuteBlockStageParams{
 					ToBlock:       execToBlock, // limit execution to the specified block

--- a/core/evm.go
+++ b/core/evm.go
@@ -20,11 +20,12 @@ import (
 	"math/big"
 
 	"github.com/holiman/uint256"
-
 	"github.com/ledgerwatch/turbo-geth/common"
 	"github.com/ledgerwatch/turbo-geth/consensus"
+	"github.com/ledgerwatch/turbo-geth/core/rawdb"
 	"github.com/ledgerwatch/turbo-geth/core/types"
 	"github.com/ledgerwatch/turbo-geth/core/vm"
+	"github.com/ledgerwatch/turbo-geth/ethdb"
 )
 
 // ChainContext supports retrieving headers and consensus parameters from the
@@ -119,4 +120,20 @@ func CanTransfer(db vm.IntraBlockState, addr common.Address, amount *uint256.Int
 func Transfer(db vm.IntraBlockState, sender, recipient common.Address, amount *uint256.Int) {
 	db.SubBalance(sender, amount)
 	db.AddBalance(recipient, amount)
+}
+
+type TinyChainContext struct {
+	db     ethdb.Database
+	engine consensus.Engine
+}
+
+func (c *TinyChainContext) Engine() consensus.Engine     { return c.engine }
+func (c *TinyChainContext) SetEngine(e consensus.Engine) { c.engine = e }
+func (c *TinyChainContext) SetDB(db ethdb.Database)      { c.db = db }
+func (c *TinyChainContext) GetHeader(hash common.Hash, number uint64) *types.Header {
+	header := rawdb.ReadHeader(c.db, hash, number)
+	if header == nil {
+		return nil
+	}
+	return header
 }

--- a/eth/downloader/downloader.go
+++ b/eth/downloader/downloader.go
@@ -546,10 +546,13 @@ func (d *Downloader) syncWithPeer(p *peerConnection, hash common.Hash, blockNumb
 			writeDB = d.stateDB
 		}
 
+		cc := &core.TinyChainContext{}
+		cc.SetDB(tx)
+		cc.SetEngine(d.blockchain.Engine())
 		d.stagedSyncState, err = d.stagedSync.Prepare(
 			d,
 			d.chainConfig,
-			d.blockchain,
+			cc,
 			d.blockchain.GetVMConfig(),
 			d.stateDB,
 			writeDB,

--- a/eth/stagedsync/all_stages.go
+++ b/eth/stagedsync/all_stages.go
@@ -69,11 +69,15 @@ func InsertBlockInStages(db ethdb.Database, config *params.ChainConfig, engine c
 		return err
 	}
 
+	cc := &core.TinyChainContext{}
+	cc.SetDB(db)
+	cc.SetEngine(bc.Engine())
+
 	// Stage 5
 	if err := SpawnExecuteBlocksStage(&StageState{
 		Stage:       stages.Execution,
 		BlockNumber: num - 1,
-	}, db, config, bc, bc.GetVMConfig(), nil, ExecuteBlockStageParams{WriteReceipts: true}); err != nil {
+	}, db, config, cc, bc.GetVMConfig(), nil, ExecuteBlockStageParams{WriteReceipts: true}); err != nil {
 		return err
 	}
 

--- a/eth/stagedsync/stage_execute.go
+++ b/eth/stagedsync/stage_execute.go
@@ -48,7 +48,7 @@ type ExecuteBlockStageParams struct {
 	WriterBuilder StateWriterBuilder
 }
 
-func SpawnExecuteBlocksStage(s *StageState, stateDB ethdb.Database, chainConfig *params.ChainConfig, chainContext core.ChainContext, vmConfig *vm.Config, quit <-chan struct{}, params ExecuteBlockStageParams) error {
+func SpawnExecuteBlocksStage(s *StageState, stateDB ethdb.Database, chainConfig *params.ChainConfig, chainContext *core.TinyChainContext, vmConfig *vm.Config, quit <-chan struct{}, params ExecuteBlockStageParams) error {
 	prevStageProgress, _, errStart := stages.GetStageProgress(stateDB, stages.Senders)
 	if errStart != nil {
 		return errStart
@@ -93,6 +93,7 @@ func SpawnExecuteBlocksStage(s *StageState, stateDB ethdb.Database, chainConfig 
 	defer batch.Rollback()
 
 	engine := chainContext.Engine()
+	chainContext.SetDB(tx)
 
 	logEvery := time.NewTicker(logInterval)
 	defer logEvery.Stop()
@@ -172,6 +173,7 @@ func SpawnExecuteBlocksStage(s *StageState, stateDB ethdb.Database, chainConfig 
 				if err = tx.CommitAndBegin(context.Background()); err != nil {
 					return err
 				}
+				chainContext.SetDB(tx)
 			}
 			warmup = params.Hdd && (to-blockNum) > 30000
 		}

--- a/eth/stagedsync/stagebuilder.go
+++ b/eth/stagedsync/stagebuilder.go
@@ -18,7 +18,7 @@ import (
 type StageParameters struct {
 	d            DownloaderGlue
 	chainConfig  *params.ChainConfig
-	chainContext core.ChainContext
+	chainContext *core.TinyChainContext
 	vmConfig     *vm.Config
 	db           ethdb.Database
 	// TX is a current transaction that staged sync runs in. It contains all the latest changes that DB has.

--- a/eth/stagedsync/stagedsync.go
+++ b/eth/stagedsync/stagedsync.go
@@ -41,7 +41,7 @@ func New(stages StageBuilders, unwindOrder UnwindOrder, params OptionalParameter
 func (stagedSync *StagedSync) Prepare(
 	d DownloaderGlue,
 	chainConfig *params.ChainConfig,
-	chainContext core.ChainContext,
+	chainContext *core.TinyChainContext,
 	vmConfig *vm.Config,
 	db ethdb.Database,
 	tx ethdb.Database,


### PR DESCRIPTION
While work on MDBX - it returned error: MDBX_TXN_OVERLAPPING: Overlapping read and write transactions for the current thread and I found that deep inside EMV used 1 method blockchain object GetHeader. And blockchain holding another database object from exec stage. 

So, here is replacement for blockchain object for execution stage. 

I suspended MDBX_TXN_OVERLAPPING in `kv_mdbx` branch - it's safe. But I testing it in the corner. 
