### PR TITLE
Hashstate graceful shutdown

### DIFF
--- a/eth/stagedsync/stage_hashstate.go
+++ b/eth/stagedsync/stage_hashstate.go
@@ -175,6 +175,7 @@ func NewPromoter(db ethdb.Database, quitCh <-chan struct{}) *Promoter {
 		db:               db,
 		ChangeSetBufSize: 256 * 1024 * 1024,
 		TempDir:          os.TempDir(),
+		quitCh:           quitCh,
 	}
 }
 
@@ -182,7 +183,7 @@ type Promoter struct {
 	db               ethdb.Database
 	ChangeSetBufSize uint64
 	TempDir          string
-	quitCh           chan struct{}
+	quitCh           <-chan struct{}
 }
 
 func getExtractFunc(db ethdb.Getter, changeSetBucket string) etl.ExtractFunc {

--- a/eth/stagedsync/stage_hashstate_test.go
+++ b/eth/stagedsync/stage_hashstate_test.go
@@ -2,11 +2,13 @@ package stagedsync
 
 import (
 	"context"
+	"errors"
 	"io/ioutil"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/ledgerwatch/turbo-geth/common"
 	"github.com/ledgerwatch/turbo-geth/common/dbutils"
 	"github.com/ledgerwatch/turbo-geth/ethdb"
 )
@@ -171,4 +173,112 @@ func TestUnwindHashed(t *testing.T) {
 	}
 
 	compareCurrentState(t, db1, db2, dbutils.CurrentStateBucket)
+}
+
+func TestPromoteIncrementallyShutdown(t *testing.T) {
+
+	tt := []struct {
+		name           string
+		cancelFuncExec bool
+		errExp         error
+	}{
+		{"cancel", true, common.ErrStopped},
+		{"no cancel", false, nil},
+	}
+
+	for _, tc := range tt {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			if tc.cancelFuncExec {
+				cancel()
+			}
+			db := ethdb.NewMemDatabase()
+			defer db.Close()
+
+			generateBlocks(t, 1, 10, plainWriterGen(db), changeCodeWithIncarnations)
+			if err := promoteHashedStateIncrementally("logPrefix", &StageState{BlockNumber: 1}, 1, 10, db, getTmpDir(), ctx.Done()); !errors.Is(err, tc.errExp) {
+				t.Errorf("error does not match expected error while shutdown promoteHashedStateIncrementally, got: %v, expected: %v", err, tc.errExp)
+			}
+		})
+
+	}
+
+}
+
+func TestPromoteHashedStateCleanlyShutdown(t *testing.T) {
+
+	tt := []struct {
+		name           string
+		cancelFuncExec bool
+		errExp         error
+	}{
+		{"cancel", true, common.ErrStopped},
+		{"no cancel", false, nil},
+	}
+
+	for _, tc := range tt {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			ctx, cancel := context.WithCancel(context.Background())
+
+			defer cancel()
+			if tc.cancelFuncExec {
+				cancel()
+			}
+
+			db := ethdb.NewMemDatabase()
+			defer db.Close()
+
+			generateBlocks(t, 1, 10, plainWriterGen(db), changeCodeWithIncarnations)
+
+			if err := PromoteHashedStateCleanly("logPrefix", db, getTmpDir(), ctx.Done()); !errors.Is(err, tc.errExp) {
+				t.Errorf("error does not match expected error while shutdown promoteHashedStateCleanly , got: %v, expected: %v", err, tc.errExp)
+			}
+
+		})
+	}
+}
+
+func TestUnwindHashStateShutdown(t *testing.T) {
+
+	tt := []struct {
+		name           string
+		cancelFuncExec bool
+		errExp         error
+	}{
+		{"cancel", true, common.ErrStopped},
+		{"no cancel", false, nil},
+	}
+
+	for _, tc := range tt {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+
+			if tc.cancelFuncExec {
+				cancel()
+			}
+
+			db := ethdb.NewMemDatabase()
+			defer db.Close()
+
+			generateBlocks(t, 1, 10, plainWriterGen(db), changeCodeWithIncarnations)
+
+			err := PromoteHashedStateCleanly("logPrefix", db, getTmpDir(), nil)
+			require.NoError(t, err)
+
+			u := &UnwindState{UnwindPoint: 5}
+			s := &StageState{BlockNumber: 10}
+			if err = unwindHashStateStageImpl("logPrefix", u, s, db, getTmpDir(), ctx.Done()); !errors.Is(err, tc.errExp) {
+				t.Errorf("error does not match expected error while shutdown unwindHashStateStageImpl, got: %v, expected: %v", err, tc.errExp)
+			}
+
+		})
+	}
+
 }


### PR DESCRIPTION
Closes #1266

Actions:
1.Added quitCh field to NewPromoter to stop HashState stage by pressing CTRL+C.
2. Added tests to test shutdown of promoteHashedStateIncrementally, PromoteHashedStateCleanly and unwindHashStateStageImpl.

