### PR TITLE
[to discuss] History transform Stops too early

### DIFF
--- a/common/etl/etl.go
+++ b/common/etl/etl.go
@@ -60,7 +60,7 @@ type LoadCommitHandler func(db ethdb.Putter, key []byte, isDone bool) error
 type AdditionalLogArguments func(k, v []byte) (additionalLogArguments []interface{})
 
 type TransformArgs struct {
-	ExtractStartKey []byte
+	ExtractStartKey []byte // [Start:End)
 	ExtractEndKey   []byte
 	FixedBits       int
 	BufferType      int

--- a/common/etl/etl.go
+++ b/common/etl/etl.go
@@ -125,6 +125,9 @@ func extractBucketIntoFiles(
 		if err := common.Stopped(quit); err != nil {
 			return false, err
 		}
+		if endkey != nil && bytes.Compare(k, endkey) > 0 {
+			return false, nil
+		}
 
 		select {
 		default:
@@ -139,9 +142,6 @@ func extractBucketIntoFiles(
 			runtime.ReadMemStats(&m)
 			logArs = append(logArs, "alloc", common.StorageSize(m.Alloc), "sys", common.StorageSize(m.Sys), "numGC", int(m.NumGC))
 			log.Info(fmt.Sprintf("[%s] ETL [1/2] Extracting", logPrefix), logArs...)
-		}
-		if endkey != nil && bytes.Compare(k, endkey) > 0 {
-			return false, nil
 		}
 		if err := extractFunc(k, v, collector.extractNextFunc); err != nil {
 			return false, err

--- a/eth/stagedsync/stage_blockhashes.go
+++ b/eth/stagedsync/stage_blockhashes.go
@@ -1,8 +1,6 @@
 package stagedsync
 
 import (
-	"encoding/binary"
-
 	"github.com/ledgerwatch/turbo-geth/common"
 	"github.com/ledgerwatch/turbo-geth/common/dbutils"
 	"github.com/ledgerwatch/turbo-geth/common/etl"
@@ -26,9 +24,8 @@ func SpawnBlockHashStage(s *StageState, stateDB ethdb.Database, tmpdir string, q
 		return nil
 	}
 
-	startKey := make([]byte, 8)
-	binary.BigEndian.PutUint64(startKey, s.BlockNumber)
-	endKey := dbutils.HeaderKey(*headNumber, headHash) // Make sure we stop at head
+	startKey := dbutils.EncodeBlockNumber(s.BlockNumber)
+	endKey := dbutils.EncodeBlockNumber(*headNumber + 1)
 
 	logPrefix := s.state.LogPrefix()
 	if err := etl.Transform(

--- a/eth/stagedsync/stage_indexes.go
+++ b/eth/stagedsync/stage_indexes.go
@@ -27,7 +27,7 @@ func SpawnAccountHistoryIndex(s *StageState, db ethdb.Database, tmpdir string, q
 	ig := core.NewIndexGenerator(logPrefix, db, quitCh)
 	ig.TempDir = tmpdir
 
-	if err := ig.GenerateIndex(blockNum, endBlock, dbutils.PlainAccountChangeSetBucket, tmpdir); err != nil {
+	if err := ig.GenerateIndex(blockNum, endBlock+1, dbutils.PlainAccountChangeSetBucket, tmpdir); err != nil {
 		return fmt.Errorf("%s: fail to generate index: %w", logPrefix, err)
 	}
 
@@ -51,7 +51,7 @@ func SpawnStorageHistoryIndex(s *StageState, db ethdb.Database, tmpdir string, q
 	}
 	ig := core.NewIndexGenerator(logPrefix, db, quitCh)
 	ig.TempDir = tmpdir
-	if err := ig.GenerateIndex(blockNum, endBlock, dbutils.PlainStorageChangeSetBucket, tmpdir); err != nil {
+	if err := ig.GenerateIndex(blockNum, endBlock+1, dbutils.PlainStorageChangeSetBucket, tmpdir); err != nil {
 		return fmt.Errorf("%s: fail to generate index: %w", logPrefix, err)
 	}
 

--- a/eth/stagedsync/stage_indexes.go
+++ b/eth/stagedsync/stage_indexes.go
@@ -9,29 +9,28 @@ import (
 )
 
 func SpawnAccountHistoryIndex(s *StageState, db ethdb.Database, tmpdir string, quitCh <-chan struct{}) error {
-	endBlock, err := s.ExecutionAt(db)
+	executionAt, err := s.ExecutionAt(db)
 	logPrefix := s.state.LogPrefix()
 	if err != nil {
 		return fmt.Errorf("%s: getting last executed block: %w", logPrefix, err)
 	}
-	if endBlock == s.BlockNumber {
+	if executionAt == s.BlockNumber {
 		s.Done()
 		return nil
 	}
-	var blockNum uint64
-	lastProcessedBlockNumber := s.BlockNumber
-	if lastProcessedBlockNumber > 0 {
-		blockNum = lastProcessedBlockNumber + 1
+	var startChangeSetsLookupAt uint64
+	if s.BlockNumber > 0 {
+		startChangeSetsLookupAt = s.BlockNumber + 1
 	}
+	stopChangeSetsLookupAt := executionAt + 1
 
 	ig := core.NewIndexGenerator(logPrefix, db, quitCh)
 	ig.TempDir = tmpdir
-
-	if err := ig.GenerateIndex(blockNum, endBlock+1, dbutils.PlainAccountChangeSetBucket, tmpdir); err != nil {
+	if err := ig.GenerateIndex(startChangeSetsLookupAt, stopChangeSetsLookupAt, dbutils.PlainAccountChangeSetBucket, tmpdir); err != nil {
 		return fmt.Errorf("%s: fail to generate index: %w", logPrefix, err)
 	}
 
-	return s.DoneAndUpdate(db, endBlock)
+	return s.DoneAndUpdate(db, executionAt)
 }
 
 func SpawnStorageHistoryIndex(s *StageState, db ethdb.Database, tmpdir string, quitCh <-chan struct{}) error {

--- a/eth/stagedsync/stage_txlookup.go
+++ b/eth/stagedsync/stage_txlookup.go
@@ -30,7 +30,7 @@ func SpawnTxLookup(s *StageState, db ethdb.Database, tmpdir string, quitCh <-cha
 
 	logPrefix := s.state.LogPrefix()
 	startKey = dbutils.HeaderHashKey(blockNum)
-	if err = TxLookupTransform(logPrefix, db, startKey, dbutils.HeaderHashKey(syncHeadNumber), quitCh, tmpdir); err != nil {
+	if err = TxLookupTransform(logPrefix, db, startKey, dbutils.HeaderHashKey(syncHeadNumber+1), quitCh, tmpdir); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
Problem: `endBlock` variable is used for 2 purposes:
1. To set history_stage progress when processing is done 
2. To stop etl.Transform function - but etl.Transform does stop by condition: 
```
if endkey != nil && bytes.Compare(k, endkey) > 0 {
   // stop
}
```
And for example if you move history_stage from block 2 to block 3, then etl.Transform will be called with parameters: ExtractStartKey=3, ExtractEndKey=3 and processing will stop after processing 1 k/v pair. 

It works for normal buckets, but DupSort can supply multiple k/v paris with same key to this function and it will stop after processing first one.  

But now - need to move etl.Transform condition to the begin of loop.... 

