### PR TITLE
migrations: make tmp dir name predictable and unique

### DIFF
--- a/migrations/migrations.go
+++ b/migrations/migrations.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"path"
 
 	"github.com/ledgerwatch/turbo-geth/common"
 	"github.com/ledgerwatch/turbo-geth/common/dbutils"
@@ -143,7 +144,7 @@ func (m *Migrator) Apply(db ethdb.Database, datadir string) error {
 			return err
 		}
 
-		if err = v.Up(tx, datadir, progress, func(_ ethdb.Putter, key []byte, isDone bool) error {
+		if err = v.Up(tx, path.Join(datadir, "migrations", v.Name), progress, func(_ ethdb.Putter, key []byte, isDone bool) error {
 			if !isDone {
 				if key != nil {
 					err = tx.Put(dbutils.Migrations, []byte("_progress_"+v.Name), key)

--- a/migrations/receipts.go
+++ b/migrations/receipts.go
@@ -75,12 +75,12 @@ var receiptsCborEncode = Migration{
 			return fmt.Errorf("clearing the receipt bucket: %w", err)
 		}
 
+	LoadStep:
 		// Commit clearing of the bucket - freelist should now be written to the database
 		if err := CommitProgress(db, []byte(loadStep), false); err != nil {
 			return fmt.Errorf("committing the removal of receipt table")
 		}
 
-	LoadStep:
 		// Commit again
 		if err := CommitProgress(db, []byte(loadStep), false); err != nil {
 			return fmt.Errorf("committing again to create a stable view the removal of receipt table")

--- a/migrations/receipts.go
+++ b/migrations/receipts.go
@@ -75,12 +75,12 @@ var receiptsCborEncode = Migration{
 			return fmt.Errorf("clearing the receipt bucket: %w", err)
 		}
 
-	LoadStep:
 		// Commit clearing of the bucket - freelist should now be written to the database
 		if err := CommitProgress(db, []byte(loadStep), false); err != nil {
 			return fmt.Errorf("committing the removal of receipt table")
 		}
 
+	LoadStep:
 		// Commit again
 		if err := CommitProgress(db, []byte(loadStep), false); err != nil {
 			return fmt.Errorf("committing again to create a stable view the removal of receipt table")


### PR DESCRIPTION
now it using separated folder for tmp files: 
Normal tmp: `/datadir/etl-tmp`
Migrations tmp: `/datadir/some_hand_crafded_folder_name/etl-tmp`
which is hard to mount to separated drive, because name is not predictable. I will change it to:
Migrations tmp: `/datadir/migrations/some_hand_crafded_folder_name/etl-tmp`
And probably need mention somewhere in docs about: that if you wanna place tmp files to separated drive need mont 2 folders `/datadir/etl-tmp` and `/datadir/migrations` - where to write about it? 
