### PR TITLE
make docker: don't send .git to Docker

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -8,4 +8,5 @@ build
 tests/testdata
 debug-web-ui
 cmd/prometheus
-semantics
+
+.git


### PR DESCRIPTION
before
`Sending build context to Docker daemon  685.6MB`

after
`Sending build context to Docker daemon  41.25MB`

should also speed-up CI