### PR TITLE
Fix infinite rpc.gascap on eth_estimateGas

### DIFF
--- a/cmd/rpcdaemon/commands/eth_call.go
+++ b/cmd/rpcdaemon/commands/eth_call.go
@@ -106,7 +106,7 @@ func (api *APIImpl) DoEstimateGas(ctx context.Context, args ethapi.CallArgs, blo
 		}
 	}
 	// Recap the highest gas allowance with specified gascap.
-	if gasCap != nil && hi > gasCap.Uint64() {
+	if gasCap != nil && gasCap.Uint64() != 0 && hi > gasCap.Uint64() {
 		log.Warn("Caller gas above allowance, capping", "requested", hi, "cap", gasCap)
 		hi = gasCap.Uint64()
 	}

--- a/cmd/rpcdaemon/commands/eth_call.go
+++ b/cmd/rpcdaemon/commands/eth_call.go
@@ -106,7 +106,7 @@ func (api *APIImpl) DoEstimateGas(ctx context.Context, args ethapi.CallArgs, blo
 		}
 	}
 	// Recap the highest gas allowance with specified gascap.
-	if gasCap != nil && gasCap.Uint64() != 0 && hi > gasCap.Uint64() {
+	if gasCap != nil && gasCap.Sign() > 0 && hi > gasCap.Uint64() {
 		log.Warn("Caller gas above allowance, capping", "requested", hi, "cap", gasCap)
 		hi = gasCap.Uint64()
 	}


### PR DESCRIPTION
Fixes #1284

Cause was that, when adapting the old rpc to the new rpcdaemon, `gasCap != 0` was translated to `gasCap != nil`, however gasCap does not come null by default, it cames as a big Int object initialized with zero value. 

The zero gasCap means infinite gasCap. 

This gascaps are added to ensure that public rpc endpoints cannot be broken with infinite loops in the estimategas and call, as they essentially run without block gas limit. 

The fix was simple, just add the check against zero again. I kept the != nil, but might be removed. 