### PR TITLE
mdbx: switch CI to mdbx, fix SeekExact, print slow/big transactions info

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -113,7 +113,7 @@ ethdb/mdbx/dist/mdbx-static.o:
         && CFLAGS_EXTRA="-Wno-deprecated-declarations" make mdbx-static.o
 
 test: ethdb/mdbx/dist/mdbx-static.o
-	TEST_DB=mdbx $(GOTEST)
+	$(GOTEST)
 
 test-lmdb:
 	TEST_DB=lmdb $(GOTEST)

--- a/Makefile
+++ b/Makefile
@@ -113,7 +113,7 @@ ethdb/mdbx/dist/mdbx-static.o:
         && CFLAGS_EXTRA="-Wno-deprecated-declarations" make mdbx-static.o
 
 test: ethdb/mdbx/dist/mdbx-static.o
-	$(GOTEST)
+	TEST_DB=mdbx $(GOTEST)
 
 test-lmdb:
 	TEST_DB=lmdb $(GOTEST)

--- a/common/debug/experiments.go
+++ b/common/debug/experiments.go
@@ -64,6 +64,9 @@ var (
 	getBigRoTx sync.Once
 )
 
+// DEBUG_BIG_RO_TX_KB - print logs with info about large read-only transactions
+// DEBUG_BIG_RW_TX_KB - print logs with info about large read-write transactions
+// DEBUG_SLOW_COMMIT_MS - print logs with commit timing details if commit is slower than this threshold
 func BigRoTxKb() uint {
 	getBigRoTx.Do(func() {
 		v, _ := os.LookupEnv("DEBUG_BIG_RO_TX_KB")

--- a/common/debug/experiments.go
+++ b/common/debug/experiments.go
@@ -2,8 +2,10 @@ package debug
 
 import (
 	"os"
+	"strconv"
 	"sync"
 	"sync/atomic"
+	"time"
 )
 
 // atomic: bit 0 is the value, bit 1 is the initialized flag
@@ -58,16 +60,20 @@ func TestDB() string {
 }
 
 var (
-	debugTxInfo    bool
-	getDebugTxInfo sync.Once
+	printTxInfoIfSlower    time.Duration
+	getPrintTxInfoIfSlower sync.Once
 )
 
-func EnabledTxInfo() bool {
-	getDebugTxInfo.Do(func() {
-		v, _ := os.LookupEnv("DEBUG_TX_INFO")
+func SlowTxMs() time.Duration {
+	getPrintTxInfoIfSlower.Do(func() {
+		v, _ := os.LookupEnv("DEBUG_SLOW_TX_MS")
 		if v != "" {
-			debugTxInfo = true
+			i, err := strconv.Atoi(v)
+			if err != nil {
+				panic(err)
+			}
+			printTxInfoIfSlower = time.Duration(i)
 		}
 	})
-	return debugTxInfo
+	return printTxInfoIfSlower
 }

--- a/common/debug/experiments.go
+++ b/common/debug/experiments.go
@@ -60,20 +60,58 @@ func TestDB() string {
 }
 
 var (
-	printTxInfoIfSlower    time.Duration
-	getPrintTxInfoIfSlower sync.Once
+	bigRoTx    uint
+	getBigRoTx sync.Once
 )
 
-func SlowTxMs() time.Duration {
-	getPrintTxInfoIfSlower.Do(func() {
-		v, _ := os.LookupEnv("DEBUG_SLOW_TX_MS")
+func BigRoTxKb() uint {
+	getBigRoTx.Do(func() {
+		v, _ := os.LookupEnv("DEBUG_BIG_RO_TX_KB")
 		if v != "" {
 			i, err := strconv.Atoi(v)
 			if err != nil {
 				panic(err)
 			}
-			printTxInfoIfSlower = time.Duration(i)
+			bigRoTx = uint(i)
 		}
 	})
-	return printTxInfoIfSlower
+	return bigRoTx
+}
+
+var (
+	bigRwTx    uint
+	getBigRwTx sync.Once
+)
+
+func BigRwTxKb() uint {
+	getBigRwTx.Do(func() {
+		v, _ := os.LookupEnv("DEBUG_BIG_RW_TX_KB")
+		if v != "" {
+			i, err := strconv.Atoi(v)
+			if err != nil {
+				panic(err)
+			}
+			bigRwTx = uint(i)
+		}
+	})
+	return bigRwTx
+}
+
+var (
+	slowCommit    time.Duration
+	getSlowCommit sync.Once
+)
+
+func SlowCommit() time.Duration {
+	getSlowCommit.Do(func() {
+		v, _ := os.LookupEnv("DEBUG_SLOW_COMMIT_MS")
+		if v != "" {
+			i, err := strconv.Atoi(v)
+			if err != nil {
+				panic(err)
+			}
+			slowCommit = time.Duration(i) * time.Millisecond
+		}
+	})
+	return slowCommit
 }

--- a/common/debug/experiments.go
+++ b/common/debug/experiments.go
@@ -56,3 +56,18 @@ func TestDB() string {
 	})
 	return testDB
 }
+
+var (
+	debugTxInfo    bool
+	getDebugTxInfo sync.Once
+)
+
+func EnabledTxInfo() bool {
+	getDebugTxInfo.Do(func() {
+		v, _ := os.LookupEnv("DEBUG_TX_INFO")
+		if v != "" {
+			debugTxInfo = true
+		}
+	})
+	return debugTxInfo
+}

--- a/ethdb/kv_mdbx.go
+++ b/ethdb/kv_mdbx.go
@@ -86,7 +86,7 @@ func (opts MdbxOpts) Open() (KV, error) {
 		return nil, err
 	}
 
-	err = env.SetOption(mdbx.OptRpAugmentLimit, 16*1024*1024)
+	err = env.SetOption(mdbx.OptRpAugmentLimit, 32*1024*1024)
 	if err != nil {
 		return nil, err
 	}

--- a/ethdb/kv_mdbx.go
+++ b/ethdb/kv_mdbx.go
@@ -86,7 +86,7 @@ func (opts MdbxOpts) Open() (KV, error) {
 		return nil, err
 	}
 
-	err = env.SetOption(mdbx.OptRpAugmentLimit, 32*1024*1024)
+	err = env.SetOption(mdbx.OptRpAugmentLimit, 16*1024*1024)
 	if err != nil {
 		return nil, err
 	}

--- a/ethdb/kv_mdbx.go
+++ b/ethdb/kv_mdbx.go
@@ -1266,14 +1266,14 @@ func (c *MdbxCursor) SeekExact(key []byte) ([]byte, []byte, error) {
 		return k, v[from-to:], nil
 	}
 
-	_, v, err := c.set(key)
+	k, v, err := c.set(key)
 	if err != nil {
 		if mdbx.IsNotFound(err) {
 			return nil, nil, nil
 		}
 		return []byte{}, nil, err
 	}
-	return []byte{}, v, nil
+	return k, v, nil
 }
 
 // Append - speedy feature of mdbx which is not part of KV interface.

--- a/ethdb/memory_database.go
+++ b/ethdb/memory_database.go
@@ -27,6 +27,6 @@ func NewMemDatabase() *ObjectDatabase {
 	case "mdbx": //nolint:goconst
 		return NewObjectDatabase(NewMDBX().InMem().MustOpen())
 	default:
-		return NewObjectDatabase(NewLMDB().InMem().MustOpen())
+		return NewObjectDatabase(NewMDBX().InMem().MustOpen())
 	}
 }

--- a/ethdb/object_db.go
+++ b/ethdb/object_db.go
@@ -80,7 +80,7 @@ func Open(path string, readOnly bool) (*ObjectDatabase, error) {
 	case testDB == "mdbx" || strings.HasSuffix(path, "_mdbx"):
 		kv, err = NewMDBX().Path(path).Open()
 	default:
-		opts := NewLMDB().Path(path)
+		opts := NewMDBX().Path(path)
 		if readOnly {
 			opts = opts.Flags(func(flags uint) uint { return flags | lmdb.Readonly })
 		}


### PR DESCRIPTION
```
DEBUG_BIG_RO_TX_KB - print logs with info about large read-only transactions
DEBUG_BIG_RW_TX_KB - print logs with info about large read-write transactions
DEBUG_SLOW_COMMIT_MS - print logs with commit timing details if commit is slower than this threshold 
```