### PR TITLE
[to discuss] lmdb: move fsync inside commit (to avoid start next write transaction before previous fsync finished)

### DIFF
--- a/cmd/snapshots/seeder/commands/root.go
+++ b/cmd/snapshots/seeder/commands/root.go
@@ -53,7 +53,7 @@ var rootCmd = &cobra.Command{
 	PersistentPostRun: func(cmd *cobra.Command, args []string) {
 		debug.Exit()
 	},
-	Args: cobra.ExactArgs(1),
+	Args:       cobra.ExactArgs(1),
 	ArgAliases: []string{"snapshots dir"},
 	RunE: func(cmd *cobra.Command, args []string) error {
 		return Seed(cmd.Context(), args[0])

--- a/cmd/state/verify/verify_headers_snapshot.go
+++ b/cmd/state/verify/verify_headers_snapshot.go
@@ -15,7 +15,7 @@ import (
 func HeadersSnapshot(snapshotPath string) error {
 	snKV := ethdb.NewLMDB().Path(snapshotPath).Flags(func(flags uint) uint { return flags | lmdb.Readonly }).WithBucketsConfig(func(defaultBuckets dbutils.BucketsCfg) dbutils.BucketsCfg {
 		return dbutils.BucketsCfg{
-			dbutils.HeaderPrefix:       dbutils.BucketConfigItem{},
+			dbutils.HeaderPrefix:              dbutils.BucketConfigItem{},
 			dbutils.HeadersSnapshotInfoBucket: dbutils.BucketConfigItem{},
 		}
 	}).MustOpen()

--- a/ethdb/kv_lmdb.go
+++ b/ethdb/kv_lmdb.go
@@ -45,7 +45,7 @@ type LmdbOpts struct {
 func NewLMDB() LmdbOpts {
 	return LmdbOpts{
 		bucketsCfg: DefaultBucketConfigs,
-		flags:      lmdb.NoReadahead | lmdb.NoSync, // do call .Sync manually after commit to measure speed of commit and speed of fsync individually
+		flags:      lmdb.NoReadahead, // do call .Sync manually after commit to measure speed of commit and speed of fsync individually
 	}
 }
 
@@ -599,16 +599,16 @@ func (tx *lmdbTx) Commit(ctx context.Context) error {
 		log.Info("Batch", "commit", commitTook)
 	}
 
-	if !tx.isSubTx && tx.db.opts.flags&lmdb.Readonly == 0 && !tx.db.opts.inMem { // call fsync only after main transaction commit
-		fsyncTimer := time.Now()
-		if err := tx.db.env.Sync(tx.flags&NoSync == 0); err != nil {
-			log.Warn("fsync after commit failed", "err", err)
-		}
-		fsyncTook := time.Since(fsyncTimer)
-		if fsyncTook > 20*time.Second {
-			log.Info("Batch", "fsync", fsyncTook)
-		}
-	}
+	//if !tx.isSubTx && tx.db.opts.flags&lmdb.Readonly == 0 && !tx.db.opts.inMem { // call fsync only after main transaction commit
+	//	fsyncTimer := time.Now()
+	//	if err := tx.db.env.Sync(tx.flags&NoSync == 0); err != nil {
+	//		log.Warn("fsync after commit failed", "err", err)
+	//	}
+	//	fsyncTook := time.Since(fsyncTimer)
+	//	if fsyncTook > 20*time.Second {
+	//		log.Info("Batch", "fsync", fsyncTook)
+	//	}
+	//}
 	return nil
 }
 


### PR DESCRIPTION
Related to: https://discord.com/channels/687972960811745322/687972960811745326/795267751803355168
```
INFO [01-03|01:48:24.372] Batch                                    fsync=40.169264829s
INFO [01-03|01:48:24.372] Commit cycle                             in=40.245551376s
INFO [01-03|01:48:24.387] Batch                                    commit=35.216617572s
INFO [01-03|01:48:24.408] Batch                                    fsync=39.218927812s
INFO [01-03|01:48:24.706] Batch                                    fsync=35.535533856s
INFO [01-03|01:48:24.706] Batch                                    fsync=35.535767206s
INFO [01-03|01:48:24.706] Batch                                    fsync=36.738516926s
They are all happened within 1 sec. it means: 1 goroutine of Sync cycles and 5 goroutines of downloader are happened and locked at 1 fsync syscall. They happened because commit decoupled from fsync - next write transaction can start after commit of previous transaction finished but before fsync of first transaction finished.
And next write transactions adding time to common fsync syscall :slight_smile: solution is to join back fsync and commit
```

Only downside I see: we can't see how much time took commit and how much time took fsync (mdbx returns for us this info, but lmdb doesn't). 