### PR TITLE
txn full fix - cursors leak

### DIFF
--- a/ethdb/kv_lmdb.go
+++ b/ethdb/kv_lmdb.go
@@ -657,6 +657,7 @@ func (tx *lmdbTx) Put(bucket string, k, v []byte) error {
 		if err != nil {
 			return err
 		}
+		defer c.Close()
 		return c.Put(k, v)
 	}
 
@@ -670,6 +671,7 @@ func (tx *lmdbTx) Delete(bucket string, k, v []byte) error {
 		if err != nil {
 			return err
 		}
+		defer c.Close()
 		return c.Delete(k, v)
 	}
 	err := tx.tx.Del(lmdb.DBI(b.DBI), k, v)

--- a/ethdb/kv_mdbx.go
+++ b/ethdb/kv_mdbx.go
@@ -712,6 +712,7 @@ func (tx *MdbxTx) Put(bucket string, k, v []byte) error {
 		if err != nil {
 			return err
 		}
+		defer c.Close()
 		return c.Put(k, v)
 	}
 
@@ -725,6 +726,7 @@ func (tx *MdbxTx) Delete(bucket string, k, v []byte) error {
 		if err != nil {
 			return err
 		}
+		defer c.Close()
 		return c.Delete(k, v)
 	}
 


### PR DESCRIPTION
- problem: every tx.Put/Del op did open cursor and doesn't close. It caused next issue - each cursor was pointed to own dirty page - dirty pages on which pointed cursor can't spill - in result all dirty pages can't spill -> txn_full
- will add cursors counter to grafana later 
- mdbx maintainer anyway plan to handle this corner-case somehow 