### PR TITLE
Hashstate graceful shutdown

### DIFF
--- a/eth/stagedsync/stage.go
+++ b/eth/stagedsync/stage.go
@@ -66,8 +66,9 @@ func (s *StageState) ExecutionAt(db ethdb.Getter) (uint64, error) {
 }
 
 // DoneAndUpdate a convenience method combining both `Done()` and `Update()` calls together.
-func (s *StageState) DoneAndUpdate(db ethdb.Putter, newBlockNum uint64) error {
+func (s *StageState) DoneAndUpdate(db ethdb.Putter, newBlockNum uint64, done <-chan struct{}) error {
 	err := stages.SaveStageProgress(db, s.Stage, newBlockNum, nil)
 	s.state.NextStage()
+	done <- struct{}{}
 	return err
 }

--- a/eth/stagedsync/stage_hashstate.go
+++ b/eth/stagedsync/stage_hashstate.go
@@ -16,6 +16,15 @@ import (
 )
 
 func SpawnHashStateStage(s *StageState, db ethdb.Database, tmpdir string, quit <-chan struct{}) error {
+	
+	go func() {
+		// we block until we can read something from the channel and then we reset hash state
+		<-quit
+		if err := ResetHashState(db); err != nil {
+			fmt.Errorf("Unable to reset hashstate %v", err)
+		}
+	}()
+
 	to, err := s.ExecutionAt(db)
 	if err != nil {
 		return err

--- a/eth/stagedsync/stage_hashstate.go
+++ b/eth/stagedsync/stage_hashstate.go
@@ -17,14 +17,6 @@ import (
 
 func SpawnHashStateStage(s *StageState, db ethdb.Database, tmpdir string, quit <-chan struct{}) error {
 	
-	go func() {
-		// we block until we can read something from the channel and then we reset hash state
-		<-quit
-		if err := ResetHashState(db); err != nil {
-			fmt.Errorf("Unable to reset hashstate %v", err)
-		}
-	}()
-
 	to, err := s.ExecutionAt(db)
 	if err != nil {
 		return err
@@ -52,7 +44,17 @@ func SpawnHashStateStage(s *StageState, db ethdb.Database, tmpdir string, quit <
 		}
 	}
 
-	return s.DoneAndUpdate(db, to)
+	for{   
+		//it will block until we get Ctrl+C pressed
+		<-quit 
+		if err := s.DoneAndUpdate(db, to); err != nil {
+			return err
+		}
+		break
+	}
+
+	return nil
+	
 }
 
 func UnwindHashStateStage(u *UnwindState, s *StageState, db ethdb.Database, tmpdir string, quit <-chan struct{}) error {


### PR DESCRIPTION
Closes #1266

Since integration tool and TG main thread will eventually call [https://github.com/ledgerwatch/turbo-geth/blob/master/eth/stagedsync/stage_hashstate.go](https://github.com/ledgerwatch/turbo-geth/blob/master/eth/stagedsync/stage_hashstate.go)  i have decided to implement [go routine](https://github.com/cyberbono3/turbo-geth/blob/hashstate-shutdown/eth/stagedsync/stage_hashstate.go#L20) that will block until user calls [shut down](https://github.com/cyberbono3/turbo-geth/blob/hashstate-shutdown/cmd/utils/cmd.go#L341) ( click CTRL+C) and cancel() in rootContext() is called. As soon it happens,  ctx.Done() is triggered and we can read from quit channel and we call resetHashstate. Does it make sense?

I could not execute `go run -trimpath ./cmd/integration stage_hash_state --chaindata=/home/ai/turbo-chaindata`. I guess , the headers and bodies must be downloaded before I can do it. Right ?

I would appreciate your feedback and some guidance to move forward.

Thanks.

