### PR TITLE
Let users override volume path.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ services:
     build: .
     command: tg --metrics --metrics.addr="0.0.0.0" --metrics.port="6060" --private.api.addr="0.0.0.0:9090" --pprof --pprof.addr="0.0.0.0" --pprof.port="6061"
     volumes:
-      - ${XDG_DATA_HOME:-~/.local/share}/turbogeth:/root/.local/share/turbogeth
+      - ${XDG_DATA_HOME:-~/.local/share/turbogeth}:/root/.local/share/turbogeth
     ports:
       - 30303:30303
 


### PR DESCRIPTION
Let users to give any name to a datadir folder if they want to override volume path.