### PR TITLE
Add the missing CaptureStart and CaptureEnd

### DIFF
--- a/core/vm/evm.go
+++ b/core/vm/evm.go
@@ -406,7 +406,6 @@ func (evm *EVM) StaticCall(caller ContractRef, addr common.Address, input []byte
 		}(gas, time.Now())
 	}
 
-
 	if p, isPrecompile := evm.precompile(addr); isPrecompile {
 		ret, gas, err = RunPrecompiledContract(p, input, gas)
 	} else {


### PR DESCRIPTION
CallCode, DelegateCall and StaticCall were missing the CaptureStart and CaptureEnd calls, which made it impossible to trace them.