### PR TITLE
Mining: remove local pow mining (from ethash), --miner.notify is required now, cycle is non-blocking now

### DIFF
--- a/cmd/integration/commands/state_stages.go
+++ b/cmd/integration/commands/state_stages.go
@@ -302,7 +302,7 @@ func syncBySmallSteps(db ethdb.Database, miningConfig *params.MiningConfig, ctx 
 			panic(err)
 		}
 
-		if miningConfig.Enabled && nextBlock.Header().Coinbase != (common.Address{}) {
+		if miningConfig.Enabled && nextBlock != nil && nextBlock.Header().Coinbase != (common.Address{}) {
 			miningWorld := stagedsync.NewMiningStagesParameters(miningConfig, true, miningTransactions(nextBlock), nil)
 
 			miningConfig.Etherbase = nextBlock.Header().Coinbase

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -349,11 +349,6 @@ var (
 		Name:  "mine",
 		Usage: "Enable mining",
 	}
-	MinerThreadsFlag = cli.IntFlag{
-		Name:  "miner.threads",
-		Usage: "Number of CPU threads to use for mining",
-		Value: 0,
-	}
 	MinerNotifyFlag = cli.StringFlag{
 		Name:  "miner.notify",
 		Usage: "Comma separated HTTP URL list to notify of new work packages",
@@ -1049,6 +1044,9 @@ func SetupMinerCobra(cmd *cobra.Command, cfg *params.MiningConfig) {
 	if err != nil {
 		panic(err)
 	}
+	if cfg.Enabled && len(cfg.Notify) == 0 {
+		panic(fmt.Sprintf("TurboGeth supports only remote miners. Flag --%s is required", MinerNotifyFlag.Name))
+	}
 	extraDataStr, err := flags.GetString(MinerExtraDataFlag.Name)
 	if err != nil {
 		panic(err)
@@ -1096,6 +1094,9 @@ func setMiner(ctx *cli.Context, cfg *params.MiningConfig) {
 	}
 	if ctx.GlobalIsSet(MinerNotifyFlag.Name) {
 		cfg.Notify = strings.Split(ctx.GlobalString(MinerNotifyFlag.Name), ",")
+	}
+	if cfg.Enabled && len(cfg.Notify) == 0 {
+		panic(fmt.Sprintf("TurboGeth supports only remote miners. Flag --%s is required", MinerNotifyFlag.Name))
 	}
 	if ctx.GlobalIsSet(MinerExtraDataFlag.Name) {
 		cfg.ExtraData = []byte(ctx.GlobalString(MinerExtraDataFlag.Name))

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -1084,7 +1084,7 @@ func SetupMinerCobra(cmd *cobra.Command, cfg *params.MiningConfig) {
 	}
 
 	// Convert the etherbase into an address and configure it
-	if etherbase != "" {
+	if etherbase == "" {
 		Fatalf("No etherbase configured")
 	}
 	cfg.Etherbase = common.HexToAddress(etherbase)

--- a/common/debugprint/receipts.go
+++ b/common/debugprint/receipts.go
@@ -71,7 +71,7 @@ func Receipts(rs1, rs2 types.Receipts) {
 			fmt.Printf("  Logs[%d].Topic:   %x, %x\n", j, l1.Topics, l2.Topics)
 			fmt.Printf("  Logs[%d].Data:    %x, %x\n", j, l1.Data, l2.Data)
 		}
-		fmt.Printf(" Bloom: %x, %x\n", r1.Bloom, r1.Bloom)
+		//fmt.Printf(" Bloom: %x, %x\n", r1.Bloom, r1.Bloom)
 	}
 }
 

--- a/consensus/clique/clique.go
+++ b/consensus/clique/clique.go
@@ -33,6 +33,7 @@ import (
 	"github.com/ledgerwatch/turbo-geth/consensus/misc"
 	"github.com/ledgerwatch/turbo-geth/core/state"
 	"github.com/ledgerwatch/turbo-geth/core/types"
+	"github.com/ledgerwatch/turbo-geth/core/types/accounts"
 	"github.com/ledgerwatch/turbo-geth/crypto"
 	"github.com/ledgerwatch/turbo-geth/ethdb"
 	"github.com/ledgerwatch/turbo-geth/log"
@@ -137,7 +138,7 @@ var (
 )
 
 // SignerFn hashes and signs the data to be signed by a backing account.
-type SignerFn func(signer common.Address, message []byte) ([]byte, error)
+type SignerFn func(signer common.Address, mimeType string, message []byte) ([]byte, error)
 
 // ecrecover extracts the Ethereum account address from a signed header.
 func ecrecover(header *types.Header, sigcache *lru.ARCCache) (common.Address, error) {
@@ -577,7 +578,7 @@ func (c *Clique) Authorize(signer common.Address, signFn SignerFn) {
 
 // Seal implements consensus.Engine, attempting to create a sealed block using
 // the local signing credentials.
-func (c *Clique) Seal(ctx consensus.Cancel, chain consensus.ChainHeaderReader, block *types.Block, results chan<- consensus.ResultWithContext, stop <-chan struct{}) error {
+func (c *Clique) Seal(chain consensus.ChainHeaderReader, block *types.Block, results chan<- *types.Block, stop <-chan struct{}) error {
 	header := block.Header()
 
 	// Sealing the genesis block is not supported
@@ -623,7 +624,7 @@ func (c *Clique) Seal(ctx consensus.Cancel, chain consensus.ChainHeaderReader, b
 		log.Trace("Out-of-turn signing requested", "wiggle", common.PrettyDuration(wiggle))
 	}
 	// Sign all the things!
-	sighash, err := signFn(signer, CliqueRLP(header))
+	sighash, err := signFn(signer, accounts.MimetypeClique, CliqueRLP(header))
 	if err != nil {
 		return err
 	}
@@ -638,7 +639,7 @@ func (c *Clique) Seal(ctx consensus.Cancel, chain consensus.ChainHeaderReader, b
 		}
 
 		select {
-		case results <- consensus.ResultWithContext{Cancel: ctx, Block: block.WithSeal(header)}:
+		case results <- block.WithSeal(header):
 		default:
 			log.Warn("Sealing result is not read by miner", "sealhash", SealHash(header))
 		}

--- a/consensus/consensus.go
+++ b/consensus/consensus.go
@@ -101,7 +101,7 @@ type Engine interface {
 	//
 	// Note, the method returns immediately and will send the result async. More
 	// than one result may also be returned depending on the consensus algorithm.
-	Seal(ctx Cancel, chain ChainHeaderReader, block *types.Block, results chan<- ResultWithContext, stop <-chan struct{}) error
+	Seal(chain ChainHeaderReader, block *types.Block, results chan<- *types.Block, stop <-chan struct{}) error
 
 	// SealHash returns the hash of a block prior to it being sealed.
 	SealHash(header *types.Header) common.Hash

--- a/consensus/ethash/consensus.go
+++ b/consensus/ethash/consensus.go
@@ -27,8 +27,6 @@ import (
 
 	mapset "github.com/deckarep/golang-set"
 	"github.com/holiman/uint256"
-	"golang.org/x/crypto/sha3"
-
 	"github.com/ledgerwatch/turbo-geth/common"
 	"github.com/ledgerwatch/turbo-geth/common/math"
 	"github.com/ledgerwatch/turbo-geth/common/u256"
@@ -38,6 +36,7 @@ import (
 	"github.com/ledgerwatch/turbo-geth/core/types"
 	"github.com/ledgerwatch/turbo-geth/params"
 	"github.com/ledgerwatch/turbo-geth/rlp"
+	"golang.org/x/crypto/sha3"
 )
 
 // Ethash proof-of-work protocol constants.

--- a/consensus/ethash/ethash.go
+++ b/consensus/ethash/ethash.go
@@ -461,6 +461,7 @@ func New(config Config, notify []string, noverify bool) *Ethash {
 		update:   make(chan struct{}),
 		hashrate: metrics.NewMeterForced(),
 	}
+
 	ethash.remote = startRemoteSealer(ethash, notify, noverify)
 	return ethash
 }

--- a/consensus/ethash/ethash.go
+++ b/consensus/ethash/ethash.go
@@ -34,13 +34,11 @@ import (
 	"unsafe"
 
 	"github.com/edsrzf/mmap-go"
-
+	"github.com/hashicorp/golang-lru/simplelru"
 	"github.com/ledgerwatch/turbo-geth/consensus"
 	"github.com/ledgerwatch/turbo-geth/log"
 	"github.com/ledgerwatch/turbo-geth/metrics"
 	"github.com/ledgerwatch/turbo-geth/rpc"
-
-	"github.com/hashicorp/golang-lru/simplelru"
 )
 
 const doNotStoreCachesOnDisk = ""
@@ -52,7 +50,7 @@ var (
 	two256 = new(big.Int).Exp(big.NewInt(2), big.NewInt(256), big.NewInt(0))
 
 	// sharedEthash is a full instance that can be shared between multiple users.
-	sharedEthash = New(Config{3, false, "", 1, 0, false, ModeNormal, nil}, nil, false)
+	sharedEthash *Ethash
 
 	// algorithmRevision is the data structure version used for file naming.
 	algorithmRevision = 23
@@ -60,6 +58,15 @@ var (
 	// dumpMagic is a dataset dump header to sanity check a data dump.
 	dumpMagic = []uint32{0xbaddcafe, 0xfee1dead}
 )
+
+func init() {
+	sharedConfig := Config{
+		PowMode:       ModeNormal,
+		CachesInMem:   3,
+		DatasetsInMem: 1,
+	}
+	sharedEthash = New(sharedConfig, nil, false)
+}
 
 // isLittleEndian returns whether the local system is running in little or big
 // endian byte order.
@@ -413,6 +420,10 @@ type Config struct {
 	DatasetsLockMmap bool
 	PowMode          Mode
 
+	// When set, notifications sent by the remote sealer will
+	// be block header JSON objects instead of work package arrays.
+	NotifyFull bool
+
 	Log log.Logger `toml:"-"`
 }
 
@@ -461,7 +472,9 @@ func New(config Config, notify []string, noverify bool) *Ethash {
 		update:   make(chan struct{}),
 		hashrate: metrics.NewMeterForced(),
 	}
-
+	if config.PowMode == ModeShared {
+		ethash.shared = sharedEthash
+	}
 	ethash.remote = startRemoteSealer(ethash, notify, noverify)
 	return ethash
 }
@@ -469,15 +482,7 @@ func New(config Config, notify []string, noverify bool) *Ethash {
 // NewTester creates a small sized ethash PoW scheme useful only for testing
 // purposes.
 func NewTester(notify []string, noverify bool) *Ethash {
-	ethash := &Ethash{
-		config:   Config{PowMode: ModeTest, Log: log.Root()},
-		caches:   newlru("cache", 1, newCache),
-		datasets: newlru("dataset", 1, newDataset),
-		update:   make(chan struct{}),
-		hashrate: metrics.NewMeterForced(),
-	}
-	ethash.remote = startRemoteSealer(ethash, notify, noverify)
-	return ethash
+	return New(Config{PowMode: ModeTest}, notify, noverify)
 }
 
 // NewFaker creates a ethash consensus engine with a fake PoW scheme that accepts
@@ -537,7 +542,6 @@ func NewShared() *Ethash {
 
 // Close closes the exit channel to notify all backend threads exiting.
 func (ethash *Ethash) Close() error {
-	var err error
 	ethash.closeOnce.Do(func() {
 		// Short circuit if the exit channel is not allocated.
 		if ethash.remote == nil {
@@ -546,7 +550,7 @@ func (ethash *Ethash) Close() error {
 		close(ethash.remote.requestExit)
 		<-ethash.remote.exitCh
 	})
-	return err
+	return nil
 }
 
 // cache tries to retrieve a verification cache for the specified block number

--- a/consensus/ethash/sealer_test.go
+++ b/consensus/ethash/sealer_test.go
@@ -22,12 +22,14 @@ import (
 	"math/big"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
 	"testing"
 	"time"
 
 	"github.com/ledgerwatch/turbo-geth/common"
-	"github.com/ledgerwatch/turbo-geth/consensus"
 	"github.com/ledgerwatch/turbo-geth/core/types"
+	"github.com/ledgerwatch/turbo-geth/internal/testlog"
+	"github.com/ledgerwatch/turbo-geth/log"
 )
 
 // Tests whether remote HTTP servers are correctly notified of new work.
@@ -55,7 +57,9 @@ func TestRemoteNotify(t *testing.T) {
 	header := &types.Header{Number: big.NewInt(1), Difficulty: big.NewInt(100)}
 	block := types.NewBlockWithHeader(header)
 
-	_ = ethash.Seal(consensus.NewCancel(), nil, block, nil, nil)
+	if err := ethash.Seal(nil, block, nil, nil); err != nil {
+		t.Fatal(err)
+	}
 	select {
 	case work := <-sink:
 		if want := ethash.SealHash(header).Hex(); work[0] != want {
@@ -73,10 +77,55 @@ func TestRemoteNotify(t *testing.T) {
 	}
 }
 
+// Tests whether remote HTTP servers are correctly notified of new work. (Full pending block body / --miner.notify.full)
+func TestRemoteNotifyFull(t *testing.T) {
+	// Start a simple web server to capture notifications.
+	sink := make(chan map[string]interface{})
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		blob, err := ioutil.ReadAll(req.Body)
+		if err != nil {
+			t.Errorf("failed to read miner notification: %v", err)
+		}
+		var work map[string]interface{}
+		if err := json.Unmarshal(blob, &work); err != nil {
+			t.Errorf("failed to unmarshal miner notification: %v", err)
+		}
+		sink <- work
+	}))
+	defer server.Close()
+
+	// Create the custom ethash engine.
+	config := Config{
+		PowMode:    ModeTest,
+		NotifyFull: true,
+		Log:        testlog.Logger(t, log.LvlWarn),
+	}
+	ethash := New(config, []string{server.URL}, false)
+	defer ethash.Close()
+
+	// Stream a work task and ensure the notification bubbles out.
+	header := &types.Header{Number: big.NewInt(1), Difficulty: big.NewInt(100)}
+	block := types.NewBlockWithHeader(header)
+
+	if err := ethash.Seal(nil, block, nil, nil); err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case work := <-sink:
+		if want := "0x" + strconv.FormatUint(header.Number.Uint64(), 16); work["number"] != want {
+			t.Errorf("pending block number mismatch: have %v, want %v", work["number"], want)
+		}
+		if want := "0x" + header.Difficulty.Text(16); work["difficulty"] != want {
+			t.Errorf("pending block difficulty mismatch: have %s, want %s", work["difficulty"], want)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatalf("notification timed out")
+	}
+}
+
 // Tests that pushing work packages fast to the miner doesn't cause any data race
 // issues in the notifications.
 func TestRemoteMultiNotify(t *testing.T) {
-	t.Skip("Often fails spuriously, needs to be investiaged")
 	// Start a simple web server to capture notifications.
 	sink := make(chan [3]string, 64)
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
@@ -94,18 +143,74 @@ func TestRemoteMultiNotify(t *testing.T) {
 
 	// Create the custom ethash engine.
 	ethash := NewTester([]string{server.URL}, false)
+	ethash.config.Log = testlog.Logger(t, log.LvlWarn)
 	defer ethash.Close()
 
 	// Provide a results reader.
 	// Otherwise the unread results will be logged asynchronously
 	// and this can happen after the test is finished, causing a panic.
-	results := make(chan consensus.ResultWithContext, cap(sink))
+	results := make(chan *types.Block, cap(sink))
 
 	// Stream a lot of work task and ensure all the notifications bubble out.
 	for i := 0; i < cap(sink); i++ {
 		header := &types.Header{Number: big.NewInt(int64(i)), Difficulty: big.NewInt(100)}
 		block := types.NewBlockWithHeader(header)
-		_ = ethash.Seal(consensus.NewCancel(), nil, block, results, nil)
+		err := ethash.Seal(nil, block, results, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	for i := 0; i < cap(sink); i++ {
+		select {
+		case <-sink:
+			<-results
+		case <-time.After(10 * time.Second):
+			t.Fatalf("notification %d timed out", i)
+		}
+	}
+}
+
+// Tests that pushing work packages fast to the miner doesn't cause any data race
+// issues in the notifications. Full pending block body / --miner.notify.full)
+func TestRemoteMultiNotifyFull(t *testing.T) {
+	// Start a simple web server to capture notifications.
+	sink := make(chan map[string]interface{}, 64)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		blob, err := ioutil.ReadAll(req.Body)
+		if err != nil {
+			t.Errorf("failed to read miner notification: %v", err)
+		}
+		var work map[string]interface{}
+		if err := json.Unmarshal(blob, &work); err != nil {
+			t.Errorf("failed to unmarshal miner notification: %v", err)
+		}
+		sink <- work
+	}))
+	defer server.Close()
+
+	// Create the custom ethash engine.
+	config := Config{
+		PowMode:    ModeTest,
+		NotifyFull: true,
+		Log:        testlog.Logger(t, log.LvlWarn),
+	}
+	ethash := New(config, []string{server.URL}, false)
+	defer ethash.Close()
+
+	// Provide a results reader.
+	// Otherwise the unread results will be logged asynchronously
+	// and this can happen after the test is finished, causing a panic.
+	results := make(chan *types.Block, cap(sink))
+
+	// Stream a lot of work task and ensure all the notifications bubble out.
+	for i := 0; i < cap(sink); i++ {
+		header := &types.Header{Number: big.NewInt(int64(i)), Difficulty: big.NewInt(100)}
+		block := types.NewBlockWithHeader(header)
+		err := ethash.Seal(nil, block, results, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
 	}
 
 	for i := 0; i < cap(sink); i++ {
@@ -167,11 +272,14 @@ func TestStaleSubmission(t *testing.T) {
 			false,
 		},
 	}
-	results := make(chan consensus.ResultWithContext, 16)
+	results := make(chan *types.Block, 16)
 
 	for id, c := range testcases {
 		for _, h := range c.headers {
-			_ = ethash.Seal(consensus.NewCancel(), nil, types.NewBlockWithHeader(h), results, nil)
+			err := ethash.Seal(nil, types.NewBlockWithHeader(h), results, nil)
+			if err != nil {
+				t.Fatal(err)
+			}
 		}
 		if res := api.SubmitWork(fakeNonce, ethash.SealHash(c.headers[c.submitIndex]), fakeDigest); res != c.submitRes {
 			t.Errorf("case %d submit result mismatch, want %t, get %t", id+1, c.submitRes, res)

--- a/consensus/ethash/sealer_test.go
+++ b/consensus/ethash/sealer_test.go
@@ -126,6 +126,8 @@ func TestRemoteNotifyFull(t *testing.T) {
 // Tests that pushing work packages fast to the miner doesn't cause any data race
 // issues in the notifications.
 func TestRemoteMultiNotify(t *testing.T) {
+	t.Skip("Often fails spuriously, needs to be investiaged")
+
 	// Start a simple web server to capture notifications.
 	sink := make(chan [3]string, 64)
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {

--- a/consensus/ethash/sealer_test.go
+++ b/consensus/ethash/sealer_test.go
@@ -176,6 +176,7 @@ func TestRemoteMultiNotify(t *testing.T) {
 // Tests that pushing work packages fast to the miner doesn't cause any data race
 // issues in the notifications. Full pending block body / --miner.notify.full)
 func TestRemoteMultiNotifyFull(t *testing.T) {
+	t.Skip("Often fails spuriously, needs to be investiaged")
 	// Start a simple web server to capture notifications.
 	sink := make(chan map[string]interface{}, 64)
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -1937,6 +1937,7 @@ func ExecuteBlockEphemerally(
 			vmConfig.Tracer = vm.NewStructLogger(&vm.LogConfig{})
 			writeTrace = true
 		}
+
 		receipt, err := ApplyTransaction(chainConfig, chainContext, nil, gp, ibs, noop, header, tx, usedGas, *vmConfig)
 		if writeTrace {
 			w, err1 := os.Create(fmt.Sprintf("txtrace_%x.txt", tx.Hash()))

--- a/core/rawdb/accessors_chain.go
+++ b/core/rawdb/accessors_chain.go
@@ -619,6 +619,7 @@ func WriteReceipts(tx DatabaseWriter, number uint64, receipts types.Receipts) er
 func AppendReceipts(tx ethdb.Database, blockNumber uint64, receipts types.Receipts) error {
 	buf := bytes.NewBuffer(make([]byte, 0, 1024))
 	for txId, r := range receipts {
+		//fmt.Printf("1: %d,%x\n", txId, r.TxHash)
 		if len(r.Logs) == 0 {
 			continue
 		}

--- a/core/tx_pool.go
+++ b/core/tx_pool.go
@@ -507,15 +507,15 @@ func (pool *TxPool) Content() (map[common.Address]types.Transactions, map[common
 // Pending retrieves all currently processable transactions, grouped by origin
 // account and sorted by nonce. The returned transaction set is a copy and can be
 // freely modified by calling code.
-func (pool *TxPool) Pending() (map[common.Address]types.Transactions, error) {
-	pending := make(map[common.Address]types.Transactions)
+func (pool *TxPool) Pending() (types.TransactionsGroupedBySender, error) {
+	var pending types.TransactionsGroupedBySender
 	if !pool.IsStarted() {
 		return pending, nil
 	}
-	pool.mu.Lock()
 	defer pool.mu.Unlock()
-	for addr, list := range pool.pending {
-		pending[addr] = list.Flatten()
+	pending = make(types.TransactionsGroupedBySender, len(pool.pending))
+	for _, list := range pool.pending {
+		pending = append(pending, list.Flatten())
 	}
 	return pending, nil
 }

--- a/core/tx_pool.go
+++ b/core/tx_pool.go
@@ -512,6 +512,7 @@ func (pool *TxPool) Pending() (types.TransactionsGroupedBySender, error) {
 	if !pool.IsStarted() {
 		return pending, nil
 	}
+	pool.mu.Lock()
 	defer pool.mu.Unlock()
 	pending = make(types.TransactionsGroupedBySender, len(pool.pending))
 	for _, list := range pool.pending {

--- a/core/types/accounts/account.go
+++ b/core/types/accounts/account.go
@@ -24,6 +24,13 @@ type Account struct {
 	Incarnation uint64
 }
 
+const (
+	MimetypeDataWithValidator = "data/validator"
+	MimetypeTypedData         = "data/typed"
+	MimetypeClique            = "application/x-clique-header"
+	MimetypeTextPlain         = "text/plain"
+)
+
 var emptyCodeHash = crypto.Keccak256Hash(nil)
 var emptyRoot = common.HexToHash("56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421")
 

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -697,7 +697,7 @@ func (s *Ethereum) StartMining(threads int) error {
 				return fmt.Errorf("signer missing: %v", err)
 			}
 
-			clique.Authorize(eb, func(_ common.Address, message []byte) ([]byte, error) {
+			clique.Authorize(eb, func(_ common.Address, mimeType string, message []byte) ([]byte, error) {
 				return crypto.Sign(message, s.signer)
 			})
 		}

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -51,7 +51,6 @@ import (
 	"github.com/ledgerwatch/turbo-geth/eth/downloader"
 	"github.com/ledgerwatch/turbo-geth/eth/ethconfig"
 	"github.com/ledgerwatch/turbo-geth/eth/ethutils"
-	"github.com/ledgerwatch/turbo-geth/eth/filters"
 	"github.com/ledgerwatch/turbo-geth/eth/gasprice"
 	"github.com/ledgerwatch/turbo-geth/eth/protocols/eth"
 	"github.com/ledgerwatch/turbo-geth/eth/stagedsync"
@@ -559,24 +558,24 @@ func (s *Ethereum) APIs() []rpc.API {
 		//	Service:   NewPublicMinerAPI(s),
 		//	Public:    true,
 		//},
-		{
-			Namespace: "eth",
-			Version:   "1.0",
-			Service:   downloader.NewPublicDownloaderAPI(s.handler.downloader, s.eventMux),
-			Public:    true,
-		},
+		//{
+		//	Namespace: "eth",
+		//	Version:   "1.0",
+		//	Service:   downloader.NewPublicDownloaderAPI(s.handler.downloader, s.eventMux),
+		//	Public:    true,
+		//},
 		//{
 		//	Namespace: "miner",
 		//	Version:   "1.0",
 		//	Service:   NewPrivateMinerAPI(s),
 		//	Public:    false,
 		//},
-		{
-			Namespace: "eth",
-			Version:   "1.0",
-			Service:   filters.NewPublicFilterAPI(s.APIBackend, 5*time.Minute),
-			Public:    true,
-		},
+		//{
+		//	Namespace: "eth",
+		//	Version:   "1.0",
+		//	Service:   filters.NewPublicFilterAPI(s.APIBackend, 5*time.Minute),
+		//	Public:    true,
+		//},
 		//{
 		//	Namespace: "admin",
 		//	Version:   "1.0",

--- a/eth/downloader/downloader.go
+++ b/eth/downloader/downloader.go
@@ -641,8 +641,8 @@ func (d *Downloader) syncWithPeer(p *peerConnection, hash common.Hash, blockNumb
 			return fmt.Errorf("failed to fetch pending transactions: %w", err)
 		}
 
-		miningResultCh := make(chan consensus.ResultWithContext, 1)
-		consensusCtx := consensus.NewCancel()
+		miningResultCh := make(chan *types.Block, 1)
+		sealCancel := make(chan struct{})
 
 		if d.miningState, err = d.mining.Prepare(
 			d,
@@ -661,7 +661,7 @@ func (d *Downloader) syncWithPeer(p *peerConnection, hash common.Hash, blockNumb
 			txPool,
 			poolStart,
 			false,
-			stagedsync.NewMiningStagesParameters(d.miningConfig, true, pending, txPool.Locals(), miningResultCh, consensusCtx),
+			stagedsync.NewMiningStagesParameters(d.miningConfig, true, pending, txPool.Locals(), miningResultCh, sealCancel),
 		); err != nil {
 			return err
 		}

--- a/eth/downloader/downloader.go
+++ b/eth/downloader/downloader.go
@@ -669,7 +669,9 @@ func (d *Downloader) syncWithPeer(p *peerConnection, hash common.Hash, blockNumb
 			return err
 		}
 		tx.Rollback()
-		_ = <-miningResultCh
+
+		// TODO: send mined block to sentry
+		<-miningResultCh
 		return nil
 	}
 

--- a/eth/handler.go
+++ b/eth/handler.go
@@ -69,7 +69,7 @@ type txPool interface {
 
 	// Pending should return pending transactions.
 	// The slice should be modifiable by the caller.
-	Pending() (map[common.Address]types.Transactions, error)
+	Pending() (types.TransactionsGroupedBySender, error)
 
 	// SubscribeNewTxsEvent should return an event subscription of
 	// NewTxsEvent and send events to the given channel.

--- a/eth/handler_test.go
+++ b/eth/handler_test.go
@@ -91,7 +91,7 @@ func (p *testTxPool) AddRemotes(txs []*types.Transaction) []error {
 }
 
 // Pending returns all the transactions known to the pool
-func (p *testTxPool) Pending() (map[common.Address]types.Transactions, error) {
+func (p *testTxPool) Pending() (types.TransactionsGroupedBySender, error) {
 	p.lock.RLock()
 	defer p.lock.RUnlock()
 
@@ -100,10 +100,12 @@ func (p *testTxPool) Pending() (map[common.Address]types.Transactions, error) {
 		from, _ := types.Sender(types.HomesteadSigner{}, tx)
 		batches[from] = append(batches[from], tx)
 	}
+	groups := types.TransactionsGroupedBySender{}
 	for _, batch := range batches {
 		sort.Sort(types.TxByNonce(batch))
+		groups = append(groups, batch)
 	}
-	return batches, nil
+	return groups, nil
 }
 
 // SubscribeNewTxsEvent should return an event subscription of NewTxsEvent and

--- a/eth/stagedsync/stage_mining_create_block.go
+++ b/eth/stagedsync/stage_mining_create_block.go
@@ -214,6 +214,9 @@ func SpawnMiningCreateBlockStage(s *StageState, tx ethdb.Database, current *mini
 	// Split the pending transactions into locals and remotes
 	localTxs, remoteTxs := types.TransactionsGroupedBySender{}, types.TransactionsGroupedBySender{}
 	for _, txs := range pendingTxs {
+		if len(txs) == 0 {
+			continue
+		}
 		from, _ := types.Sender(signer, txs[0])
 		isLocal := false
 		for _, local := range txPoolLocals {

--- a/eth/stagedsync/stage_mining_create_block.go
+++ b/eth/stagedsync/stage_mining_create_block.go
@@ -27,14 +27,14 @@ type miningBlock struct {
 	Txs      []*types.Transaction
 	Receipts types.Receipts
 
-	localTxs  *types.TransactionsByPriceAndNonce
-	remoteTxs *types.TransactionsByPriceAndNonce
+	LocalTxs  types.TransactionsStream
+	RemoteTxs types.TransactionsStream
 }
 
 // SpawnMiningCreateBlockStage
 //TODO:
 // - resubmitAdjustCh - variable is not implemented
-func SpawnMiningCreateBlockStage(s *StageState, tx ethdb.Database, current *miningBlock, chainConfig *params.ChainConfig, engine consensus.Engine, extra hexutil.Bytes, gasFloor, gasCeil uint64, coinbase common.Address, txPoolLocals []common.Address, pendingTxs map[common.Address]types.Transactions, quit <-chan struct{}) error {
+func SpawnMiningCreateBlockStage(s *StageState, tx ethdb.Database, current *miningBlock, chainConfig *params.ChainConfig, engine consensus.Engine, extra hexutil.Bytes, gasFloor, gasCeil uint64, coinbase common.Address, txPoolLocals []common.Address, pendingTxs types.TransactionsGroupedBySender, quit <-chan struct{}) error {
 
 	const (
 		// staleThreshold is the maximum depth of the acceptable stale block.
@@ -212,15 +212,26 @@ func SpawnMiningCreateBlockStage(s *StageState, tx ethdb.Database, current *mini
 	current.Uncles = makeUncles(env.uncles)
 
 	// Split the pending transactions into locals and remotes
-	localTxs, remoteTxs := make(map[common.Address]types.Transactions), pendingTxs
-	for _, account := range txPoolLocals {
-		if txs := remoteTxs[account]; len(txs) > 0 {
-			delete(remoteTxs, account)
-			localTxs[account] = txs
+	localTxs, remoteTxs := types.TransactionsGroupedBySender{}, types.TransactionsGroupedBySender{}
+	for _, txs := range pendingTxs {
+		from, _ := types.Sender(signer, txs[0])
+		isLocal := false
+		for _, local := range txPoolLocals {
+			if local == from {
+				isLocal = true
+				break
+			}
+		}
+
+		if isLocal {
+			localTxs = append(localTxs, txs)
+		} else {
+			remoteTxs = append(remoteTxs, txs)
 		}
 	}
-	current.localTxs = types.NewTransactionsByPriceAndNonce(signer, localTxs)
-	current.remoteTxs = types.NewTransactionsByPriceAndNonce(signer, remoteTxs)
+
+	current.LocalTxs = types.NewTransactionsByPriceAndNonce(signer, localTxs)
+	current.RemoteTxs = types.NewTransactionsByPriceAndNonce(signer, remoteTxs)
 	s.Done()
 	return nil
 }

--- a/eth/stagedsync/stage_mining_exec.go
+++ b/eth/stagedsync/stage_mining_exec.go
@@ -18,7 +18,7 @@ import (
 // SpawnMiningExecStage
 //TODO:
 // - resubmitAdjustCh - variable is not implemented
-func SpawnMiningExecStage(s *StageState, tx ethdb.Database, current *miningBlock, chainConfig *params.ChainConfig, vmConfig *vm.Config, cc *core.TinyChainContext, localTxs, remoteTxs *types.TransactionsByPriceAndNonce, coinbase common.Address, noempty bool, notifier ChainEventNotifier, quit <-chan struct{}) error {
+func SpawnMiningExecStage(s *StageState, tx ethdb.Database, current *miningBlock, chainConfig *params.ChainConfig, vmConfig *vm.Config, cc *core.TinyChainContext, localTxs, remoteTxs types.TransactionsStream, coinbase common.Address, noempty bool, notifier ChainEventNotifier, quit <-chan struct{}) error {
 	vmConfig.NoReceipts = false
 	logPrefix := s.state.LogPrefix()
 
@@ -107,7 +107,7 @@ func SpawnMiningExecStage(s *StageState, tx ethdb.Database, current *miningBlock
 	return nil
 }
 
-func addTransactionsToMiningBlock(current *miningBlock, chainConfig *params.ChainConfig, vmConfig *vm.Config, cc *core.TinyChainContext, txs *types.TransactionsByPriceAndNonce, coinbase common.Address, ibs *state.IntraBlockState, stateWriter state.StateWriter, quit <-chan struct{}) (types.Logs, error) {
+func addTransactionsToMiningBlock(current *miningBlock, chainConfig *params.ChainConfig, vmConfig *vm.Config, cc *core.TinyChainContext, txs types.TransactionsStream, coinbase common.Address, ibs *state.IntraBlockState, stateWriter state.StateWriter, quit <-chan struct{}) (types.Logs, error) {
 	header := current.Header
 	tcount := 0
 	gasPool := new(core.GasPool).AddGas(current.Header.GasLimit)
@@ -123,6 +123,7 @@ func addTransactionsToMiningBlock(current *miningBlock, chainConfig *params.Chai
 			ibs.RevertToSnapshot(snap)
 			return nil, err
 		}
+
 		//if !chainConfig.IsByzantium(header.Number) {
 		//	batch.Rollback()
 		//}

--- a/eth/stagedsync/stage_mining_finish.go
+++ b/eth/stagedsync/stage_mining_finish.go
@@ -1,9 +1,6 @@
 package stagedsync
 
 import (
-	"fmt"
-
-	"github.com/ledgerwatch/turbo-geth/common"
 	"github.com/ledgerwatch/turbo-geth/consensus"
 	"github.com/ledgerwatch/turbo-geth/core/types"
 	"github.com/ledgerwatch/turbo-geth/ethdb"
@@ -13,8 +10,8 @@ import (
 
 //var prev common.Hash
 
-func SpawnMiningFinishStage(s *StageState, tx ethdb.Database, current *miningBlock, engine consensus.Engine, chainConfig *params.ChainConfig, quit <-chan struct{}) (*types.Block, error) {
-	logPrefix := s.state.LogPrefix()
+func SpawnMiningFinishStage(s *StageState, tx ethdb.Database, current *miningBlock, engine consensus.Engine, chainConfig *params.ChainConfig, resultCh chan consensus.ResultWithContext, consensusCtx consensus.Cancel, quit <-chan struct{}) error {
+	//logPrefix := s.state.LogPrefix()
 
 	// Short circuit when receiving duplicate result caused by resubmitting.
 	//if w.chain.HasBlock(block.Hash(), block.NumberU64()) {
@@ -22,6 +19,7 @@ func SpawnMiningFinishStage(s *StageState, tx ethdb.Database, current *miningBlo
 	//}
 
 	block := types.NewBlock(current.Header, current.Txs, current.Uncles, current.Receipts)
+	*current = miningBlock{} // hack to clean global data
 
 	//sealHash := engine.SealHash(block.Header())
 	// Reject duplicate sealing work due to resubmitting.
@@ -33,35 +31,29 @@ func SpawnMiningFinishStage(s *StageState, tx ethdb.Database, current *miningBlo
 
 	// Tests may set pre-calculated nonce
 	if block.Header().Nonce.Uint64() != 0 {
+		resultCh <- consensus.ResultWithContext{Cancel: consensusCtx, Block: block}
 		s.Done()
-		*current = miningBlock{} // hack to clean global data
-		return block, nil
+		return nil
 	}
 
 	chain := ChainReader{chainConfig, tx}
-	ctx := consensus.NewCancel()
-	resultCh := make(chan consensus.ResultWithContext, 1)
-	if err := engine.Seal(ctx, chain, block, resultCh, ctx.Done()); err != nil {
+	if err := engine.Seal(consensusCtx, chain, block, resultCh, consensusCtx.Done()); err != nil {
 		log.Warn("Block sealing failed", "err", err)
 	}
 
-	select {
-	case <-ctx.Done():
-		return nil, ctx.Err()
-	case <-quit:
-		ctx.CancelFunc()
-		return nil, common.ErrStopped
-	case result := <-resultCh:
-		block = result.Block
-	}
-
-	log.Info(fmt.Sprintf("[%s] mined block", logPrefix), "txs", block.Transactions().Len())
-	// Broadcast the block and announce chain insertion event
-	//if err := mux.Post(core.NewMinedBlockEvent{Block: block}); err != nil {
-	//	return err
+	//select {
+	//case <-ctx.Done():
+	//	return ctx.Err()
+	//case <-quit:
+	//	ctx.CancelFunc()
+	//	return common.ErrStopped
+	//case result := <-resultCh:
+	//	block = result.Block
 	//}
+	//
+	//log.Info(fmt.Sprintf("[%s] mined block", logPrefix), "txs", block.Transactions().Len())
+	//result <- *block
 
 	s.Done()
-	*current = miningBlock{} // hack to clean global data
-	return block, nil
+	return nil
 }

--- a/eth/stagedsync/stagebuilder.go
+++ b/eth/stagedsync/stagebuilder.go
@@ -66,14 +66,14 @@ type MiningStagesParameters struct {
 	// in this case this feature will add all empty blocks into canonical chain
 	// non-stop and no real transaction will be included.
 	noempty      bool
-	PendingTxs   map[common.Address]types.Transactions
+	PendingTxs   types.TransactionsGroupedBySender
 	TxPoolLocals []common.Address
 
 	// runtime dat
 	Block *miningBlock
 }
 
-func NewMiningStagesParameters(cfg *params.MiningConfig, noempty bool, pendingTxs map[common.Address]types.Transactions, txPoolLocals []common.Address) *MiningStagesParameters {
+func NewMiningStagesParameters(cfg *params.MiningConfig, noempty bool, pendingTxs types.TransactionsGroupedBySender, txPoolLocals []common.Address) *MiningStagesParameters {
 	return &MiningStagesParameters{MiningConfig: cfg, noempty: noempty, PendingTxs: pendingTxs, TxPoolLocals: txPoolLocals, Block: &miningBlock{}}
 
 }
@@ -440,8 +440,8 @@ func MiningStages() StageBuilders {
 							world.ChainConfig,
 							world.vmConfig,
 							world.chainContext,
-							world.mining.Block.localTxs,
-							world.mining.Block.remoteTxs,
+							world.mining.Block.LocalTxs,
+							world.mining.Block.RemoteTxs,
 							world.mining.Etherbase,
 							world.mining.noempty,
 							world.notifier,

--- a/eth/sync.go
+++ b/eth/sync.go
@@ -51,7 +51,6 @@ func (h *handler) syncTransactions(p *eth.Peer) {
 	// the transactions if the sorting is not cached yet. However, with a random
 	// order, insertions could overflow the non-executable queues and get dropped.
 	//
-	// TODO(karalabe): Figure out if we could get away with random order somehow
 	var txs types.Transactions
 	pending, _ := h.txpool.Pending()
 	for _, batch := range pending {

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -36,8 +36,6 @@ import (
 	"github.com/ledgerwatch/turbo-geth/core"
 	"github.com/ledgerwatch/turbo-geth/core/state"
 	"github.com/ledgerwatch/turbo-geth/core/types"
-	"github.com/ledgerwatch/turbo-geth/core/vm"
-	"github.com/ledgerwatch/turbo-geth/eth/stagedsync"
 	"github.com/ledgerwatch/turbo-geth/event"
 	"github.com/ledgerwatch/turbo-geth/log"
 	"github.com/ledgerwatch/turbo-geth/params"
@@ -608,74 +606,15 @@ func (w *worker) taskLoop() {
 				continue
 			}
 
-			resultCh := make(chan consensus.ResultWithContext, 1)
-			if err := w.engine.Seal(task.ctx, w.chain, task.block, resultCh, task.ctx.Done()); err != nil {
+			resultCh := make(chan *types.Block, 1)
+			if err := w.engine.Seal(w.chain, task.block, resultCh, task.ctx.Done()); err != nil {
 				log.Warn("Block sealing failed", "err", err)
 			}
 
-			w.insertToChain(<-resultCh, task.createdAt, sealHash, task, false)
 		case <-w.exitCh:
 			return
 		}
 	}
-}
-
-func (w *worker) insertToChain(result consensus.ResultWithContext, createdAt time.Time, sealHash common.Hash, task *task, directInsert bool) {
-	// Short circuit when receiving empty result.
-	if result.Block == nil {
-		return
-	}
-	block := result.Block
-
-	// Short circuit when receiving duplicate result caused by resubmitting.
-	if w.chain.HasBlock(block.Hash(), block.NumberU64()) {
-		log.Warn("Duplicate result caused by resubmitting", "number", block.NumberU64(), "hash", block.Hash().String())
-		return
-	}
-
-	// Different block could share same sealhash, deep copy here to prevent write-write conflict.
-	if directInsert {
-		var (
-			receipts = make([]*types.Receipt, len(task.receipts))
-			logs     = make([]*types.Log, len(task.receipts))
-		)
-		hash := block.Hash()
-
-		for i, receipt := range task.receipts {
-			// add block location fields
-			receipt.BlockHash = hash
-			receipt.BlockNumber = block.Number()
-			receipt.TransactionIndex = uint(i)
-
-			receipts[i] = new(types.Receipt)
-			*receipts[i] = *receipt
-
-			// Update the block hash in all logs since it is now available and not when the
-			// receipt/log of individual transactions were created.
-			for _, log := range receipt.Logs {
-				log.BlockHash = hash
-			}
-			logs = append(logs, receipt.Logs...)
-		}
-
-		// Commit block and state to database.
-		_, err := w.chain.WriteBlockWithState(result.Cancel, block, receipts, logs, task.state, task.tds, true)
-		if err != nil {
-			log.Error("Failed writing block with state", "err", err)
-			return
-		}
-
-		log.Info("Successfully sealed new block", "number", block.Number(), "sealhash", sealHash, "hash", block.Hash(),
-			"elapsed", common.PrettyDuration(time.Since(createdAt)), "difficulty", block.Difficulty())
-	} else {
-		if _, err := stagedsync.InsertBlockInStages(w.chain.ChainDb(), w.chain.Config(), &vm.Config{}, w.chain.Engine(), block, true /* checkRoot */); err != nil {
-			log.Error("Failed writing block to chain", "err", err)
-			return
-		}
-	}
-
-	// Broadcast the block and announce chain insertion event
-	_ = w.mux.Post(core.NewMinedBlockEvent{Block: block})
 }
 
 // makeCurrent creates a new environment for the current cycle.

--- a/miner/worker_test.go
+++ b/miner/worker_test.go
@@ -126,7 +126,7 @@ func newTestWorkerBackend(t *testing.T, chainConfig *params.ChainConfig, engine 
 	case *clique.Clique:
 		gspec.ExtraData = make([]byte, 32+common.AddressLength+crypto.SignatureLength)
 		copy(gspec.ExtraData[32:32+common.AddressLength], testBankAddress.Bytes())
-		e.Authorize(testBankAddress, func(account common.Address, data []byte) ([]byte, error) {
+		e.Authorize(testBankAddress, func(account common.Address, mimeType string, data []byte) ([]byte, error) {
 			return crypto.Sign(crypto.Keccak256(data), testBankKey)
 		})
 	case *ethash.Ethash:

--- a/turbo/adapter/chain_context.go
+++ b/turbo/adapter/chain_context.go
@@ -49,7 +49,8 @@ func (c *powEngine) FinalizeAndAssemble(chainConfig *params.ChainConfig, header 
 	uncles []*types.Header, receipts []*types.Receipt) (*types.Block, error) {
 	panic("must not be called")
 }
-func (c *powEngine) Seal(_ consensus.Cancel, chain consensus.ChainHeaderReader, block *types.Block, results chan<- consensus.ResultWithContext, stop <-chan struct{}) error {
+
+func (c *powEngine) Seal(chain consensus.ChainHeaderReader, block *types.Block, results chan<- *types.Block, stop <-chan struct{}) error {
 	panic("must not be called")
 }
 func (c *powEngine) SealHash(header *types.Header) common.Hash {


### PR DESCRIPTION
Rational: 
- TurboGeth is moving towards splitting monolith to components (services). Mining is not part of db-service responsibility. 
- TurboGeth will only prepare blocks: choosing txs from txPool, calculate new state root, add uncles. Then just send work to remote miners.

Details:
- mining loop doesn't wait for remote miners anymore. it accepts `resultCh` and `consesusCtx` as incoming params. then prepare block, send it to consensus engine, that's it.
- Another component (probably new downloader) will need goroutine to manage this: receive result, forward it to sentry, or cancel remote miners work. 
