### PR TITLE
Add tzdata to alpine container for log timestamps

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ RUN make all
 
 FROM alpine:3.13
 
-RUN apk add --no-cache ca-certificates libgcc libstdc++
+RUN apk add --no-cache ca-certificates libgcc libstdc++ tzdata
 COPY --from=builder /app/build/bin/* /usr/local/bin/
 
 EXPOSE 8545 8546 30303 30303/udp 8080 9090 6060


### PR DESCRIPTION
Alpine containers, by default, do not include `tzdata` package, so they do not honor the `TZ` environment variable. When running in a docker container the logs timestamps will always be in UTC without this package. I propose we add `tzdata` so that the timezone can be changed.