### PR TITLE
[to discuss] More compact append implementation

### DIFF
--- a/common/changeset/storage_changeset_test.go
+++ b/common/changeset/storage_changeset_test.go
@@ -403,9 +403,9 @@ func doTestFind(
 		}
 
 		c := tx.Cursor(bucket)
-		defer c.Close()
+
 		err := encodeFunc(1, ch, func(k, v []byte) error {
-			if err2 := c.Append(common.CopyBytes(k), common.CopyBytes(v)); err2 != nil {
+			if err2 := c.Put(common.CopyBytes(k), common.CopyBytes(v)); err2 != nil {
 				return err2
 			}
 			return nil
@@ -555,7 +555,7 @@ func TestMultipleIncarnationsOfTheSameContract(t *testing.T) {
 	assert.NoError(t, ch.Add(dbutils.PlainGenerateCompositeStorageKey(contractC, 5, key4), val4))
 
 	assert.NoError(t, EncodeStoragePlain(1, ch, func(k, v []byte) error {
-		return c.Append(k, v)
+		return c.Put(k, v)
 	}))
 
 	data1, err1 := cs.FindWithIncarnation(1, dbutils.PlainGenerateCompositeStorageKey(contractA, 2, key1))

--- a/common/etl/collector.go
+++ b/common/etl/collector.go
@@ -212,7 +212,7 @@ func loadFilesIntoBucket(logPrefix string, db ethdb.Database, bucket string, pro
 		if canUseAppend {
 			if isDupSort {
 				if bytes.Equal(k, pervK) {
-					if err := tx.(*ethdb.TxDb).AppendDup(bucket, k, v); err != nil {
+					if err := tx.AppendDup(bucket, k, v); err != nil {
 						return fmt.Errorf("%s: append: k=%x, %w", logPrefix, k, err)
 					}
 				} else {

--- a/core/generate_index_test.go
+++ b/core/generate_index_test.go
@@ -222,7 +222,7 @@ func generateTestData(t *testing.T, db ethdb.Database, csBucket string, numOfBlo
 			expected3[len(expected3)-1] = expected3[len(expected3)-1].Append(uint64(i), false)
 		}
 		err = csInfo.Encode(uint64(i), cs, func(k, v []byte) error {
-			return db.Append(csBucket, k, v)
+			return db.Put(csBucket, k, v)
 		})
 		if err != nil {
 			t.Fatal(err)

--- a/core/state/plain_state_writer.go
+++ b/core/state/plain_state_writer.go
@@ -156,11 +156,11 @@ func (w *PlainStateWriter) WriteChangeSets() error {
 	var prevK []byte
 	if err = changeset.Mapper[dbutils.PlainAccountChangeSetBucket].Encode(w.blockNumber, accountChanges, func(k, v []byte) error {
 		if bytes.Equal(k, prevK) {
-			if err := db.(*ethdb.TxDb).AppendDup(dbutils.PlainAccountChangeSetBucket, k, v); err != nil {
+			if err = db.AppendDup(dbutils.PlainAccountChangeSetBucket, k, v); err != nil {
 				return err
 			}
 		} else {
-			if err := db.Append(dbutils.PlainAccountChangeSetBucket, k, v); err != nil {
+			if err = db.Append(dbutils.PlainAccountChangeSetBucket, k, v); err != nil {
 				return err
 			}
 		}
@@ -180,11 +180,11 @@ func (w *PlainStateWriter) WriteChangeSets() error {
 	}
 	if err = changeset.Mapper[dbutils.PlainStorageChangeSetBucket].Encode(w.blockNumber, storageChanges, func(k, v []byte) error {
 		if bytes.Equal(k, prevK) {
-			if err := db.(*ethdb.TxDb).AppendDup(dbutils.PlainStorageChangeSetBucket, k, v); err != nil {
+			if err = db.(*ethdb.TxDb).AppendDup(dbutils.PlainStorageChangeSetBucket, k, v); err != nil {
 				return err
 			}
 		} else {
-			if err := db.Append(dbutils.PlainStorageChangeSetBucket, k, v); err != nil {
+			if err = db.Append(dbutils.PlainStorageChangeSetBucket, k, v); err != nil {
 				return err
 			}
 		}

--- a/core/state/plain_state_writer.go
+++ b/core/state/plain_state_writer.go
@@ -1,6 +1,7 @@
 package state
 
 import (
+	"bytes"
 	"context"
 	"encoding/binary"
 
@@ -152,11 +153,23 @@ func (w *PlainStateWriter) WriteChangeSets() error {
 	if err != nil {
 		return err
 	}
+	var prevK []byte
 	if err = changeset.Mapper[dbutils.PlainAccountChangeSetBucket].Encode(w.blockNumber, accountChanges, func(k, v []byte) error {
-		return db.Append(dbutils.PlainAccountChangeSetBucket, k, v)
+		if bytes.Equal(k, prevK) {
+			if err := db.(*ethdb.TxDb).AppendDup(dbutils.PlainAccountChangeSetBucket, k, v); err != nil {
+				return err
+			}
+		} else {
+			if err := db.Append(dbutils.PlainAccountChangeSetBucket, k, v); err != nil {
+				return err
+			}
+		}
+		prevK = k
+		return nil
 	}); err != nil {
 		return err
 	}
+	prevK = nil
 
 	storageChanges, err := w.csw.GetStorageChanges()
 	if err != nil {
@@ -166,7 +179,17 @@ func (w *PlainStateWriter) WriteChangeSets() error {
 		return nil
 	}
 	if err = changeset.Mapper[dbutils.PlainStorageChangeSetBucket].Encode(w.blockNumber, storageChanges, func(k, v []byte) error {
-		return db.Append(dbutils.PlainStorageChangeSetBucket, k, v)
+		if bytes.Equal(k, prevK) {
+			if err := db.(*ethdb.TxDb).AppendDup(dbutils.PlainStorageChangeSetBucket, k, v); err != nil {
+				return err
+			}
+		} else {
+			if err := db.Append(dbutils.PlainStorageChangeSetBucket, k, v); err != nil {
+				return err
+			}
+		}
+		prevK = k
+		return nil
 	}); err != nil {
 		return err
 	}

--- a/core/state/plain_state_writer.go
+++ b/core/state/plain_state_writer.go
@@ -180,7 +180,7 @@ func (w *PlainStateWriter) WriteChangeSets() error {
 	}
 	if err = changeset.Mapper[dbutils.PlainStorageChangeSetBucket].Encode(w.blockNumber, storageChanges, func(k, v []byte) error {
 		if bytes.Equal(k, prevK) {
-			if err = db.(*ethdb.TxDb).AppendDup(dbutils.PlainStorageChangeSetBucket, k, v); err != nil {
+			if err = db.AppendDup(dbutils.PlainStorageChangeSetBucket, k, v); err != nil {
 				return err
 			}
 		} else {

--- a/ethdb/interface.go
+++ b/ethdb/interface.go
@@ -104,6 +104,7 @@ type Database interface {
 	Ancients() (uint64, error)
 	TruncateAncients(items uint64) error
 	Append(bucket string, key, value []byte) error
+	AppendDup(bucket string, key, value []byte) error
 	Sequence(bucket string, amount uint64) (uint64, error)
 }
 

--- a/ethdb/kv_lmdb.go
+++ b/ethdb/kv_lmdb.go
@@ -1317,7 +1317,11 @@ func (c *LmdbCursor) Append(k []byte, v []byte) error {
 	}
 
 	if b.Flags&lmdb.DupSort != 0 {
-		return c.appendDup(k, v)
+		// try with Append|AppendDup flag, if face error (key exists) - try with AppendDup
+		if err := c.c.Put(k, v, lmdb.Append|lmdb.AppendDup); err != nil {
+			return c.appendDup(k, v)
+		}
+		return nil
 	}
 
 	return c.append(k, v)

--- a/ethdb/kv_lmdb.go
+++ b/ethdb/kv_lmdb.go
@@ -1317,11 +1317,7 @@ func (c *LmdbCursor) Append(k []byte, v []byte) error {
 	}
 
 	if b.Flags&lmdb.DupSort != 0 {
-		// try with Append|AppendDup flag, if face error (key exists) - try with AppendDup
-		if err := c.c.Put(k, v, lmdb.Append|lmdb.AppendDup); err != nil {
-			return c.appendDup(k, v)
-		}
-		return nil
+		return c.appendDup(k, v)
 	}
 
 	return c.append(k, v)
@@ -1528,6 +1524,19 @@ func (c *LmdbDupSortCursor) LastDup(k []byte) ([]byte, error) {
 		return nil, fmt.Errorf("in LastDup: %w", err)
 	}
 	return v, nil
+}
+
+func (c *LmdbDupSortCursor) Append(k []byte, v []byte) error {
+	if c.c == nil {
+		if err := c.initCursor(); err != nil {
+			return err
+		}
+	}
+
+	if err := c.c.Put(k, v, lmdb.Append|lmdb.AppendDup); err != nil {
+		return fmt.Errorf("in Append: %w", err)
+	}
+	return nil
 }
 
 func (c *LmdbDupSortCursor) AppendDup(k []byte, v []byte) error {

--- a/ethdb/kv_mdbx.go
+++ b/ethdb/kv_mdbx.go
@@ -1277,11 +1277,7 @@ func (c *MdbxCursor) Append(k []byte, v []byte) error {
 	}
 
 	if b.Flags&mdbx.DupSort != 0 {
-		// try with Append|AppendDup flag, if face error (key exists) - try with AppendDup
-		if err := c.c.Put(k, v, mdbx.Append|mdbx.AppendDup); err != nil {
-			return c.appendDup(k, v)
-		}
-		return nil
+		return c.appendDup(k, v)
 	}
 
 	return c.append(k, v)
@@ -1488,6 +1484,19 @@ func (c *MdbxDupSortCursor) LastDup(k []byte) ([]byte, error) {
 		return nil, fmt.Errorf("in LastDup: %w", err)
 	}
 	return v, nil
+}
+
+func (c *MdbxDupSortCursor) Append(k []byte, v []byte) error {
+	if c.c == nil {
+		if err := c.initCursor(); err != nil {
+			return err
+		}
+	}
+
+	if err := c.c.Put(k, v, mdbx.Append|mdbx.AppendDup); err != nil {
+		return fmt.Errorf("in Append: %w", err)
+	}
+	return nil
 }
 
 func (c *MdbxDupSortCursor) AppendDup(k []byte, v []byte) error {

--- a/ethdb/kv_mdbx.go
+++ b/ethdb/kv_mdbx.go
@@ -1277,7 +1277,11 @@ func (c *MdbxCursor) Append(k []byte, v []byte) error {
 	}
 
 	if b.Flags&mdbx.DupSort != 0 {
-		return c.appendDup(k, v)
+		// try with Append|AppendDup flag, if face error (key exists) - try with AppendDup
+		if err := c.c.Put(k, v, mdbx.Append|mdbx.AppendDup); err != nil {
+			return c.appendDup(k, v)
+		}
+		return nil
 	}
 
 	return c.append(k, v)

--- a/ethdb/mutation.go
+++ b/ethdb/mutation.go
@@ -144,6 +144,10 @@ func (m *mutation) Append(table string, key []byte, value []byte) error {
 	return m.Put(table, key, value)
 }
 
+func (m *mutation) AppendDup(table string, key []byte, value []byte) error {
+	return m.Put(table, key, value)
+}
+
 func (m *mutation) MultiPut(tuples ...[]byte) (uint64, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()

--- a/ethdb/object_db.go
+++ b/ethdb/object_db.go
@@ -108,6 +108,14 @@ func (db *ObjectDatabase) Append(bucket string, key []byte, value []byte) error 
 	return err
 }
 
+// AppendDup appends a single entry to the end of the bucket.
+func (db *ObjectDatabase) AppendDup(bucket string, key []byte, value []byte) error {
+	err := db.kv.Update(context.Background(), func(tx Tx) error {
+		return tx.CursorDupSort(bucket).AppendDup(key, value)
+	})
+	return err
+}
+
 // MultiPut - requirements: input must be sorted and without duplicates
 func (db *ObjectDatabase) MultiPut(tuples ...[]byte) (uint64, error) {
 	err := db.kv.Update(context.Background(), func(tx Tx) error {

--- a/ethdb/tx_db.go
+++ b/ethdb/tx_db.go
@@ -71,12 +71,12 @@ func (m *TxDb) Reserve(bucket string, key []byte, i int) ([]byte, error) {
 
 func (m *TxDb) Append(bucket string, key []byte, value []byte) error {
 	m.len += uint64(len(key) + len(value))
-	switch c := m.cursors[bucket].(type) {
-	case CursorDupSort:
-		return c.AppendDup(key, value)
-	default:
-		return c.Append(key, value)
-	}
+	return m.cursors[bucket].Append(key, value)
+}
+
+func (m *TxDb) AppendDup(bucket string, key []byte, value []byte) error {
+	m.len += uint64(len(key) + len(value))
+	return m.cursors[bucket].(CursorDupSort).AppendDup(key, value)
 }
 
 func (m *TxDb) Delete(bucket string, k, v []byte) error {


### PR DESCRIPTION
Problem 1: only AppendDup used now for dupsort buckets, not Append - as a result pages where keys stored filled not 100%
Problem 2: most of changesets are too small - as a result sub-db's have not much values - page allocated but not filled 100%.
