### PR TITLE
Replace rpc notifier struct with event feed

### DIFF
--- a/eth/backend.go
+++ b/eth/backend.go
@@ -364,16 +364,9 @@ func New(stack *node.Node, config *Config) (*Ethereum, error) {
 
 	stagedSync := config.StagedSync
 
-	// setting notifier to support streaming events to rpc daemon
-	remoteEvents := remotedbserver.NewEvents()
+	// if there is not stagedsync, we create one
 	if stagedSync == nil {
-		// if there is not stagedsync, we create one with the custom notifier
-		stagedSync = stagedsync.New(stagedsync.DefaultStages(), stagedsync.DefaultUnwindOrder(), stagedsync.OptionalParameters{Notifier: remoteEvents})
-	} else {
-		// otherwise we add one if needed
-		if stagedSync.Notifier == nil {
-			stagedSync.Notifier = remoteEvents
-		}
+		stagedSync = stagedsync.New(stagedsync.DefaultStages(), stagedsync.DefaultUnwindOrder(), stagedsync.OptionalParameters{})
 	}
 
 	if stack.Config().PrivateApiAddr != "" {
@@ -408,12 +401,12 @@ func New(stack *node.Node, config *Config) (*Ethereum, error) {
 			if err != nil {
 				return nil, err
 			}
-			eth.privateAPI, err = remotedbserver.StartGrpc(chainDb.KV(), eth, stack.Config().PrivateApiAddr, &creds, remoteEvents)
+			eth.privateAPI, err = remotedbserver.StartGrpc(chainDb.KV(), eth, stagedSync, stack.Config().PrivateApiAddr, &creds)
 			if err != nil {
 				return nil, err
 			}
 		} else {
-			eth.privateAPI, err = remotedbserver.StartGrpc(chainDb.KV(), eth, stack.Config().PrivateApiAddr, nil, remoteEvents)
+			eth.privateAPI, err = remotedbserver.StartGrpc(chainDb.KV(), eth, stagedSync, stack.Config().PrivateApiAddr, nil)
 			if err != nil {
 				return nil, err
 			}

--- a/eth/stagedsync/stage_finish.go
+++ b/eth/stagedsync/stage_finish.go
@@ -5,14 +5,10 @@ import (
 
 	"github.com/ledgerwatch/turbo-geth/core/rawdb"
 	"github.com/ledgerwatch/turbo-geth/ethdb"
-	"github.com/ledgerwatch/turbo-geth/log"
+	"github.com/ledgerwatch/turbo-geth/event"
 )
 
-func NotifyRpcDaemon(from, to uint64, notifier ChainEventNotifier, db ethdb.Database) error {
-	if notifier == nil {
-		log.Warn("rpc notifier is not set, rpc daemon won't be updated about headers")
-		return nil
-	}
+func NotifyRpcDaemon(from, to uint64, notifier *event.Feed, db ethdb.Database) error {
 	for i := from; i <= to; i++ {
 		hash, err := rawdb.ReadCanonicalHash(db, i)
 		if err != nil {
@@ -22,7 +18,7 @@ func NotifyRpcDaemon(from, to uint64, notifier ChainEventNotifier, db ethdb.Data
 		if header == nil {
 			return fmt.Errorf("could not find canonical header for hash: %x number: %d", hash, i)
 		}
-		notifier.OnNewHeader(header)
+		notifier.Send(ChainHeadEvent{Header: header})
 	}
 	return nil
 }

--- a/eth/stagedsync/stagebuilder.go
+++ b/eth/stagedsync/stagebuilder.go
@@ -12,13 +12,12 @@ import (
 	"github.com/ledgerwatch/turbo-geth/crypto/secp256k1"
 	"github.com/ledgerwatch/turbo-geth/eth/stagedsync/stages"
 	"github.com/ledgerwatch/turbo-geth/ethdb"
+	"github.com/ledgerwatch/turbo-geth/event"
 	"github.com/ledgerwatch/turbo-geth/log"
 	"github.com/ledgerwatch/turbo-geth/params"
 )
 
-type ChainEventNotifier interface {
-	OnNewHeader(*types.Header)
-}
+type ChainHeadEvent struct{ Header *types.Header }
 
 // StageParameters contains the stage that stages receives at runtime when initializes.
 // Then the stage can use it to receive different useful functions.
@@ -46,7 +45,7 @@ type StageParameters struct {
 	prefetchedBlocks      *PrefetchedBlocks
 	stateReaderBuilder    StateReaderBuilder
 	stateWriterBuilder    StateWriterBuilder
-	notifier              ChainEventNotifier
+	notifier              *event.Feed
 	silkwormExecutionFunc unsafe.Pointer
 }
 

--- a/ethdb/remote/remotedbserver/ethbackend.go
+++ b/ethdb/remote/remotedbserver/ethbackend.go
@@ -8,20 +8,25 @@ import (
 	"github.com/ledgerwatch/turbo-geth/common"
 	"github.com/ledgerwatch/turbo-geth/core"
 	"github.com/ledgerwatch/turbo-geth/core/types"
+	"github.com/ledgerwatch/turbo-geth/eth/stagedsync"
 	"github.com/ledgerwatch/turbo-geth/ethdb/remote"
 	"github.com/ledgerwatch/turbo-geth/log"
 	"github.com/ledgerwatch/turbo-geth/rlp"
 )
 
+const (
+	chainChanSize = 10
+)
+
 type EthBackendServer struct {
 	remote.UnimplementedETHBACKENDServer // must be embedded to have forward compatible implementations.
 
-	eth    core.Backend
-	events *Events
+	eth        core.Backend
+	stagedSync *stagedsync.StagedSync
 }
 
-func NewEthBackendServer(eth core.Backend, events *Events) *EthBackendServer {
-	return &EthBackendServer{eth: eth, events: events}
+func NewEthBackendServer(eth core.Backend, stagedSync *stagedsync.StagedSync) *EthBackendServer {
+	return &EthBackendServer{eth: eth, stagedSync: stagedSync}
 }
 
 func (s *EthBackendServer) Add(_ context.Context, in *remote.TxRequest) (*remote.AddReply, error) {
@@ -64,38 +69,47 @@ func (s *EthBackendServer) Subscribe(r *remote.SubscribeRequest, subscribeServer
 	log.Debug("establishing event subscription channel with the RPC daemon")
 	wg := sync.WaitGroup{}
 	wg.Add(1)
-	s.events.AddHeaderSubscription(func(h *types.Header) error {
-		select {
-		case <-subscribeServer.Context().Done():
-			wg.Done()
-			return subscribeServer.Context().Err()
-		default:
-		}
 
-		payload, err := json.Marshal(h)
-		if err != nil {
-			log.Warn("error while marshaling a header", "err", err)
-			return err
-		}
+	chainCh := make(chan stagedsync.ChainHeadEvent, chainChanSize)
+	s.stagedSync.SubscribeChainHeadEvent(chainCh)
 
-		err = subscribeServer.Send(&remote.SubscribeReply{
-			Type: uint64(EventTypeHeader),
-			Data: payload,
-		})
+	go func() {
+		defer wg.Done()
+		for {
+			select {
+			case <-subscribeServer.Context().Done():
+				return
+			case h := <-chainCh:
+				payload, err := json.Marshal(h.Header)
+				if err != nil {
+					log.Warn("error while marshaling a header", "err", err)
+					return
+				}
 
-		// we only close the wg on error because if we successfully sent an event,
-		// that means that the channel wasn't closed and is ready to
-		// receive more events.
-		// if rpcdaemon disconnects, we will receive an error here
-		// next time we try to send an event
-		if err != nil {
-			log.Info("event subscription channel was closed", "reason", err)
+				err = subscribeServer.Send(&remote.SubscribeReply{
+					Type: uint64(EventTypeHeader),
+					Data: payload,
+				})
+
+				// we only close the wg on error because if we successfully sent an event,
+				// that means that the channel wasn't closed and is ready to
+				// receive more events.
+				// if rpcdaemon disconnects, we will receive an error here
+				// next time we try to send an event
+				if err != nil {
+					log.Info("event subscription channel was closed", "reason", err)
+					return
+				}
+			}
 		}
-		return err
-	})
+	}()
 
 	log.Info("event subscription channel established with the RPC daemon")
 	wg.Wait()
-	log.Info("event subscription channel closed with the RPC daemon")
+	if err := subscribeServer.Context().Err(); err != nil {
+		log.Warn("event subscription channel was closed", "reason", err)
+	} else {
+		log.Info("event subscription channel closed with the RPC daemon")
+	}
 	return nil
 }

--- a/ethdb/remote/remotedbserver/events.go
+++ b/ethdb/remote/remotedbserver/events.go
@@ -1,35 +1,7 @@
 package remotedbserver
 
-import (
-	"github.com/ledgerwatch/turbo-geth/core/types"
-)
-
 type RpcEventType uint64
 
 const (
 	EventTypeHeader = RpcEventType(iota)
 )
-
-type HeaderSubscription func(*types.Header) error
-
-type Events struct {
-	headerSubscription HeaderSubscription
-}
-
-func NewEvents() *Events {
-	return &Events{}
-}
-
-func (e *Events) AddHeaderSubscription(s HeaderSubscription) {
-	e.headerSubscription = s
-}
-
-func (e *Events) OnNewHeader(newHeader *types.Header) {
-	if e.headerSubscription == nil {
-		return
-	}
-	err := e.headerSubscription(newHeader)
-	if err != nil {
-		e.headerSubscription = nil
-	}
-}

--- a/ethdb/remote/remotedbserver/server.go
+++ b/ethdb/remote/remotedbserver/server.go
@@ -12,6 +12,7 @@ import (
 	grpc_prometheus "github.com/grpc-ecosystem/go-grpc-prometheus"
 	"github.com/ledgerwatch/turbo-geth/common"
 	"github.com/ledgerwatch/turbo-geth/core"
+	"github.com/ledgerwatch/turbo-geth/eth/stagedsync"
 	"github.com/ledgerwatch/turbo-geth/ethdb"
 	"github.com/ledgerwatch/turbo-geth/ethdb/remote"
 	"github.com/ledgerwatch/turbo-geth/log"
@@ -29,7 +30,7 @@ type KvServer struct {
 	kv ethdb.KV
 }
 
-func StartGrpc(kv ethdb.KV, eth core.Backend, addr string, creds *credentials.TransportCredentials, events *Events) (*grpc.Server, error) {
+func StartGrpc(kv ethdb.KV, eth core.Backend, stagedSync *stagedsync.StagedSync, addr string, creds *credentials.TransportCredentials) (*grpc.Server, error) {
 	log.Info("Starting private RPC server", "on", addr)
 	lis, err := net.Listen("tcp", addr)
 	if err != nil {
@@ -38,7 +39,7 @@ func StartGrpc(kv ethdb.KV, eth core.Backend, addr string, creds *credentials.Tr
 
 	kv2Srv := NewKvServer(kv)
 	dbSrv := NewDBServer(kv)
-	ethBackendSrv := NewEthBackendServer(eth, events)
+	ethBackendSrv := NewEthBackendServer(eth, stagedSync)
 	var (
 		streamInterceptors []grpc.StreamServerInterceptor
 		unaryInterceptors  []grpc.UnaryServerInterceptor


### PR DESCRIPTION
This change will allow a one to many subscription model for the stagedsync's notifier. While implementing the txpool provider, I realized that it wasn't possible to have both the rpcdaemon and it running at the same time since the struct can only maintain 1 subscriber at a time. This change will allow multiple services to subscribe to new chain head updates.