### PR TITLE
IH: regenerate must clear IH bucket  

### DIFF
--- a/eth/stagedsync/stage_interhashes.go
+++ b/eth/stagedsync/stage_interhashes.go
@@ -80,6 +80,10 @@ func SpawnIntermediateHashesStage(s *StageState, db ethdb.Database, tmpdir strin
 
 func regenerateIntermediateHashes(logPrefix string, db ethdb.Database, tmpdir string, expectedRootHash common.Hash, quit <-chan struct{}) error {
 	log.Info(fmt.Sprintf("[%s] Regeneration intermediate hashes started", logPrefix))
+	if err := db.(ethdb.BucketsMigrator).ClearBuckets(dbutils.IntermediateTrieHashBucket); err != nil {
+		return err
+	}
+
 	buf := etl.NewSortableBuffer(etl.BufferOptimalSize)
 	comparator := db.(ethdb.HasTx).Tx().Comparator(dbutils.IntermediateTrieHashBucket)
 	buf.SetComparator(comparator)
@@ -227,10 +231,8 @@ func incrementIntermediateHashes(logPrefix string, s *StageState, db ethdb.Datab
 	p := NewHashPromoter(db, quit)
 	p.TempDir = tmpdir
 	var exclude [][]byte
-	//ihFilter := trie.NewPrefixFilter()
 	collect := func(k []byte, _ []byte, _ etl.CurrentTableReader, _ etl.LoadNextFunc) error {
 		exclude = append(exclude, k)
-		//ihFilter.Add(k)
 		return nil
 	}
 

--- a/turbo/trie/trie_root.go
+++ b/turbo/trie/trie_root.go
@@ -385,7 +385,7 @@ func (l *FlatDBTrieLoader) CalcTrieRoot(db ethdb.Database, quit <-chan struct{})
 	var filter = func(k []byte) bool {
 		return !l.rd.Retain(k)
 	}
-	ih := IH(filter, tx.CursorDupSort(l.intermediateHashesBucket), tx.CursorDupSort(l.intermediateHashesBucket))
+	ih := IH(filter, tx.CursorDupSort(l.intermediateHashesBucket))
 	if err := l.iteration(c, ih, true /* first */); err != nil {
 		return EmptyRoot, err
 	}
@@ -733,13 +733,12 @@ const IHDupKeyLen = 2 * (common.HashLength + common.IncarnationLength)
 
 // IHCursor - holds logic related to iteration over IH bucket
 type IHCursor struct {
-	c          ethdb.CursorDupSort
-	cForDelete ethdb.CursorDupSort
-	filter     Filter
+	c      ethdb.CursorDupSort
+	filter Filter
 }
 
-func IH(f Filter, c ethdb.CursorDupSort, cForDelete ethdb.CursorDupSort) *IHCursor {
-	return &IHCursor{c: c, filter: f, cForDelete: cForDelete}
+func IH(f Filter, c ethdb.CursorDupSort) *IHCursor {
+	return &IHCursor{c: c, filter: f}
 }
 
 func (c *IHCursor) _seek(seek []byte) (k, v []byte, err error) {
@@ -764,7 +763,6 @@ func (c *IHCursor) _seek(seek []byte) (k, v []byte, err error) {
 		return nil, nil, nil
 	}
 
-	kCopy, vCopy := common.CopyBytes(k), common.CopyBytes(v)
 	if len(v) > common.HashLength {
 		keyPart := len(v) - common.HashLength
 		k = append(k, v[:keyPart]...)
@@ -774,7 +772,7 @@ func (c *IHCursor) _seek(seek []byte) (k, v []byte, err error) {
 		return k, v, nil
 	}
 
-	err = c.cForDelete.Delete(kCopy, vCopy)
+	err = c.c.Delete(k, v)
 	if err != nil {
 		return []byte{}, nil, err
 	}
@@ -792,7 +790,6 @@ func (c *IHCursor) _next() (k, v []byte, err error) {
 			return nil, nil, nil
 		}
 
-		kCopy, vCopy := common.CopyBytes(k), common.CopyBytes(v)
 		if len(v) > common.HashLength {
 			keyPart := len(v) - common.HashLength
 			k = append(k, v[:keyPart]...)
@@ -803,7 +800,7 @@ func (c *IHCursor) _next() (k, v []byte, err error) {
 			return k, v, nil
 		}
 
-		err = c.cForDelete.Delete(kCopy, vCopy)
+		err = c.c.Delete(k, v)
 		if err != nil {
 			return []byte{}, nil, err
 		}


### PR DESCRIPTION
If you promote sync to stage 2, then unwind to 0, then promote to 4:
- then on second promotion IH bucket will be not clean while retain list empty - it causing hash-root mismatch 


Also removed additional cursor for deletes - because LMDB and MDBX are fixed this problem already.