### PR TITLE
All stages - finish fast if current progress > target

### DIFF
--- a/eth/stagedsync/stage_finish.go
+++ b/eth/stagedsync/stage_finish.go
@@ -14,7 +14,7 @@ func FinishForward(s *StageState, db ethdb.Database, notifier ChainEventNotifier
 	if executionAt, err = s.ExecutionAt(db); err != nil {
 		return err
 	}
-	if executionAt == s.BlockNumber {
+	if executionAt <= s.BlockNumber {
 		s.Done()
 		return nil
 	}

--- a/eth/stagedsync/stage_finish.go
+++ b/eth/stagedsync/stage_finish.go
@@ -14,6 +14,11 @@ func FinishForward(s *StageState, db ethdb.Database, notifier ChainEventNotifier
 	if executionAt, err = s.ExecutionAt(db); err != nil {
 		return err
 	}
+	if executionAt == s.BlockNumber {
+		s.Done()
+		return nil
+	}
+
 	logPrefix := s.state.LogPrefix()
 	log.Info(fmt.Sprintf("[%s] Update current block for the RPC API", logPrefix), "to", executionAt)
 

--- a/eth/stagedsync/stage_indexes.go
+++ b/eth/stagedsync/stage_indexes.go
@@ -55,7 +55,7 @@ func SpawnAccountHistoryIndex(s *StageState, db ethdb.Database, cfg HistoryCfg, 
 	if err != nil {
 		return fmt.Errorf("%s: getting last executed block: %w", logPrefix, err)
 	}
-	if executionAt == s.BlockNumber {
+	if executionAt <= s.BlockNumber {
 		s.Done()
 		return nil
 	}
@@ -102,7 +102,7 @@ func SpawnStorageHistoryIndex(s *StageState, db ethdb.Database, cfg HistoryCfg, 
 	if err != nil {
 		return fmt.Errorf("%s: logs index: getting last executed block: %w", logPrefix, err)
 	}
-	if executionAt == s.BlockNumber {
+	if executionAt <= s.BlockNumber {
 		s.Done()
 		return nil
 	}

--- a/eth/stagedsync/stage_txpool.go
+++ b/eth/stagedsync/stage_txpool.go
@@ -42,6 +42,11 @@ func SpawnTxPool(s *StageState, db ethdb.Database, cfg TxPoolCfg, quitCh <-chan 
 	if err != nil {
 		return err
 	}
+	if to == s.BlockNumber {
+		s.Done()
+		return nil
+	}
+
 	logPrefix := s.state.LogPrefix()
 	if to < s.BlockNumber {
 		return fmt.Errorf("%s: to (%d) < from (%d)", logPrefix, to, s.BlockNumber)

--- a/eth/stagedsync/stagebuilder.go
+++ b/eth/stagedsync/stagebuilder.go
@@ -349,6 +349,10 @@ func DefaultStages() StageBuilders {
 						if executionAt, err = s.ExecutionAt(world.DB); err != nil {
 							return err
 						}
+						if executionAt == s.BlockNumber {
+							s.Done()
+							return nil
+						}
 						logPrefix := s.state.LogPrefix()
 						log.Info(fmt.Sprintf("[%s] Update current block for the RPC API", logPrefix), "to", executionAt)
 

--- a/eth/stagedsync/stagebuilder.go
+++ b/eth/stagedsync/stagebuilder.go
@@ -12,7 +12,6 @@ import (
 	"github.com/ledgerwatch/turbo-geth/core/vm"
 	"github.com/ledgerwatch/turbo-geth/eth/stagedsync/stages"
 	"github.com/ledgerwatch/turbo-geth/ethdb"
-	"github.com/ledgerwatch/turbo-geth/log"
 	"github.com/ledgerwatch/turbo-geth/params"
 	"github.com/ledgerwatch/turbo-geth/turbo/stages/bodydownload"
 )
@@ -344,32 +343,10 @@ func DefaultStages() StageBuilders {
 					ID:          stages.Finish,
 					Description: "Final: update current block for the RPC API",
 					ExecFunc: func(s *StageState, _ Unwinder) error {
-						var executionAt uint64
-						var err error
-						if executionAt, err = s.ExecutionAt(world.DB); err != nil {
-							return err
-						}
-						if executionAt == s.BlockNumber {
-							s.Done()
-							return nil
-						}
-						logPrefix := s.state.LogPrefix()
-						log.Info(fmt.Sprintf("[%s] Update current block for the RPC API", logPrefix), "to", executionAt)
-
-						err = NotifyNewHeaders(s.BlockNumber+1, executionAt, world.notifier, world.DB)
-						if err != nil {
-							return err
-						}
-
-						return s.DoneAndUpdate(world.DB, executionAt)
+						return FinishForward(s, world.DB, world.notifier)
 					},
 					UnwindFunc: func(u *UnwindState, s *StageState) error {
-						var executionAt uint64
-						var err error
-						if executionAt, err = s.ExecutionAt(world.DB); err != nil {
-							return err
-						}
-						return s.DoneAndUpdate(world.DB, executionAt)
+						return UnwindFinish(u, s, world.DB)
 					},
 				}
 			},

--- a/eth/stagedsync/state.go
+++ b/eth/stagedsync/state.go
@@ -174,6 +174,7 @@ func (s *State) Run(db ethdb.GetterPutter, tx ethdb.GetterPutter) error {
 				}
 				timings = append(timings, "Unwind "+string(unwind.Stage), time.Since(t))
 			}
+			fmt.Printf("Run set: %s\n", s.stages[0].ID)
 			if err := s.SetCurrentStage(s.stages[0].ID); err != nil {
 				return err
 			}

--- a/eth/stagedsync/state.go
+++ b/eth/stagedsync/state.go
@@ -150,8 +150,11 @@ func (s *State) StageState(stage stages.SyncStage, db ethdb.KVGetter) (*StageSta
 func (s *State) Run(db ethdb.GetterPutter, tx ethdb.GetterPutter) error {
 	var timings []interface{}
 	for !s.IsDone() {
+		fmt.Printf("Run: is empty: %t\n", s.unwindStack.Empty())
 		if !s.unwindStack.Empty() {
 			for unwind := s.unwindStack.Pop(); unwind != nil; unwind = s.unwindStack.Pop() {
+				fmt.Printf("Run unwind: %s\n", unwind.Stage)
+
 				if err := s.SetCurrentStage(unwind.Stage); err != nil {
 					return err
 				}
@@ -175,7 +178,9 @@ func (s *State) Run(db ethdb.GetterPutter, tx ethdb.GetterPutter) error {
 				return err
 			}
 		}
+
 		_, stage := s.CurrentStage()
+		fmt.Printf("Run run: %s\n", stage.ID)
 		if hook, ok := s.beforeStageRun[string(stage.ID)]; ok {
 			if err := hook(); err != nil {
 				return err

--- a/eth/stagedsync/state.go
+++ b/eth/stagedsync/state.go
@@ -131,6 +131,7 @@ func NewState(stagesList []*Stage) *State {
 
 func (s *State) LoadUnwindInfo(db ethdb.KVGetter) error {
 	for _, stage := range s.unwindOrder {
+		fmt.Printf("LoadUnwindInfo: %s\n", stage.ID)
 		if err := s.unwindStack.AddFromDB(db, stage.ID); err != nil {
 			return err
 		}

--- a/eth/stagedsync/state.go
+++ b/eth/stagedsync/state.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/ledgerwatch/turbo-geth/common"
+	"github.com/ledgerwatch/turbo-geth/common/debug"
 	"github.com/ledgerwatch/turbo-geth/eth/stagedsync/stages"
 	"github.com/ledgerwatch/turbo-geth/ethdb"
 	"github.com/ledgerwatch/turbo-geth/log"
@@ -178,6 +179,9 @@ func (s *State) Run(db ethdb.GetterPutter, tx ethdb.GetterPutter) error {
 			if err := s.SetCurrentStage(s.stages[0].ID); err != nil {
 				return err
 			}
+		} else {
+			fmt.Printf("Run: is empt2y: %s\n", debug.Callers(7))
+
 		}
 
 		_, stage := s.CurrentStage()


### PR DESCRIPTION
https://github.com/ledgerwatch/turbo-geth/issues/1454 happens because: 
- to unwind staged sync - you need run it forward first. It's make sense, because better finish all unfinished things - only then unwind.
- But most of time it means: run staged sync forward without blocks progress... i mean from block N to block N. 
- Most of stages don't do anything in this case, but TxPool and Finish stages do print some logs. 
- I added progress check to TxPool and Finish stages
- But line `[11/14 CallTraces] disabled. Work In Progress` still here because it's implemented in general-purpose code where we can't check progress. I don't have good Ideas - what to do in this case... 