### PR TITLE
Migration idempotency: handle corner-cases of CriticalCollector

### DIFF
--- a/migrations/dupsort_state.go
+++ b/migrations/dupsort_state.go
@@ -12,7 +12,7 @@ import (
 
 var dupSortHashState = Migration{
 	Name: "dupsort_hash_state",
-	Up: func(db ethdb.Database, datadir string, OnLoadCommit etl.LoadCommitHandler) error {
+	Up: func(db ethdb.Database, datadir string, progress []byte, OnLoadCommit etl.LoadCommitHandler) error {
 		if exists, err := db.(ethdb.BucketsMigrator).BucketExists(dbutils.CurrentStateBucketOld1); err != nil {
 			return err
 		} else if !exists {
@@ -47,7 +47,7 @@ var dupSortHashState = Migration{
 
 var dupSortPlainState = Migration{
 	Name: "dupsort_plain_state",
-	Up: func(db ethdb.Database, datadir string, OnLoadCommit etl.LoadCommitHandler) error {
+	Up: func(db ethdb.Database, datadir string, progress []byte, OnLoadCommit etl.LoadCommitHandler) error {
 		if exists, err := db.(ethdb.BucketsMigrator).BucketExists(dbutils.PlainStateBucketOld1); err != nil {
 			return err
 		} else if !exists {
@@ -82,7 +82,7 @@ var dupSortPlainState = Migration{
 
 var dupSortIH = Migration{
 	Name: "dupsort_intermediate_trie_hashes",
-	Up: func(db ethdb.Database, datadir string, OnLoadCommit etl.LoadCommitHandler) error {
+	Up: func(db ethdb.Database, datadir string, progress []byte, OnLoadCommit etl.LoadCommitHandler) error {
 		if err := db.(ethdb.BucketsMigrator).ClearBuckets(dbutils.IntermediateTrieHashBucket); err != nil {
 			return err
 		}
@@ -123,7 +123,7 @@ var dupSortIH = Migration{
 
 var clearIndices = Migration{
 	Name: "clear_log_indices7",
-	Up: func(db ethdb.Database, datadir string, OnLoadCommit etl.LoadCommitHandler) error {
+	Up: func(db ethdb.Database, datadir string, progress []byte, OnLoadCommit etl.LoadCommitHandler) error {
 		if err := db.(ethdb.BucketsMigrator).ClearBuckets(dbutils.LogAddressIndex, dbutils.LogTopicIndex); err != nil {
 			return err
 		}
@@ -141,7 +141,7 @@ var clearIndices = Migration{
 
 var resetIHBucketToRecoverDB = Migration{
 	Name: "reset_in_bucket_to_recover_db",
-	Up: func(db ethdb.Database, datadir string, OnLoadCommit etl.LoadCommitHandler) error {
+	Up: func(db ethdb.Database, datadir string, progress []byte, OnLoadCommit etl.LoadCommitHandler) error {
 		if err := db.(ethdb.BucketsMigrator).ClearBuckets(dbutils.IntermediateTrieHashBucket); err != nil {
 			return err
 		}

--- a/migrations/migrations.go
+++ b/migrations/migrations.go
@@ -142,7 +142,7 @@ func (m *Migrator) Apply(db ethdb.Database, datadir string) error {
 			return err
 		}
 
-		if err := v.Up(tx, datadir, progress, func(putter ethdb.Putter, key []byte, isDone bool) error {
+		if err = v.Up(tx, datadir, progress, func(putter ethdb.Putter, key []byte, isDone bool) error {
 			if !isDone {
 				if key != nil {
 					err = putter.Put(dbutils.Migrations, []byte("_progress_"+v.Name), key)

--- a/migrations/migrations.go
+++ b/migrations/migrations.go
@@ -142,10 +142,10 @@ func (m *Migrator) Apply(db ethdb.Database, datadir string) error {
 			return err
 		}
 
-		if err = v.Up(tx, datadir, progress, func(putter ethdb.Putter, key []byte, isDone bool) error {
+		if err = v.Up(tx, datadir, progress, func(_ ethdb.Putter, key []byte, isDone bool) error {
 			if !isDone {
 				if key != nil {
-					err = putter.Put(dbutils.Migrations, []byte("_progress_"+v.Name), key)
+					err = tx.Put(dbutils.Migrations, []byte("_progress_"+v.Name), key)
 					if err != nil {
 						return err
 					}
@@ -162,7 +162,12 @@ func (m *Migrator) Apply(db ethdb.Database, datadir string) error {
 			if err != nil {
 				return err
 			}
-			err = putter.Put(dbutils.Migrations, []byte(v.Name), stagesProgress)
+			err = tx.Put(dbutils.Migrations, []byte(v.Name), stagesProgress)
+			if err != nil {
+				return err
+			}
+
+			err = tx.Delete(dbutils.Migrations, []byte("_progress_"+v.Name))
 			if err != nil {
 				return err
 			}

--- a/migrations/migrations.go
+++ b/migrations/migrations.go
@@ -74,6 +74,7 @@ type Migration struct {
 var (
 	ErrMigrationNonUniqueName   = fmt.Errorf("please provide unique migration name")
 	ErrMigrationCommitNotCalled = fmt.Errorf("migraion commit function was not called")
+	ErrMigrationETLFilesDeleted = fmt.Errorf("db migration progress was interrupted after extraction step and ETL files was deleted, please contact development team for help or re-sync from scratch")
 )
 
 func NewMigrator() *Migrator {

--- a/migrations/migrations_test.go
+++ b/migrations/migrations_test.go
@@ -17,13 +17,13 @@ func TestApplyWithInit(t *testing.T) {
 	migrations = []Migration{
 		{
 			"one",
-			func(db ethdb.Database, datadir string, OnLoadCommit etl.LoadCommitHandler) error {
+			func(db ethdb.Database, datadir string, progress []byte, OnLoadCommit etl.LoadCommitHandler) error {
 				return OnLoadCommit(db, nil, true)
 			},
 		},
 		{
 			"two",
-			func(db ethdb.Database, datadir string, OnLoadCommit etl.LoadCommitHandler) error {
+			func(db ethdb.Database, datadir string, progress []byte, OnLoadCommit etl.LoadCommitHandler) error {
 				return OnLoadCommit(db, nil, true)
 			},
 		},
@@ -56,14 +56,14 @@ func TestApplyWithoutInit(t *testing.T) {
 	migrations = []Migration{
 		{
 			"one",
-			func(db ethdb.Database, datadir string, OnLoadCommit etl.LoadCommitHandler) error {
+			func(db ethdb.Database, datadir string, progress []byte, OnLoadCommit etl.LoadCommitHandler) error {
 				t.Fatal("shouldn't been executed")
 				return nil
 			},
 		},
 		{
 			"two",
-			func(db ethdb.Database, datadir string, OnLoadCommit etl.LoadCommitHandler) error {
+			func(db ethdb.Database, datadir string, progress []byte, OnLoadCommit etl.LoadCommitHandler) error {
 				return OnLoadCommit(db, nil, true)
 			},
 		},
@@ -99,13 +99,13 @@ func TestWhenNonFirstMigrationAlreadyApplied(t *testing.T) {
 	migrations = []Migration{
 		{
 			"one",
-			func(db ethdb.Database, datadir string, OnLoadCommit etl.LoadCommitHandler) error {
+			func(db ethdb.Database, datadir string, progress []byte, OnLoadCommit etl.LoadCommitHandler) error {
 				return OnLoadCommit(db, nil, true)
 			},
 		},
 		{
 			"two",
-			func(db ethdb.Database, datadir string, OnLoadCommit etl.LoadCommitHandler) error {
+			func(db ethdb.Database, datadir string, progress []byte, OnLoadCommit etl.LoadCommitHandler) error {
 				t.Fatal("shouldn't been executed")
 				return nil
 			},
@@ -160,13 +160,13 @@ func TestValidation(t *testing.T) {
 	migrations = []Migration{
 		{
 			Name: "repeated_name",
-			Up: func(db ethdb.Database, datadir string, OnLoadCommit etl.LoadCommitHandler) error {
+			Up: func(db ethdb.Database, datadir string, progress []byte, OnLoadCommit etl.LoadCommitHandler) error {
 				return OnLoadCommit(db, nil, true)
 			},
 		},
 		{
 			Name: "repeated_name",
-			Up: func(db ethdb.Database, datadir string, OnLoadCommit etl.LoadCommitHandler) error {
+			Up: func(db ethdb.Database, datadir string, progress []byte, OnLoadCommit etl.LoadCommitHandler) error {
 				return OnLoadCommit(db, nil, true)
 			},
 		},
@@ -186,7 +186,7 @@ func TestCommitCallRequired(t *testing.T) {
 	migrations = []Migration{
 		{
 			Name: "one",
-			Up: func(db ethdb.Database, datadir string, OnLoadCommit etl.LoadCommitHandler) error {
+			Up: func(db ethdb.Database, datadir string, progress []byte, OnLoadCommit etl.LoadCommitHandler) error {
 				return nil // don't call OnLoadCommit
 			},
 		},

--- a/migrations/receipts.go
+++ b/migrations/receipts.go
@@ -29,7 +29,7 @@ var receiptsCborEncode = Migration{
 			return err1
 		}
 		if collector != nil && progress != nil {
-			goto LoadPart
+			goto LoadStep
 		}
 
 		if string(progress) == loadStep && collector == nil {
@@ -74,7 +74,7 @@ var receiptsCborEncode = Migration{
 			return fmt.Errorf("committing the removal of receipt table")
 		}
 
-	LoadPart:
+	LoadStep:
 		// Commit again
 		if err := CommitProgress(db, []byte(loadStep), false); err != nil {
 			return fmt.Errorf("committing again to create a stable view the removal of receipt table")

--- a/migrations/receipts.go
+++ b/migrations/receipts.go
@@ -33,10 +33,7 @@ var receiptsCborEncode = Migration{
 		case "":
 			if collector != nil { //  can't use files if progress field not set
 				_ = os.RemoveAll(datadir)
-				collector, err1 = etl.NewCollectorFromFiles(datadir)
-				if err1 != nil {
-					return err1
-				}
+				collector = nil
 			}
 		case loadStep:
 			if collector == nil {

--- a/migrations/receipts.go
+++ b/migrations/receipts.go
@@ -40,7 +40,7 @@ var receiptsCborEncode = Migration{
 			}
 		case loadStep:
 			if collector == nil {
-				return fmt.Errorf("db migration progress was interrupted after extraction step and ETL files was deleted, please contact development team for help or re-sync from scratch")
+				return ErrMigrationETLFilesDeleted
 			}
 			goto LoadStep
 		}

--- a/migrations/receipts.go
+++ b/migrations/receipts.go
@@ -18,57 +18,68 @@ import (
 
 var receiptsCborEncode = Migration{
 	Name: "receipts_cbor_encode",
-	Up: func(db ethdb.Database, datadir string, OnLoadCommit etl.LoadCommitHandler) error {
+	Up: func(db ethdb.Database, datadir string, progress []byte, CommitProgress etl.LoadCommitHandler) error {
 		logEvery := time.NewTicker(30 * time.Second)
 		defer logEvery.Stop()
+		buf := make([]byte, 0, 100_000)
+
 		collector, err1 := etl.NewCollectorFromFiles(datadir)
 		if err1 != nil {
 			return err1
 		}
-		if collector == nil {
-			collector = etl.NewCriticalCollector(datadir, etl.NewSortableBuffer(etl.BufferOptimalSize))
-			buf := make([]byte, 0, 100_000)
-			if err1 = db.Walk(dbutils.BlockReceiptsPrefix, nil, 0, func(k, v []byte) (bool, error) {
-				blockNum := binary.BigEndian.Uint64(k[:8])
-				select {
-				default:
-				case <-logEvery.C:
-					var m runtime.MemStats
-					runtime.ReadMemStats(&m)
-					log.Info("Migration progress", "blockNum", blockNum, "alloc", common.StorageSize(m.Alloc), "sys", common.StorageSize(m.Sys))
-				}
-
-				// Convert the receipts from their storage form to their internal representation
-				storageReceipts := []*types.ReceiptForStorage{}
-				if err := rlp.DecodeBytes(v, &storageReceipts); err != nil {
-					return false, fmt.Errorf("invalid receipt array RLP: %w, k=%x", err, k)
-				}
-
-				buf = buf[:0]
-				if err := cbor.Marshal(&buf, storageReceipts); err != nil {
-					return false, err
-				}
-				if err := collector.Collect(k, buf); err != nil {
-					return false, fmt.Errorf("collecting key %x: %w", k, err)
-				}
-				return true, nil
-			}); err1 != nil {
-				return err1
-			}
+		if collector != nil && progress != nil {
+			goto LoadPart
 		}
+
+		if string(progress) == "load" && collector == nil {
+			return fmt.Errorf("db migration progress was interrupted after extraction step and ETL files was deleted, please contact development team for help or re-sync from scratch")
+		}
+
+		collector = etl.NewCriticalCollector(datadir, etl.NewSortableBuffer(etl.BufferOptimalSize))
+		if err1 = db.Walk(dbutils.BlockReceiptsPrefix, nil, 0, func(k, v []byte) (bool, error) {
+			blockNum := binary.BigEndian.Uint64(k[:8])
+			select {
+			default:
+			case <-logEvery.C:
+				var m runtime.MemStats
+				runtime.ReadMemStats(&m)
+				log.Info("Migration progress", "blockNum", blockNum, "alloc", common.StorageSize(m.Alloc), "sys", common.StorageSize(m.Sys))
+			}
+
+			// Convert the receipts from their storage form to their internal representation
+			storageReceipts := []*types.ReceiptForStorage{}
+			if err := rlp.DecodeBytes(v, &storageReceipts); err != nil {
+				return false, fmt.Errorf("invalid receipt array RLP: %w, k=%x", err, k)
+			}
+
+			buf = buf[:0]
+			if err := cbor.Marshal(&buf, storageReceipts); err != nil {
+				return false, err
+			}
+			if err := collector.Collect(k, buf); err != nil {
+				return false, fmt.Errorf("collecting key %x: %w", k, err)
+			}
+			return true, nil
+		}); err1 != nil {
+			return err1
+		}
+
 		if err := db.(ethdb.BucketsMigrator).ClearBuckets(dbutils.BlockReceiptsPrefix); err != nil {
 			return fmt.Errorf("clearing the receipt bucket: %w", err)
 		}
+
 		// Commit clearing of the bucket - freelist should now be written to the database
-		if err := OnLoadCommit(db, nil, false); err != nil {
+		if err := CommitProgress(db, []byte("load"), false); err != nil {
 			return fmt.Errorf("committing the removal of receipt table")
 		}
+
+	LoadPart:
 		// Commit again
-		if err := OnLoadCommit(db, nil, false); err != nil {
+		if err := CommitProgress(db, []byte("load"), false); err != nil {
 			return fmt.Errorf("committing again to create a stable view the removal of receipt table")
 		}
 		// Now transaction would have been re-opened, and we should be re-using the space
-		if err := collector.Load(db, dbutils.BlockReceiptsPrefix, etl.IdentityLoadFunc, etl.TransformArgs{OnLoadCommit: OnLoadCommit}); err != nil {
+		if err := collector.Load(db, dbutils.BlockReceiptsPrefix, etl.IdentityLoadFunc, etl.TransformArgs{OnLoadCommit: CommitProgress}); err != nil {
 			return fmt.Errorf("loading the transformed data back into the receipts table: %w", err)
 		}
 		return nil

--- a/migrations/receipts.go
+++ b/migrations/receipts.go
@@ -22,6 +22,7 @@ var receiptsCborEncode = Migration{
 		logEvery := time.NewTicker(30 * time.Second)
 		defer logEvery.Stop()
 		buf := make([]byte, 0, 100_000)
+		const loadStep = "load"
 
 		collector, err1 := etl.NewCollectorFromFiles(datadir)
 		if err1 != nil {
@@ -31,7 +32,7 @@ var receiptsCborEncode = Migration{
 			goto LoadPart
 		}
 
-		if string(progress) == "load" && collector == nil {
+		if string(progress) == loadStep && collector == nil {
 			return fmt.Errorf("db migration progress was interrupted after extraction step and ETL files was deleted, please contact development team for help or re-sync from scratch")
 		}
 
@@ -69,13 +70,13 @@ var receiptsCborEncode = Migration{
 		}
 
 		// Commit clearing of the bucket - freelist should now be written to the database
-		if err := CommitProgress(db, []byte("load"), false); err != nil {
+		if err := CommitProgress(db, []byte(loadStep), false); err != nil {
 			return fmt.Errorf("committing the removal of receipt table")
 		}
 
 	LoadPart:
 		// Commit again
-		if err := CommitProgress(db, []byte("load"), false); err != nil {
+		if err := CommitProgress(db, []byte(loadStep), false); err != nil {
 			return fmt.Errorf("committing again to create a stable view the removal of receipt table")
 		}
 		// Now transaction would have been re-opened, and we should be re-using the space

--- a/migrations/receipts.go
+++ b/migrations/receipts.go
@@ -28,10 +28,9 @@ var receiptsCborEncode = Migration{
 		if err1 != nil {
 			return err1
 		}
-		if collector != nil && progress != nil {
+		if collector != nil && progress != nil && string(progress) == loadStep {
 			goto LoadStep
 		}
-
 		if string(progress) == loadStep && collector == nil {
 			return fmt.Errorf("db migration progress was interrupted after extraction step and ETL files was deleted, please contact development team for help or re-sync from scratch")
 		}

--- a/migrations/receipts.go
+++ b/migrations/receipts.go
@@ -41,9 +41,8 @@ var receiptsCborEncode = Migration{
 		case loadStep:
 			if collector == nil {
 				return fmt.Errorf("db migration progress was interrupted after extraction step and ETL files was deleted, please contact development team for help or re-sync from scratch")
-			} else {
-				goto LoadStep
 			}
+			goto LoadStep
 		}
 
 		collector = etl.NewCriticalCollector(datadir, etl.NewSortableBuffer(etl.BufferOptimalSize))

--- a/migrations/receipts_test.go
+++ b/migrations/receipts_test.go
@@ -21,4 +21,14 @@ func TestReceiptCbor(t *testing.T) {
 	migrator.Migrations = []Migration{receiptsCborEncode}
 	err = migrator.Apply(db, "")
 	require.NoError(err)
+
+	err = receiptsCborEncode.Up(db, "tmp-test-dir", nil, func(db ethdb.Putter, key []byte, isDone bool) error {
+		return nil
+	})
+	require.NoError(err)
+
+	err = receiptsCborEncode.Up(db, "tmp-test-dir", []byte("load"), func(db ethdb.Putter, key []byte, isDone bool) error {
+		return nil
+	})
+	require.NoError(err)
 }

--- a/migrations/receipts_test.go
+++ b/migrations/receipts_test.go
@@ -1,0 +1,24 @@
+package migrations
+
+import (
+	"context"
+	"testing"
+
+	"github.com/ledgerwatch/turbo-geth/common/dbutils"
+	"github.com/ledgerwatch/turbo-geth/ethdb"
+	"github.com/stretchr/testify/require"
+)
+
+func TestReceiptCbor(t *testing.T) {
+	require, db := require.New(t), ethdb.NewMemDatabase()
+
+	err := db.KV().Update(context.Background(), func(tx ethdb.Tx) error {
+		return tx.(ethdb.BucketMigrator).CreateBucket(dbutils.BlockReceiptsPrefix)
+	})
+	require.NoError(err)
+
+	migrator := NewMigrator()
+	migrator.Migrations = []Migration{receiptsCborEncode}
+	err = migrator.Apply(db, "")
+	require.NoError(err)
+}

--- a/migrations/receipts_test.go
+++ b/migrations/receipts_test.go
@@ -2,6 +2,7 @@ package migrations
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/ledgerwatch/turbo-geth/common/dbutils"
@@ -30,5 +31,5 @@ func TestReceiptCbor(t *testing.T) {
 	err = receiptsCborEncode.Up(db, "tmp-test-dir", []byte("load"), func(db ethdb.Putter, key []byte, isDone bool) error {
 		return nil
 	})
-	require.NoError(err)
+	require.True(errors.Is(err, ErrMigrationETLFilesDeleted))
 }

--- a/migrations/stagedsync_to_use_stage_blockhashes.go
+++ b/migrations/stagedsync_to_use_stage_blockhashes.go
@@ -8,15 +8,15 @@ import (
 
 var stagedsyncToUseStageBlockhashes = Migration{
 	Name: "stagedsync_to_use_stage_blockhashes",
-	Up: func(db ethdb.Database, datadir string, OnLoadCommit etl.LoadCommitHandler) error {
+	Up: func(db ethdb.Database, datadir string, progress []byte, OnLoadCommit etl.LoadCommitHandler) error {
 
-		var progress uint64
+		var stageProgress uint64
 		var err error
-		if progress, _, err = stages.GetStageProgress(db, stages.Headers); err != nil {
+		if stageProgress, _, err = stages.GetStageProgress(db, stages.Headers); err != nil {
 			return err
 		}
 
-		if err = stages.SaveStageProgress(db, stages.BlockHashes, progress, nil); err != nil {
+		if err = stages.SaveStageProgress(db, stages.BlockHashes, stageProgress, nil); err != nil {
 			return err
 		}
 
@@ -30,15 +30,15 @@ var stagedsyncToUseStageBlockhashes = Migration{
 
 var unwindStagedsyncToUseStageBlockhashes = Migration{
 	Name: "unwind_stagedsync_to_use_stage_blockhashes",
-	Up: func(db ethdb.Database, datadir string, OnLoadCommit etl.LoadCommitHandler) error {
+	Up: func(db ethdb.Database, datadir string, progress []byte, OnLoadCommit etl.LoadCommitHandler) error {
 
-		var progress uint64
+		var stageProgress uint64
 		var err error
-		if progress, _, err = stages.GetStageUnwind(db, stages.Headers); err != nil {
+		if stageProgress, _, err = stages.GetStageUnwind(db, stages.Headers); err != nil {
 			return err
 		}
 
-		if err = stages.SaveStageUnwind(db, stages.BlockHashes, progress, nil); err != nil {
+		if err = stages.SaveStageUnwind(db, stages.BlockHashes, stageProgress, nil); err != nil {
 			return err
 		}
 

--- a/migrations/stages_to_use_named_keys.go
+++ b/migrations/stages_to_use_named_keys.go
@@ -24,7 +24,7 @@ var dbKeys = []stages.SyncStage{
 
 var stagesToUseNamedKeys = Migration{
 	Name: "stages_to_use_named_keys",
-	Up: func(db ethdb.Database, datadir string, OnLoadCommit etl.LoadCommitHandler) error {
+	Up: func(db ethdb.Database, datadir string, progress []byte, OnLoadCommit etl.LoadCommitHandler) error {
 
 		if exists, err := db.(ethdb.BucketsMigrator).BucketExists(dbutils.SyncStageProgressOld1); err != nil {
 			return err
@@ -69,7 +69,7 @@ var stagesToUseNamedKeys = Migration{
 
 var unwindStagesToUseNamedKeys = Migration{
 	Name: "unwind_stages_to_use_named_keys",
-	Up: func(db ethdb.Database, datadir string, OnLoadCommit etl.LoadCommitHandler) error {
+	Up: func(db ethdb.Database, datadir string, progress []byte, OnLoadCommit etl.LoadCommitHandler) error {
 		if exists, err := db.(ethdb.BucketsMigrator).BucketExists(dbutils.SyncStageUnwindOld1); err != nil {
 			return err
 		} else if !exists {


### PR DESCRIPTION
- don't clean if panic happened
- don't clean if any error happened
- save progress of stage and use collected files only if progress value is == "load"
