### PR TITLE
Clique fixes

### DIFF
--- a/consensus/clique/clique.go
+++ b/consensus/clique/clique.go
@@ -36,6 +36,7 @@ import (
 	"github.com/ledgerwatch/turbo-geth/common/dbutils"
 	"github.com/ledgerwatch/turbo-geth/common/hexutil"
 	"github.com/ledgerwatch/turbo-geth/consensus"
+	"github.com/ledgerwatch/turbo-geth/consensus/misc"
 	"github.com/ledgerwatch/turbo-geth/core/state"
 	"github.com/ledgerwatch/turbo-geth/core/types"
 	"github.com/ledgerwatch/turbo-geth/core/types/accounts"
@@ -273,13 +274,12 @@ func (c *Clique) Author(header *types.Header) (common.Address, error) {
 // VerifyHeader checks whether a header conforms to the consensus rules.
 func (c *Clique) VerifyHeader(chain consensus.ChainHeaderReader, header *types.Header, _ bool) error {
 	// Verify the header's EIP-1559 attributes.
-	/*
-		if chain.Config().IsAleut(header.Number.Uint64()) {
-			if err := misc.VerifyEip1559Header(parent, header, chain.Config().IsAleut(parent.Number.Uint64())); err != nil {
-				return err
-			}
+	if chain.Config().IsAleut(header.Number.Uint64()) {
+		parent := chain.GetHeaderByHash(header.ParentHash)
+		if err := misc.VerifyEip1559Header(parent, header, chain.Config().IsAleut(parent.Number.Uint64())); err != nil {
+			return err
 		}
-	*/
+	}
 	c.reinit.Do(func() {
 		c.regenerateSnapshots(chain, header.Number.Uint64()-1)
 	})


### PR DESCRIPTION
Attempts to fix this
```
INFO [04-22|23:06:43.901] NewBlockMsg{blockNumber: 4666045} from [e15a32beb1b4328a58302899425f3374c855026d0fe266406df317166da2912a]
INFO [04-22|23:06:44.026] database closed (LMDB)                   lmdb=goerli
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x8 pc=0x4936247]

goroutine 1 [running]:
github.com/ledgerwatch/turbo-geth/consensus/clique.(*Clique).verifyCascadingFieldsBySnapshot(0xc0033e9810, 0x57d5618, 0xc00131d860, 0x5c096f146c0, 0x0, 0x6758038, 0x5c0bd4fbfe0)
	github.com/ledgerwatch/turbo-geth/consensus/clique/verifier.go:165 +0x67
github.com/ledgerwatch/turbo-geth/consensus/clique.(*Clique).verifyHeaderBySnapshot(0xc0033e9810, 0x57d5618, 0xc00131d860, 0x5c096f146c0, 0x0, 0x20f4923ddce84a68, 0x17661a4401982f6)
	github.com/ledgerwatch/turbo-geth/consensus/clique/verifier.go:34 +0x95
github.com/ledgerwatch/turbo-geth/consensus/clique.(*Clique).VerifyHeader(0xc0033e9810, 0x57d5618, 0xc00131d860, 0x5c096f146c0, 0x5c04a7c6801, 0x0, 0x0)
	github.com/ledgerwatch/turbo-geth/consensus/clique/clique.go:291 +0x27b
github.com/ledgerwatch/turbo-geth/turbo/stages/headerdownload.(*HeaderDownload).InsertHeaders(0xc00011ea90, 0x5c000c4bd88, 0x0, 0x0)
	github.com/ledgerwatch/turbo-geth/turbo/stages/headerdownload/header_algos.go:549 +0x152
github.com/ledgerwatch/turbo-geth/eth/stagedsync.HeadersForward(0xc0034f0f20, 0x57bc2e0, 0xc0012c0360, 0x57d2b10, 0xc00022b740, 0x57e1ab8, 0xc0013301c0, 0xc00011ea90, 0x5e9eb60, 0xc001419960, ...)
	github.com/ledgerwatch/turbo-geth/eth/stagedsync/stage_headers_new.go:120 +0x9e5
github.com/ledgerwatch/turbo-geth/turbo/stages.ReplacementStages.func1.1(0xc0034f0f20, 0x57bc2e0, 0xc0012c0360, 0x2e9c5c18, 0xc0013301c0)
	github.com/ledgerwatch/turbo-geth/turbo/stages/stageloop.go:128 +0xae
github.com/ledgerwatch/turbo-geth/eth/stagedsync.(*State).runStage(0xc0012c0360, 0xc0000a5c20, 0x2e9c5c18, 0xc0013301c0, 0x2e9c5c18, 0xc0013301c0, 0x2, 0x2)
	github.com/ledgerwatch/turbo-geth/eth/stagedsync/state.go:226 +0x14c
github.com/ledgerwatch/turbo-geth/eth/stagedsync.(*State).Run(0xc0012c0360, 0x2ee91fa8, 0xc0013301c0, 0x2ee91fa8, 0xc0013301c0, 0x0, 0xc0034f2bc0)
	github.com/ledgerwatch/turbo-geth/eth/stagedsync/state.go:198 +0x34b
github.com/ledgerwatch/turbo-geth/turbo/stages.StageLoop(0x57d2b10, 0xc00022b740, 0x57e1ab8, 0xc0013301c0, 0xc00011ea90, 0xc0002b19a0, 0x5e9eb60, 0xc001419960, 0xc001419970, 0xc001419980, ...)
	github.com/ledgerwatch/turbo-geth/turbo/stages/stageloop.go:87 +0x634
github.com/ledgerwatch/turbo-geth/cmd/headers/download.Download(0xc003375e60, 0x1, 0x1, 0x57e1ab8, 0xc0013301c0, 0x1e, 0x10000, 0x7ffeefbffb21, 0x6, 0xc0002d5d68, ...)
	github.com/ledgerwatch/turbo-geth/cmd/headers/download/downloader.go:114 +0x65b
github.com/ledgerwatch/turbo-geth/cmd/headers/commands.glob..func1(0x5ea18c0, 0xc00022b680, 0x0, 0x4, 0x0, 0x0)
	github.com/ledgerwatch/turbo-geth/cmd/headers/commands/download.go:43 +0x24c
github.com/spf13/cobra.(*Command).execute(0x5ea18c0, 0xc00022b640, 0x4, 0x4, 0x5ea18c0, 0xc00022b640)
	github.com/spf13/cobra@v1.1.3/command.go:852 +0x472
github.com/spf13/cobra.(*Command).ExecuteC(0x5ea1b40, 0xc00022b540, 0x200000003, 0xc000000180)
	github.com/spf13/cobra@v1.1.3/command.go:960 +0x375
github.com/spf13/cobra.(*Command).Execute(...)
	github.com/spf13/cobra@v1.1.3/command.go:897
github.com/spf13/cobra.(*Command).ExecuteContext(...)
	github.com/spf13/cobra@v1.1.3/command.go:890
github.com/ledgerwatch/turbo-geth/cmd/headers/commands.Execute()
	github.com/ledgerwatch/turbo-geth/cmd/headers/commands/root.go:73 +0x5b
main.main()
	github.com/ledgerwatch/turbo-geth/cmd/headers/main.go:11 +0x25
```

also re-introduces EIP-1559 header verification for Clique