### PR TITLE
Clean up DB interfaces

### DIFF
--- a/ethdb/interface.go
+++ b/ethdb/interface.go
@@ -138,8 +138,6 @@ type DbWithPendingMutations interface {
 	CommitAndBegin(ctx context.Context) error
 	Rollback()
 	BatchSize() int
-
-	Reserve(bucket string, key []byte, i int) ([]byte, error)
 }
 
 type HasKV interface {

--- a/ethdb/kv_abstract.go
+++ b/ethdb/kv_abstract.go
@@ -113,8 +113,6 @@ type Tx interface {
 	BucketSize(name string) (uint64, error)
 
 	Comparator(bucket string) dbutils.CmpFunc
-	Cmp(bucket string, a, b []byte) int
-	DCmp(bucket string, a, b []byte) int
 
 	// Allows to create a linear sequence of unique positive integers for each table.
 	// Can be called for a read transaction to retrieve the current sequence value, and the increment must be zero.
@@ -165,12 +163,6 @@ type Cursor interface {
 	// Both MDB_NEXT and MDB_GET_CURRENT will return the same record after
 	// this operation.
 	DeleteCurrent() error
-
-	// PutNoOverwrite(key, value []byte) error
-	Reserve(k []byte, n int) ([]byte, error)
-
-	// PutCurrent - replace the item at the current cursor position.
-	PutCurrent(key, value []byte) error
 
 	Count() (uint64, error) // Count - fast way to calculate amount of keys in bucket. It counts all keys even if Prefix was set.
 

--- a/ethdb/kv_lmdb.go
+++ b/ethdb/kv_lmdb.go
@@ -426,16 +426,6 @@ func (tx *lmdbTx) Comparator(bucket string) dbutils.CmpFunc {
 	return chooseComparator(tx.tx, lmdb.DBI(b.DBI), b)
 }
 
-// Cmp - this func follow bytes.Compare return style: The result will be 0 if a==b, -1 if a < b, and +1 if a > b.
-func (tx *lmdbTx) Cmp(bucket string, a, b []byte) int {
-	return tx.tx.Cmp(lmdb.DBI(tx.db.buckets[bucket].DBI), a, b)
-}
-
-// DCmp - this func follow bytes.Compare return style: The result will be 0 if a==b, -1 if a < b, and +1 if a > b.
-func (tx *lmdbTx) DCmp(bucket string, a, b []byte) int {
-	return tx.tx.DCmp(lmdb.DBI(tx.db.buckets[bucket].DBI), a, b)
-}
-
 // All buckets stored as keys of un-named bucket
 func (tx *lmdbTx) ExistingBuckets() ([]string, error) {
 	var res []string
@@ -811,25 +801,24 @@ func (tx *lmdbTx) CHandle() unsafe.Pointer {
 }
 
 // methods here help to see better pprof picture
-func (c *LmdbCursor) set(k []byte) ([]byte, []byte, error)    { return c.c.Get(k, nil, lmdb.Set) }
-func (c *LmdbCursor) getCurrent() ([]byte, []byte, error)     { return c.c.Get(nil, nil, lmdb.GetCurrent) }
-func (c *LmdbCursor) first() ([]byte, []byte, error)          { return c.c.Get(nil, nil, lmdb.First) }
-func (c *LmdbCursor) next() ([]byte, []byte, error)           { return c.c.Get(nil, nil, lmdb.Next) }
-func (c *LmdbCursor) nextDup() ([]byte, []byte, error)        { return c.c.Get(nil, nil, lmdb.NextDup) }
-func (c *LmdbCursor) nextNoDup() ([]byte, []byte, error)      { return c.c.Get(nil, nil, lmdb.NextNoDup) }
-func (c *LmdbCursor) prev() ([]byte, []byte, error)           { return c.c.Get(nil, nil, lmdb.Prev) }
-func (c *LmdbCursor) prevDup() ([]byte, []byte, error)        { return c.c.Get(nil, nil, lmdb.PrevDup) }
-func (c *LmdbCursor) prevNoDup() ([]byte, []byte, error)      { return c.c.Get(nil, nil, lmdb.PrevNoDup) }
-func (c *LmdbCursor) last() ([]byte, []byte, error)           { return c.c.Get(nil, nil, lmdb.Last) }
-func (c *LmdbCursor) delCurrent() error                       { return c.c.Del(lmdb.Current) }
-func (c *LmdbCursor) delNoDupData() error                     { return c.c.Del(lmdb.NoDupData) }
-func (c *LmdbCursor) put(k, v []byte) error                   { return c.c.Put(k, v, 0) }
-func (c *LmdbCursor) putCurrent(k, v []byte) error            { return c.c.Put(k, v, lmdb.Current) }
-func (c *LmdbCursor) putNoOverwrite(k, v []byte) error        { return c.c.Put(k, v, lmdb.NoOverwrite) }
-func (c *LmdbCursor) putNoDupData(k, v []byte) error          { return c.c.Put(k, v, lmdb.NoDupData) }
-func (c *LmdbCursor) append(k, v []byte) error                { return c.c.Put(k, v, lmdb.Append) }
-func (c *LmdbCursor) appendDup(k, v []byte) error             { return c.c.Put(k, v, lmdb.AppendDup) }
-func (c *LmdbCursor) reserve(k []byte, n int) ([]byte, error) { return c.c.PutReserve(k, n, 0) }
+func (c *LmdbCursor) set(k []byte) ([]byte, []byte, error) { return c.c.Get(k, nil, lmdb.Set) }
+func (c *LmdbCursor) getCurrent() ([]byte, []byte, error)  { return c.c.Get(nil, nil, lmdb.GetCurrent) }
+func (c *LmdbCursor) first() ([]byte, []byte, error)       { return c.c.Get(nil, nil, lmdb.First) }
+func (c *LmdbCursor) next() ([]byte, []byte, error)        { return c.c.Get(nil, nil, lmdb.Next) }
+func (c *LmdbCursor) nextDup() ([]byte, []byte, error)     { return c.c.Get(nil, nil, lmdb.NextDup) }
+func (c *LmdbCursor) nextNoDup() ([]byte, []byte, error)   { return c.c.Get(nil, nil, lmdb.NextNoDup) }
+func (c *LmdbCursor) prev() ([]byte, []byte, error)        { return c.c.Get(nil, nil, lmdb.Prev) }
+func (c *LmdbCursor) prevDup() ([]byte, []byte, error)     { return c.c.Get(nil, nil, lmdb.PrevDup) }
+func (c *LmdbCursor) prevNoDup() ([]byte, []byte, error)   { return c.c.Get(nil, nil, lmdb.PrevNoDup) }
+func (c *LmdbCursor) last() ([]byte, []byte, error)        { return c.c.Get(nil, nil, lmdb.Last) }
+func (c *LmdbCursor) delCurrent() error                    { return c.c.Del(lmdb.Current) }
+func (c *LmdbCursor) delNoDupData() error                  { return c.c.Del(lmdb.NoDupData) }
+func (c *LmdbCursor) put(k, v []byte) error                { return c.c.Put(k, v, 0) }
+func (c *LmdbCursor) putCurrent(k, v []byte) error         { return c.c.Put(k, v, lmdb.Current) }
+func (c *LmdbCursor) putNoOverwrite(k, v []byte) error     { return c.c.Put(k, v, lmdb.NoOverwrite) }
+func (c *LmdbCursor) putNoDupData(k, v []byte) error       { return c.c.Put(k, v, lmdb.NoDupData) }
+func (c *LmdbCursor) append(k, v []byte) error             { return c.c.Put(k, v, lmdb.Append) }
+func (c *LmdbCursor) appendDup(k, v []byte) error          { return c.c.Put(k, v, lmdb.AppendDup) }
 func (c *LmdbCursor) getBoth(k, v []byte) ([]byte, []byte, error) {
 	return c.c.Get(k, v, lmdb.GetBoth)
 }
@@ -1149,16 +1138,6 @@ func (c *LmdbCursor) DeleteCurrent() error {
 	return c.delCurrent()
 }
 
-func (c *LmdbCursor) Reserve(k []byte, n int) ([]byte, error) {
-	if c.c == nil {
-		if err := c.initCursor(); err != nil {
-			return nil, err
-		}
-	}
-
-	return c.reserve(k, n)
-}
-
 func (c *LmdbCursor) deleteDupSort(key []byte) error {
 	b := c.bucketCfg
 	from, to := b.DupFromLen, b.DupToLen
@@ -1272,25 +1251,6 @@ func (c *LmdbCursor) putDupSort(key []byte, value []byte) error {
 	return c.put(key, value)
 }
 
-func (c *LmdbCursor) PutCurrent(key []byte, value []byte) error {
-	if len(key) == 0 {
-		return fmt.Errorf("lmdb doesn't support empty keys. bucket: %s", c.bucketName)
-	}
-	if c.c == nil {
-		if err := c.initCursor(); err != nil {
-			return err
-		}
-	}
-
-	b := c.bucketCfg
-	if b.AutoDupSortKeysConversion && len(key) == b.DupFromLen {
-		value = append(key[b.DupToLen:], value...)
-		key = key[:b.DupToLen]
-	}
-
-	return c.putCurrent(key, value)
-}
-
 func (c *LmdbCursor) SeekExact(key []byte) ([]byte, []byte, error) {
 	if c.c == nil {
 		if err := c.initCursor(); err != nil {
@@ -1384,16 +1344,6 @@ func (c *LmdbDupSortCursor) initCursor() error {
 	}
 
 	return c.LmdbCursor.initCursor()
-}
-
-// Warning! this method doesn't check order of keys, it means you can insert key in wrong place of bucket
-//	The key parameter must still be provided, and must match it.
-//	If using sorted duplicates (#MDB_DUPSORT) the data item must still
-//	sort into the same place. This is intended to be used when the
-//	new data is the same size as the old. Otherwise it will simply
-//	perform a delete of the old record followed by an insert.
-func (c *LmdbDupSortCursor) PutCurrent(k, v []byte) error {
-	panic("method is too dangerous, read docs")
 }
 
 // DeleteExact - does delete

--- a/ethdb/kv_mdbx.go
+++ b/ethdb/kv_mdbx.go
@@ -421,16 +421,6 @@ func (tx *MdbxTx) Comparator(bucket string) dbutils.CmpFunc {
 	return chooseComparator2(tx.tx, mdbx.DBI(b.DBI), b)
 }
 
-// Cmp - this func follow bytes.Compare return style: The result will be 0 if a==b, -1 if a < b, and +1 if a > b.
-func (tx *MdbxTx) Cmp(bucket string, a, b []byte) int {
-	return tx.tx.Cmp(mdbx.DBI(tx.db.buckets[bucket].DBI), a, b)
-}
-
-// DCmp - this func follow bytes.Compare return style: The result will be 0 if a==b, -1 if a < b, and +1 if a > b.
-func (tx *MdbxTx) DCmp(bucket string, a, b []byte) int {
-	return tx.tx.DCmp(mdbx.DBI(tx.db.buckets[bucket].DBI), a, b)
-}
-
 // All buckets stored as keys of un-named bucket
 func (tx *MdbxTx) ExistingBuckets() ([]string, error) {
 	var res []string
@@ -860,25 +850,24 @@ func (tx *MdbxTx) CHandle() unsafe.Pointer {
 }
 
 // methods here help to see better pprof picture
-func (c *MdbxCursor) set(k []byte) ([]byte, []byte, error)    { return c.c.Get(k, nil, mdbx.Set) }
-func (c *MdbxCursor) getCurrent() ([]byte, []byte, error)     { return c.c.Get(nil, nil, mdbx.GetCurrent) }
-func (c *MdbxCursor) first() ([]byte, []byte, error)          { return c.c.Get(nil, nil, mdbx.First) }
-func (c *MdbxCursor) next() ([]byte, []byte, error)           { return c.c.Get(nil, nil, mdbx.Next) }
-func (c *MdbxCursor) nextDup() ([]byte, []byte, error)        { return c.c.Get(nil, nil, mdbx.NextDup) }
-func (c *MdbxCursor) nextNoDup() ([]byte, []byte, error)      { return c.c.Get(nil, nil, mdbx.NextNoDup) }
-func (c *MdbxCursor) prev() ([]byte, []byte, error)           { return c.c.Get(nil, nil, mdbx.Prev) }
-func (c *MdbxCursor) prevDup() ([]byte, []byte, error)        { return c.c.Get(nil, nil, mdbx.PrevDup) }
-func (c *MdbxCursor) prevNoDup() ([]byte, []byte, error)      { return c.c.Get(nil, nil, mdbx.PrevNoDup) }
-func (c *MdbxCursor) last() ([]byte, []byte, error)           { return c.c.Get(nil, nil, mdbx.Last) }
-func (c *MdbxCursor) delCurrent() error                       { return c.c.Del(mdbx.Current) }
-func (c *MdbxCursor) delNoDupData() error                     { return c.c.Del(mdbx.NoDupData) }
-func (c *MdbxCursor) put(k, v []byte) error                   { return c.c.Put(k, v, 0) }
-func (c *MdbxCursor) putCurrent(k, v []byte) error            { return c.c.Put(k, v, mdbx.Current) }
-func (c *MdbxCursor) putNoOverwrite(k, v []byte) error        { return c.c.Put(k, v, mdbx.NoOverwrite) }
-func (c *MdbxCursor) putNoDupData(k, v []byte) error          { return c.c.Put(k, v, mdbx.NoDupData) }
-func (c *MdbxCursor) append(k, v []byte) error                { return c.c.Put(k, v, mdbx.Append) }
-func (c *MdbxCursor) appendDup(k, v []byte) error             { return c.c.Put(k, v, mdbx.AppendDup) }
-func (c *MdbxCursor) reserve(k []byte, n int) ([]byte, error) { return c.c.PutReserve(k, n, 0) }
+func (c *MdbxCursor) set(k []byte) ([]byte, []byte, error) { return c.c.Get(k, nil, mdbx.Set) }
+func (c *MdbxCursor) getCurrent() ([]byte, []byte, error)  { return c.c.Get(nil, nil, mdbx.GetCurrent) }
+func (c *MdbxCursor) first() ([]byte, []byte, error)       { return c.c.Get(nil, nil, mdbx.First) }
+func (c *MdbxCursor) next() ([]byte, []byte, error)        { return c.c.Get(nil, nil, mdbx.Next) }
+func (c *MdbxCursor) nextDup() ([]byte, []byte, error)     { return c.c.Get(nil, nil, mdbx.NextDup) }
+func (c *MdbxCursor) nextNoDup() ([]byte, []byte, error)   { return c.c.Get(nil, nil, mdbx.NextNoDup) }
+func (c *MdbxCursor) prev() ([]byte, []byte, error)        { return c.c.Get(nil, nil, mdbx.Prev) }
+func (c *MdbxCursor) prevDup() ([]byte, []byte, error)     { return c.c.Get(nil, nil, mdbx.PrevDup) }
+func (c *MdbxCursor) prevNoDup() ([]byte, []byte, error)   { return c.c.Get(nil, nil, mdbx.PrevNoDup) }
+func (c *MdbxCursor) last() ([]byte, []byte, error)        { return c.c.Get(nil, nil, mdbx.Last) }
+func (c *MdbxCursor) delCurrent() error                    { return c.c.Del(mdbx.Current) }
+func (c *MdbxCursor) delNoDupData() error                  { return c.c.Del(mdbx.NoDupData) }
+func (c *MdbxCursor) put(k, v []byte) error                { return c.c.Put(k, v, 0) }
+func (c *MdbxCursor) putCurrent(k, v []byte) error         { return c.c.Put(k, v, mdbx.Current) }
+func (c *MdbxCursor) putNoOverwrite(k, v []byte) error     { return c.c.Put(k, v, mdbx.NoOverwrite) }
+func (c *MdbxCursor) putNoDupData(k, v []byte) error       { return c.c.Put(k, v, mdbx.NoDupData) }
+func (c *MdbxCursor) append(k, v []byte) error             { return c.c.Put(k, v, mdbx.Append) }
+func (c *MdbxCursor) appendDup(k, v []byte) error          { return c.c.Put(k, v, mdbx.AppendDup) }
 func (c *MdbxCursor) getBoth(k, v []byte) ([]byte, error) {
 	_, v, err := c.c.Get(k, v, mdbx.GetBoth)
 	return v, err
@@ -1199,16 +1188,6 @@ func (c *MdbxCursor) DeleteCurrent() error {
 	return c.delCurrent()
 }
 
-func (c *MdbxCursor) Reserve(k []byte, n int) ([]byte, error) {
-	if c.c == nil {
-		if err := c.initCursor(); err != nil {
-			return nil, err
-		}
-	}
-
-	return c.reserve(k, n)
-}
-
 func (c *MdbxCursor) deleteDupSort(key []byte) error {
 	b := c.bucketCfg
 	from, to := b.DupFromLen, b.DupToLen
@@ -1322,25 +1301,6 @@ func (c *MdbxCursor) putDupSort(key []byte, value []byte) error {
 	return c.put(key, value)
 }
 
-func (c *MdbxCursor) PutCurrent(key []byte, value []byte) error {
-	if len(key) == 0 {
-		return fmt.Errorf("mdbx doesn't support empty keys. bucket: %s", c.bucketName)
-	}
-	if c.c == nil {
-		if err := c.initCursor(); err != nil {
-			return err
-		}
-	}
-
-	b := c.bucketCfg
-	if b.AutoDupSortKeysConversion && len(key) == b.DupFromLen {
-		value = append(key[b.DupToLen:], value...)
-		key = key[:b.DupToLen]
-	}
-
-	return c.putCurrent(key, value)
-}
-
 func (c *MdbxCursor) SeekExact(key []byte) ([]byte, []byte, error) {
 	if c.c == nil {
 		if err := c.initCursor(); err != nil {
@@ -1444,16 +1404,6 @@ func (c *MdbxDupSortCursor) initCursor() error {
 	}
 
 	return c.MdbxCursor.initCursor()
-}
-
-// Warning! this method doesn't check order of keys, it means you can insert key in wrong place of bucket
-//	The key parameter must still be provided, and must match it.
-//	If using sorted duplicates (#MDB_DUPSORT) the data item must still
-//	sort into the same place. This is intended to be used when the
-//	new data is the same size as the old. Otherwise it will simply
-//	perform a delete of the old record followed by an insert.
-func (c *MdbxDupSortCursor) PutCurrent(k, v []byte) error {
-	panic("method is too dangerous, read docs")
 }
 
 // DeleteExact - does delete

--- a/ethdb/kv_remote.go
+++ b/ethdb/kv_remote.go
@@ -228,8 +228,6 @@ func (db *RemoteKV) Update(ctx context.Context, f func(tx Tx) error) (err error)
 }
 
 func (tx *remoteTx) Comparator(bucket string) dbutils.CmpFunc { panic("not implemented yet") }
-func (tx *remoteTx) Cmp(bucket string, a, b []byte) int       { panic("not implemented yet") }
-func (tx *remoteTx) DCmp(bucket string, a, b []byte) int      { panic("not implemented yet") }
 func (tx *remoteTx) CHandle() unsafe.Pointer                  { panic("not implemented yet") }
 
 func (tx *remoteTx) Sequence(bucket string, amount uint64) (uint64, error) {
@@ -319,12 +317,10 @@ func (c *remoteCursor) initCursor() error {
 
 func (c *remoteCursor) Put(key []byte, value []byte) error            { panic("not supported") }
 func (c *remoteCursor) PutNoOverwrite(key []byte, value []byte) error { panic("not supported") }
-func (c *remoteCursor) PutCurrent(key, value []byte) error            { panic("not supported") }
 func (c *remoteCursor) Append(key []byte, value []byte) error         { panic("not supported") }
 func (c *remoteCursor) Delete(k, v []byte) error                      { panic("not supported") }
 func (c *remoteCursor) DeleteCurrent() error                          { panic("not supported") }
 func (c *remoteCursor) Count() (uint64, error)                        { panic("not supported") }
-func (c *remoteCursor) Reserve(k []byte, n int) ([]byte, error)       { panic("not supported") }
 
 func (c *remoteCursor) first() ([]byte, []byte, error) {
 	if err := c.stream.Send(&remote.Cursor{Cursor: c.id, Op: remote.Op_FIRST}); err != nil {

--- a/ethdb/kv_snapshot.go
+++ b/ethdb/kv_snapshot.go
@@ -272,14 +272,6 @@ func (s *sn2TX) Comparator(bucket string) dbutils.CmpFunc {
 	return s.dbTX.Comparator(bucket)
 }
 
-func (s *sn2TX) Cmp(bucket string, a, b []byte) int {
-	panic("implement me")
-}
-
-func (s *sn2TX) DCmp(bucket string, a, b []byte) int {
-	panic("implement me")
-}
-
 func (s *sn2TX) Sequence(bucket string, amount uint64) (uint64, error) {
 	panic("implement me")
 }
@@ -523,14 +515,6 @@ func (s *snCursor2) DeleteCurrent() error {
 	panic("implement me")
 }
 
-func (s *snCursor2) Reserve(k []byte, n int) ([]byte, error) {
-	panic("implement me")
-}
-
-func (s *snCursor2) PutCurrent(key, value []byte) error {
-	panic("implement me")
-}
-
 func (s *snCursor2) Count() (uint64, error) {
 	panic("implement me")
 }
@@ -699,14 +683,6 @@ func GenStateData(data []KvData) (KV, error) {
 //}
 //
 //func (c *cursorSnapshotDupsort) DeleteCurrent() error {
-//	panic("implement me")
-//}
-//
-//func (c *cursorSnapshotDupsort) Reserve(k []byte, n int) ([]byte, error) {
-//	panic("implement me")
-//}
-//
-//func (c *cursorSnapshotDupsort) PutCurrent(key, value []byte) error {
 //	panic("implement me")
 //}
 //

--- a/ethdb/mutation.go
+++ b/ethdb/mutation.go
@@ -107,10 +107,6 @@ func (m *mutation) Last(table string) ([]byte, []byte, error) {
 	return m.db.Last(table)
 }
 
-func (m *mutation) Reserve(table string, key []byte, i int) ([]byte, error) {
-	return m.db.(DbWithPendingMutations).Reserve(table, key, i)
-}
-
 func (m *mutation) hasMem(table string, key []byte) bool {
 	m.mu.RLock()
 	defer m.mu.RUnlock()

--- a/ethdb/object_db.go
+++ b/ethdb/object_db.go
@@ -368,10 +368,6 @@ func (db *ObjectDatabase) TruncateAncients(items uint64) error {
 	return errNotSupported
 }
 
-func (db *ObjectDatabase) Reserve(bucket string, key []byte, i int) ([]byte, error) {
-	panic("supported only by TxDb")
-}
-
 // Type which expecting sequence of triplets: dbi, key, value, ....
 // It sorts entries by dbi name, then inside dbi clusters sort by keys
 type MultiPutTuples [][]byte

--- a/ethdb/tx_db.go
+++ b/ethdb/tx_db.go
@@ -66,11 +66,6 @@ func (m *TxDb) Put(bucket string, key []byte, value []byte) error {
 	return m.cursor(bucket).Put(key, value)
 }
 
-func (m *TxDb) Reserve(bucket string, key []byte, i int) ([]byte, error) {
-	m.len += uint64(len(key) + i)
-	return m.cursor(bucket).Reserve(key, i)
-}
-
 func (m *TxDb) Append(bucket string, key []byte, value []byte) error {
 	m.len += uint64(len(key) + len(value))
 	return m.cursor(bucket).Append(key, value)


### PR DESCRIPTION
This PR prunes KV and other DB interfaces, removing forgotten, superseded and simply unused code. Besides TG itself this is important for porters, as it allows concentrating attention on rewriting code that counts.