### PR TITLE
[Pending test] Update skip analysis

### DIFF
--- a/core/skip_analysis.go
+++ b/core/skip_analysis.go
@@ -30,7 +30,7 @@ import (
 // 0x86e55d1818b5355424975de9633a57c40789ca08552297b726333a9433949c92 (block 6426298)
 // 0x3666640316df11865abd1352f4c0b4c5126f8ac1d858ef2a0c6e744a4865bca2 (block 5800596)
 
-const MainnetNotCheckedFrom uint64 = 11075819
+const MainnetNotCheckedFrom uint64 = 11104756
 
 func SkipAnalysis(config *params.ChainConfig, blockNumber uint64) bool {
 	if config != params.MainnetChainConfig {
@@ -39,7 +39,7 @@ func SkipAnalysis(config *params.ChainConfig, blockNumber uint64) bool {
 	if blockNumber >= MainnetNotCheckedFrom { // We have not checked beyond that block
 		return false
 	}
-	if blockNumber == 6426298 || blockNumber == 6426432 || blockNumber == 5800596 {
+	if blockNumber == 6426298 || blockNumber == 6426432 || blockNumber == 5800596 || blockNumber == 11079912 {
 		return false
 	}
 	return true


### PR DESCRIPTION
There is one new exclusion caused by this:
```
INFO [10-22|08:02:08.473] Checked                                  blocks=11079000
WARN [10-22|08:03:31.434] Code Bitmap used for detecting invalid jump tx=0xcdb5bf0b4b51093e1c994f471921f88623c9d3e1b6aa2782049f53a0048f2b32 block number=11079912
INFO [10-22|08:03:38.983] Checked                                  blocks=11080000
```
